### PR TITLE
feat: enforce authz permissions for Pages & Resources endpoints

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_tabs_permissions.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_tabs_permissions.py
@@ -1,0 +1,109 @@
+"""
+Integration tests verifying authz permissions for v0 tabs REST API views.
+"""
+from urllib.parse import urlencode
+
+from django.urls import reverse
+from openedx_authz.constants.roles import COURSE_AUDITOR, COURSE_LIMITED_STAFF, COURSE_STAFF
+from rest_framework.test import APIClient
+
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
+
+
+class TabsV0AuthzTest(CourseAuthoringAuthzTestMixin, CourseTestCase):
+    """
+    Integration tests for v0 tabs API authz permissions.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.list_url = reverse(
+            'cms.djangoapps.contentstore:v0:course_tab_list',
+            kwargs={'course_id': self.course.id},
+        )
+        self.settings_url = reverse(
+            'cms.djangoapps.contentstore:v0:course_tab_settings',
+            kwargs={'course_id': self.course.id},
+        )
+        self.reorder_url = reverse(
+            'cms.djangoapps.contentstore:v0:course_tab_reorder',
+            kwargs={'course_id': self.course.id},
+        )
+
+    # --- CourseTabListView (GET) - requires courses.view_pages_and_resources ---
+
+    def test_staff_can_list_tabs(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.get(self.list_url)
+        assert resp.status_code == 200
+
+    def test_auditor_can_list_tabs(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.authorized_client.get(self.list_url)
+        assert resp.status_code == 200
+
+    def test_limited_staff_cannot_list_tabs(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_LIMITED_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.get(self.list_url)
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_list_tabs(self):
+        resp = self.unauthorized_client.get(self.list_url)
+        assert resp.status_code == 403
+
+    # --- CourseTabSettingsView (POST) - requires courses.manage_pages_and_resources ---
+
+    def test_staff_can_update_tab_settings(self):
+        """Asserts not-403 rather than 200 because the minimal payload may fail validation."""
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.post(
+            f'{self.settings_url}?{urlencode({"tab_id": "wiki"})}',
+            data={'is_hidden': True},
+            format='json',
+        )
+        assert resp.status_code != 403
+
+    def test_auditor_cannot_update_tab_settings(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.authorized_client.post(
+            f'{self.settings_url}?{urlencode({"tab_id": "wiki"})}',
+            data={'is_hidden': True},
+            format='json',
+        )
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_update_tab_settings(self):
+        resp = self.unauthorized_client.post(
+            f'{self.settings_url}?{urlencode({"tab_id": "wiki"})}',
+            data={'is_hidden': True},
+            format='json',
+        )
+        assert resp.status_code == 403
+
+    # --- CourseTabReorderView (POST) - requires courses.manage_pages_and_resources ---
+
+    def test_staff_can_reorder_tabs(self):
+        """Asserts not-403 rather than 200 because the empty tab list may fail validation."""
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.post(self.reorder_url, data=[], format='json')
+        assert resp.status_code != 403
+
+    def test_auditor_cannot_reorder_tabs(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.authorized_client.post(self.reorder_url, data=[], format='json')
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_reorder_tabs(self):
+        resp = self.unauthorized_client.post(self.reorder_url, data=[], format='json')
+        assert resp.status_code == 403
+
+    # --- Superuser bypass ---
+
+    def test_superuser_can_list_tabs(self):
+        superuser = UserFactory(is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+        resp = client.get(self.list_url)
+        assert resp.status_code == 200

--- a/cms/djangoapps/contentstore/rest_api/v0/views/tabs.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/tabs.py
@@ -3,12 +3,17 @@
 import edx_api_doc_tools as apidocs
 from django.utils.translation import gettext_lazy as _
 from opaque_keys.edx.keys import CourseKey
+from openedx_authz.constants.permissions import (
+    COURSES_MANAGE_PAGES_AND_RESOURCES,
+    COURSES_VIEW_PAGES_AND_RESOURCES,
+)
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from common.djangoapps.student.auth import has_studio_read_access, has_studio_write_access
+from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
+from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -79,7 +84,12 @@ class CourseTabListView(DeveloperErrorViewMixin, APIView):
         ```
         """
         course_key = CourseKey.from_string(course_id)
-        if not has_studio_read_access(request.user, course_key):
+        if not user_has_course_permission(
+            request.user,
+            COURSES_VIEW_PAGES_AND_RESOURCES.identifier,
+            course_key,
+            LegacyAuthoringPermission.READ,
+        ):
             self.permission_denied(request)
 
         course_block = modulestore().get_course(course_key)
@@ -150,7 +160,12 @@ class CourseTabSettingsView(DeveloperErrorViewMixin, APIView):
         without any content.
         """
         course_key = CourseKey.from_string(course_id)
-        if not has_studio_write_access(request.user, course_key):
+        if not user_has_course_permission(
+            request.user,
+            COURSES_MANAGE_PAGES_AND_RESOURCES.identifier,
+            course_key,
+            LegacyAuthoringPermission.WRITE,
+        ):
             self.permission_denied(request)
 
         tab_id_locator = TabIDLocatorSerializer(data=request.query_params)
@@ -222,7 +237,12 @@ class CourseTabReorderView(DeveloperErrorViewMixin, APIView):
         without any content.
         """
         course_key = CourseKey.from_string(course_id)
-        if not has_studio_write_access(request.user, course_key):
+        if not user_has_course_permission(
+            request.user,
+            COURSES_MANAGE_PAGES_AND_RESOURCES.identifier,
+            course_key,
+            LegacyAuthoringPermission.WRITE,
+        ):
             self.permission_denied(request)
 
         course_block = modulestore().get_course(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_textbooks.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_textbooks.py
@@ -2,9 +2,12 @@
 Unit tests for the course's textbooks.
 """
 from django.urls import reverse
-from rest_framework import status
+from openedx_authz.constants.roles import COURSE_AUDITOR, COURSE_LIMITED_STAFF, COURSE_STAFF
+from rest_framework.test import APIClient
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
 
 from ...mixins import PermissionAccessMixin
 
@@ -39,5 +42,44 @@ class CourseTextbooksViewTest(CourseTestCase, PermissionAccessMixin):
         self.save_course()
 
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["textbooks"], expected_textbook)
+
+
+class CourseTextbooksAuthzTest(CourseAuthoringAuthzTestMixin, CourseTestCase):
+    """
+    Integration tests for CourseTextbooksView authz permissions.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse(
+            "cms.djangoapps.contentstore:v1:textbooks",
+            kwargs={"course_id": self.course.id},
+        )
+
+    def test_staff_can_view_textbooks(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.get(self.url)
+        assert resp.status_code == 200
+
+    def test_auditor_can_view_textbooks(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.authorized_client.get(self.url)
+        assert resp.status_code == 200
+
+    def test_limited_staff_cannot_view_textbooks(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_LIMITED_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.get(self.url)
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_view_textbooks(self):
+        resp = self.unauthorized_client.get(self.url)
+        assert resp.status_code == 403
+
+    def test_superuser_can_view_textbooks(self):
+        superuser = UserFactory(is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+        resp = client.get(self.url)
+        assert resp.status_code == 200

--- a/cms/djangoapps/contentstore/rest_api/v1/views/textbooks.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/textbooks.py
@@ -2,13 +2,15 @@
 
 import edx_api_doc_tools as apidocs
 from opaque_keys.edx.keys import CourseKey
+from openedx_authz.constants.permissions import COURSES_VIEW_PAGES_AND_RESOURCES
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from cms.djangoapps.contentstore.rest_api.v1.serializers import CourseTextbooksSerializer
 from cms.djangoapps.contentstore.utils import get_textbooks_context
-from common.djangoapps.student.auth import has_studio_read_access
+from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
+from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
 from xmodule.modulestore.django import modulestore
 
@@ -74,7 +76,12 @@ class CourseTextbooksView(DeveloperErrorViewMixin, APIView):
         course_key = CourseKey.from_string(course_id)
         store = modulestore()
 
-        if not has_studio_read_access(request.user, course_key):
+        if not user_has_course_permission(
+            request.user,
+            COURSES_VIEW_PAGES_AND_RESOURCES.identifier,
+            course_key,
+            LegacyAuthoringPermission.READ,
+        ):
             self.permission_denied(request)
 
         with store.bulk_operations(course_key):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -33,8 +33,10 @@ from openedx_authz.api.data import CourseOverviewData
 from openedx_authz.constants.permissions import (
     COURSES_MANAGE_COURSE_UPDATES,
     COURSES_MANAGE_GROUP_CONFIGURATIONS,
+    COURSES_MANAGE_PAGES_AND_RESOURCES,
     COURSES_VIEW_COURSE,
     COURSES_VIEW_COURSE_UPDATES,
+    COURSES_VIEW_PAGES_AND_RESOURCES,
 )
 from organizations.api import add_organization_course, ensure_organization
 from organizations.exceptions import InvalidOrganizationException
@@ -1653,16 +1655,23 @@ def textbooks_list_handler(request, course_key_string):
     """
     course_key = CourseKey.from_string(course_key_string)
     if "application/json" not in request.META.get('HTTP_ACCEPT', 'text/html'):
-        # return HTML page
-        # We don't need to do an access check here because
-        # that is done when the endpoint for the actual content of the page.
-        # This is just to handle redirecting anyone that has bookmarked the old
-        # textbooks page.
+        # Legacy HTML bookmark redirect — no data is exposed here.
+        # Access is enforced when the MFE fetches data from the textbooks API.
         return redirect(get_textbooks_url(course_key))
+
+    if request.method == 'GET':
+        authz_perm = COURSES_VIEW_PAGES_AND_RESOURCES.identifier
+        legacy_perm = LegacyAuthoringPermission.READ
+    else:
+        authz_perm = COURSES_MANAGE_PAGES_AND_RESOURCES.identifier
+        legacy_perm = LegacyAuthoringPermission.WRITE
+
+    if not user_has_course_permission(request.user, authz_perm, course_key, legacy_perm):
+        raise PermissionDenied()
 
     store = modulestore()
     with store.bulk_operations(course_key):
-        course = get_course_and_check_access(course_key, request.user)
+        course = _get_course_block(course_key)
 
         # from here on down, we know the client has requested JSON
         if request.method == 'GET':
@@ -1725,9 +1734,20 @@ def textbooks_detail_handler(request, course_key_string, textbook_id):
         json: remove textbook
     """
     course_key = CourseKey.from_string(course_key_string)
+
+    if request.method == 'GET':
+        authz_perm = COURSES_VIEW_PAGES_AND_RESOURCES.identifier
+        legacy_perm = LegacyAuthoringPermission.READ
+    else:
+        authz_perm = COURSES_MANAGE_PAGES_AND_RESOURCES.identifier
+        legacy_perm = LegacyAuthoringPermission.WRITE
+
+    if not user_has_course_permission(request.user, authz_perm, course_key, legacy_perm):
+        raise PermissionDenied()
+
     store = modulestore()
     with store.bulk_operations(course_key):
-        course_block = get_course_and_check_access(course_key, request.user)
+        course_block = _get_course_block(course_key)
         matching_id = [tb for tb in course_block.pdf_textbooks
                        if str(tb.get("id")) == str(textbook_id)]
         if matching_id:

--- a/cms/djangoapps/contentstore/views/tests/test_textbooks_permissions.py
+++ b/cms/djangoapps/contentstore/views/tests/test_textbooks_permissions.py
@@ -1,0 +1,148 @@
+"""
+Integration tests verifying authz permissions for legacy textbook handler views.
+"""
+import json
+
+from django.test import Client
+from openedx_authz.constants.roles import COURSE_AUDITOR, COURSE_LIMITED_STAFF, COURSE_STAFF
+
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
+
+
+class TextbooksListHandlerAuthzTest(CourseAuthoringAuthzTestMixin, CourseTestCase):
+    """
+    Integration tests for textbooks_list_handler authz permissions.
+
+    Uses Django test Client (not DRF APIClient) because textbooks_list_handler
+    is a function-based view with @login_required.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse_course_url('textbooks_list_handler', self.course.id)
+
+        self.staff_client = Client()
+        self.staff_client.login(username=self.authorized_user.username, password=self.password)
+
+        self.unauth_client = Client()
+        self.unauth_client.login(username=self.unauthorized_user.username, password=self.password)
+
+    # --- GET (JSON) - requires courses.view_pages_and_resources ---
+
+    def test_staff_can_get(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.staff_client.get(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 200
+
+    def test_auditor_can_get(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.staff_client.get(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 200
+
+    def test_limited_staff_cannot_get(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_LIMITED_STAFF.external_key, self.course.id)
+        resp = self.staff_client.get(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_get(self):
+        resp = self.unauth_client.get(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 403
+
+    # --- POST - requires courses.manage_pages_and_resources ---
+
+    def test_staff_can_post(self):
+        """Asserts not-403 rather than 200 because minimal payload may fail validation."""
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.staff_client.post(
+            self.url,
+            data=json.dumps({"tab_title": "Test", "chapters": []}),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        assert resp.status_code != 403
+
+    def test_auditor_cannot_post(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.staff_client.post(
+            self.url,
+            data=json.dumps({"tab_title": "Test", "chapters": []}),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_post(self):
+        resp = self.unauth_client.post(
+            self.url,
+            data=json.dumps({"tab_title": "Test", "chapters": []}),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        assert resp.status_code == 403
+
+    # --- Superuser bypass ---
+
+    def test_superuser_can_get(self):
+        superuser = UserFactory(is_superuser=True, password=self.password)
+        client = Client()
+        client.login(username=superuser.username, password=self.password)
+        resp = client.get(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 200
+
+
+class TextbooksDetailHandlerAuthzTest(CourseAuthoringAuthzTestMixin, CourseTestCase):
+    """
+    Integration tests for textbooks_detail_handler authz permissions.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.course.pdf_textbooks = [{"tab_title": "Test", "chapters": [], "id": "1test"}]
+        self.save_course()
+        self.url = f'/textbooks/{self.course.id}/1test'
+
+        self.staff_client = Client()
+        self.staff_client.login(username=self.authorized_user.username, password=self.password)
+
+        self.unauth_client = Client()
+        self.unauth_client.login(username=self.unauthorized_user.username, password=self.password)
+
+    # --- GET - requires courses.view_pages_and_resources ---
+
+    def test_staff_can_get(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.staff_client.get(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 200
+
+    def test_auditor_can_get(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.staff_client.get(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 200
+
+    def test_limited_staff_cannot_get(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_LIMITED_STAFF.external_key, self.course.id)
+        resp = self.staff_client.get(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_get(self):
+        resp = self.unauth_client.get(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 403
+
+    # --- DELETE - requires courses.manage_pages_and_resources ---
+
+    def test_staff_can_delete(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.staff_client.delete(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 204
+
+    def test_auditor_cannot_delete(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.staff_client.delete(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_delete(self):
+        resp = self.unauth_client.delete(self.url, HTTP_ACCEPT='application/json')
+        assert resp.status_code == 403

--- a/openedx/core/djangoapps/course_apps/rest_api/tests/test_views_permissions.py
+++ b/openedx/core/djangoapps/course_apps/rest_api/tests/test_views_permissions.py
@@ -1,0 +1,102 @@
+"""
+Integration tests verifying authz permissions for CourseAppsView.
+"""
+import contextlib
+from unittest import mock
+
+from django.urls import reverse
+from openedx_authz.constants.roles import COURSE_AUDITOR, COURSE_LIMITED_STAFF, COURSE_STAFF
+from rest_framework.test import APIClient
+
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
+from openedx.core.djangolib.testing.utils import skip_unless_cms
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from ...tests.utils import make_test_course_app
+
+
+@skip_unless_cms
+class CourseAppsAuthzTest(CourseAuthoringAuthzTestMixin, SharedModuleStoreTestCase):
+    """
+    Integration tests for CourseAppsView authz permissions.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('course_apps_api:v1:course_apps', kwargs={'course_id': self.course.id})
+
+    @contextlib.contextmanager
+    def _setup_plugin_mock(self):
+        """Patch get_available_plugins to return a test plugin."""
+        patcher = mock.patch('openedx.core.djangoapps.course_apps.plugins.PluginManager.get_available_plugins')
+        mock_plugins = patcher.start()
+        mock_plugins.return_value = {
+            'app1': make_test_course_app(app_id='app1', name='App One', is_available=True),
+        }
+        yield
+        patcher.stop()
+
+    # --- GET - requires courses.view_pages_and_resources ---
+
+    def test_staff_can_list_apps(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        with self._setup_plugin_mock():
+            resp = self.authorized_client.get(self.url)
+        assert resp.status_code == 200
+
+    def test_auditor_can_list_apps(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        with self._setup_plugin_mock():
+            resp = self.authorized_client.get(self.url)
+        assert resp.status_code == 200
+
+    def test_limited_staff_cannot_list_apps(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_LIMITED_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.get(self.url)
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_list_apps(self):
+        resp = self.unauthorized_client.get(self.url)
+        assert resp.status_code == 403
+
+    # --- PATCH - requires courses.manage_pages_and_resources ---
+
+    def test_staff_can_toggle_app(self):
+        """Asserts not-403 rather than 200 because the test plugin may not fully process the toggle."""
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        with self._setup_plugin_mock():
+            resp = self.authorized_client.patch(
+                self.url, data={'id': 'app1', 'enabled': True}, format='json',
+            )
+        assert resp.status_code != 403
+
+    def test_auditor_cannot_toggle_app(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.authorized_client.patch(
+            self.url, data={'id': 'app1', 'enabled': True}, format='json',
+        )
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_toggle_app(self):
+        resp = self.unauthorized_client.patch(
+            self.url, data={'id': 'app1', 'enabled': True}, format='json',
+        )
+        assert resp.status_code == 403
+
+    # --- Superuser bypass ---
+
+    def test_superuser_can_list_apps(self):
+        superuser = UserFactory(is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+        with self._setup_plugin_mock():
+            resp = client.get(self.url)
+        assert resp.status_code == 200

--- a/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/course_apps/rest_api/v1/views.py
@@ -8,13 +8,18 @@ from edx_django_utils.plugins import PluginError
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys.edx.keys import CourseKey
+from openedx_authz.constants.permissions import (
+    COURSES_MANAGE_PAGES_AND_RESOURCES,
+    COURSES_VIEW_PAGES_AND_RESOURCES,
+)
 from rest_framework import serializers, views
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from common.djangoapps.student.auth import has_studio_write_access
+from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
+from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from openedx.core.djangoapps.course_apps.models import CourseAppStatus
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, validate_course_key, verify_course_exists
@@ -26,19 +31,24 @@ User = get_user_model()
 log = logging.getLogger(__name__)
 
 
-class HasStudioWriteAccess(BasePermission):
+class HasPagesAndResourcesAccess(BasePermission):
     """
-    Check if the user has write access to studio.
+    Check if the user has access to Pages & Resources.
+
+    Uses authz permissions when the feature flag is enabled,
+    falling back to legacy studio access.
+    GET requests check view permission, all others check manage permission.
     """
 
     def has_permission(self, request, view):
-        """
-        Check if the user has write access to studio.
-        """
         user = request.user
         course_key_string = view.kwargs.get("course_id")
         course_key = validate_course_key(course_key_string)
-        return has_studio_write_access(user, course_key)
+        if request.method == 'GET':
+            authz_perm = COURSES_VIEW_PAGES_AND_RESOURCES.identifier
+        else:
+            authz_perm = COURSES_MANAGE_PAGES_AND_RESOURCES.identifier
+        return user_has_course_permission(user, authz_perm, course_key, LegacyAuthoringPermission.WRITE)
 
 
 class CourseAppSerializer(serializers.Serializer):  # pylint: disable=abstract-method
@@ -88,7 +98,7 @@ class CourseAppsView(DeveloperErrorViewMixin, views.APIView):
         BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
-    permission_classes = (HasStudioWriteAccess,)
+    permission_classes = (HasPagesAndResourcesAccess,)
 
     @schema(
         parameters=[

--- a/openedx/core/djangoapps/discussions/permissions.py
+++ b/openedx/core/djangoapps/discussions/permissions.py
@@ -1,11 +1,17 @@
 """
 API library for Django REST Framework permissions-oriented workflows
 """
+from openedx_authz import api as authz_api
+from openedx_authz.constants.permissions import (
+    COURSES_MANAGE_PAGES_AND_RESOURCES,
+    COURSES_VIEW_PAGES_AND_RESOURCES,
+)
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import BasePermission
 
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, GlobalStaff
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
+from openedx.core import toggles as core_toggles
 from openedx.core.lib.api.view_utils import validate_course_key
 
 DEFAULT_MESSAGE = "You're not authorized to perform this operation."
@@ -14,27 +20,43 @@ PERMISSION_MESSAGES = {
 }
 
 
-class IsStaffOrCourseTeam(BasePermission):
-    """
-    Check if user is global or course staff
+def _legacy_is_staff_or_course_team(user, course_key):
+    """Legacy permission check: allows global staff, course instructor, course staff, or discussion moderators/TAs."""
+    if GlobalStaff().has_user(user):
+        return True
+    return (
+        CourseInstructorRole(course_key).has_user(user)
+        or CourseStaffRole(course_key).has_user(user)
+        or has_discussion_privileges(user, course_key)
+    )
 
-    Permission that checks to see if the user is global staff, course
-    staff, course admin, or has discussion privileges. If none of those conditions are
-    met, HTTP403 is returned.
+
+class HasPagesAndResourcesAccess(BasePermission):
+    """
+    Check if user has access to Pages & Resources.
+
+    When the authz feature flag is enabled, uses authz permissions.
+    GET requests check view permission, all others check manage permission.
+    Falls back to has_discussion_privileges when authz denies access
+    (transitional until discussion roles are migrated to authz).
+    When the flag is off, falls back to legacy behavior: global staff,
+    course instructor, course staff, or discussion privileges.
     """
 
     def has_permission(self, request, view):
         course_key_string = view.kwargs.get('course_key_string')
         course_key = validate_course_key(course_key_string)
 
-        if GlobalStaff().has_user(request.user):
-            return True
+        if core_toggles.enable_authz_course_authoring(course_key):
+            if request.method == 'GET':
+                authz_perm = COURSES_VIEW_PAGES_AND_RESOURCES.identifier
+            else:
+                authz_perm = COURSES_MANAGE_PAGES_AND_RESOURCES.identifier
+            if authz_api.is_user_allowed(request.user.username, authz_perm, str(course_key)):
+                return True
+            return has_discussion_privileges(request.user, course_key)
 
-        return (
-            CourseInstructorRole(course_key).has_user(request.user) or
-            CourseStaffRole(course_key).has_user(request.user) or
-            has_discussion_privileges(request.user, course_key)
-        )
+        return _legacy_is_staff_or_course_team(request.user, course_key)
 
 
 def user_permissions_for_course(course, user):

--- a/openedx/core/djangoapps/discussions/tests/test_views.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views.py
@@ -23,7 +23,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 from ..config.waffle import ENABLE_NEW_STRUCTURE_DISCUSSIONS
 from ..models import AVAILABLE_PROVIDER_MAP, DEFAULT_CONFIG_ENABLED, Provider, get_default_provider_type
-from ..permissions import IsStaffOrCourseTeam
+from ..permissions import HasPagesAndResourcesAccess
 
 DATA_LEGACY_COHORTS = {
     'divided_inline_discussions': [],
@@ -864,12 +864,12 @@ class SyncDiscussionTopicsViewTests(ModuleStoreTestCase, APITestCase):
         self.url = reverse('sync-discussion-topics', kwargs={'course_key_string': self.course_key_string})
 
         # Mock the permission class for course team checking
-        self.original_has_permission = IsStaffOrCourseTeam.has_permission
-        IsStaffOrCourseTeam.has_permission = Mock(return_value=True)
+        self.original_has_permission = HasPagesAndResourcesAccess.has_permission
+        HasPagesAndResourcesAccess.has_permission = Mock(return_value=True)
 
     def tearDown(self):
         # Restore original permission method
-        IsStaffOrCourseTeam.has_permission = self.original_has_permission
+        HasPagesAndResourcesAccess.has_permission = self.original_has_permission
         super().tearDown()
 
     @patch('openedx.core.djangoapps.discussions.views.update_discussions_settings_from_course_task')
@@ -892,7 +892,7 @@ class SyncDiscussionTopicsViewTests(ModuleStoreTestCase, APITestCase):
         self.client.force_authenticate(user=self.instructor_user)
 
         # Mock the course team permission check
-        IsStaffOrCourseTeam.has_permission = Mock(return_value=True)
+        HasPagesAndResourcesAccess.has_permission = Mock(return_value=True)
 
         response = self.client.post(self.url)
 
@@ -916,7 +916,7 @@ class SyncDiscussionTopicsViewTests(ModuleStoreTestCase, APITestCase):
         self.client.force_authenticate(user=self.student_user)
 
         # Mock the course team permission check to return False
-        IsStaffOrCourseTeam.has_permission = Mock(return_value=False)
+        HasPagesAndResourcesAccess.has_permission = Mock(return_value=False)
 
         response = self.client.post(self.url)
 

--- a/openedx/core/djangoapps/discussions/tests/test_views_permissions.py
+++ b/openedx/core/djangoapps/discussions/tests/test_views_permissions.py
@@ -1,0 +1,93 @@
+"""
+Integration tests verifying authz permissions for discussions views.
+"""
+from django.urls import reverse
+from openedx_authz.constants.roles import COURSE_AUDITOR, COURSE_LIMITED_STAFF, COURSE_STAFF
+from rest_framework.test import APIClient
+
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+class DiscussionsAuthzTest(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase):
+    """
+    Integration tests for discussions views authz permissions.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
+        self.settings_url = reverse(
+            'discussions-settings',
+            kwargs={'course_key_string': str(self.course.id)},
+        )
+        self.providers_url = reverse(
+            'discussions-providers',
+            kwargs={'course_key_string': str(self.course.id)},
+        )
+
+    # --- GET settings - requires courses.view_pages_and_resources ---
+
+    def test_staff_can_get_settings(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.get(self.settings_url)
+        assert resp.status_code == 200
+
+    def test_auditor_can_get_settings(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.authorized_client.get(self.settings_url)
+        assert resp.status_code == 200
+
+    def test_limited_staff_cannot_get_settings(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_LIMITED_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.get(self.settings_url)
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_get_settings(self):
+        resp = self.unauthorized_client.get(self.settings_url)
+        assert resp.status_code == 403
+
+    # --- POST settings - requires courses.manage_pages_and_resources ---
+
+    def test_staff_can_post_settings(self):
+        """Asserts not-403 rather than 200 because the empty payload may fail validation."""
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.post(self.settings_url, data={}, format='json')
+        assert resp.status_code != 403
+
+    def test_auditor_cannot_post_settings(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.authorized_client.post(self.settings_url, data={}, format='json')
+        assert resp.status_code == 403
+
+    def test_unauthorized_cannot_post_settings(self):
+        resp = self.unauthorized_client.post(self.settings_url, data={}, format='json')
+        assert resp.status_code == 403
+
+    # --- GET providers - requires courses.view_pages_and_resources ---
+
+    def test_staff_can_get_providers(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
+        resp = self.authorized_client.get(self.providers_url)
+        assert resp.status_code == 200
+
+    def test_auditor_can_get_providers(self):
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_AUDITOR.external_key, self.course.id)
+        resp = self.authorized_client.get(self.providers_url)
+        assert resp.status_code == 200
+
+    def test_unauthorized_cannot_get_providers(self):
+        resp = self.unauthorized_client.get(self.providers_url)
+        assert resp.status_code == 403
+
+    # --- Superuser bypass ---
+
+    def test_superuser_can_get_settings(self):
+        superuser = UserFactory(is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+        resp = client.get(self.settings_url)
+        assert resp.status_code == 200

--- a/openedx/core/djangoapps/discussions/views.py
+++ b/openedx/core/djangoapps/discussions/views.py
@@ -18,7 +18,7 @@ from openedx.core.lib.api.view_utils import validate_course_key
 
 from .config.waffle import ENABLE_NEW_STRUCTURE_DISCUSSIONS
 from .models import AVAILABLE_PROVIDER_MAP, DiscussionsConfiguration, Features, Provider
-from .permissions import IsStaffOrCourseTeam, check_course_permissions
+from .permissions import HasPagesAndResourcesAccess, check_course_permissions
 from .serializers import DiscussionsConfigurationSerializer, DiscussionsProvidersSerializer
 from .tasks import update_discussions_settings_from_course_task
 
@@ -32,7 +32,7 @@ class DiscussionsConfigurationSettingsView(APIView):
         BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser
     )
-    permission_classes = (IsStaffOrCourseTeam,)
+    permission_classes = (HasPagesAndResourcesAccess,)
 
     @apidocs.schema(
         parameters=[
@@ -134,7 +134,7 @@ class DiscussionsProvidersView(APIView):
         BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser
     )
-    permission_classes = (IsStaffOrCourseTeam,)
+    permission_classes = (HasPagesAndResourcesAccess,)
 
     @apidocs.schema(
         parameters=[
@@ -258,7 +258,7 @@ class SyncDiscussionTopicsView(APIView):
     View for syncing discussion topics for a course.
     """
     authentication_classes = (BearerAuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser)
-    permission_classes = (IsAuthenticated, IsStaffOrCourseTeam)
+    permission_classes = (IsAuthenticated, HasPagesAndResourcesAccess)
 
     def post(self, request, course_key_string):
         """


### PR DESCRIPTION
## Description

When the `authz.enable_course_authoring` flag is enabled use openedx-authz based permissions to authorize calls to the endpoints that support the Pages & Resources pages and functionality in Studio.

### Endpoints covered

**Pages & Resources**

| UI Action | Type | URL Path | Django View |
|---|---|---|---|
| Load Pages & Resources grid | GET | `/api/course_apps/v1/apps/{courseId}` | `openedx.core.djangoapps.course_apps.rest_api.v1.views.CourseAppsView` |
| Toggle app enabled/disabled | PATCH | `/api/course_apps/v1/apps/{courseId}` | `openedx.core.djangoapps.course_apps.rest_api.v1.views.CourseAppsView` |
| Load app settings (wiki visibility, etc.) | GET | `/api/contentstore/v0/advanced_settings/{courseId}` | `cms.djangoapps.contentstore.rest_api.v0.views.advanced_settings.AdvancedCourseSettingsView` * |
| Save app settings | PATCH | `/api/contentstore/v0/advanced_settings/{courseId}` | `cms.djangoapps.contentstore.rest_api.v0.views.advanced_settings.AdvancedCourseSettingsView` * |

**Discussions**

| UI Action | Type | URL Path | Django View |
|---|---|---|---|
| Load discussions settings | GET | `/api/discussions/v0/course/{courseId}/settings` | `openedx.core.djangoapps.discussions.views.DiscussionsConfigurationSettingsView` |
| Save discussions settings | POST | `/api/discussions/v0/course/{courseId}/settings` | `openedx.core.djangoapps.discussions.views.DiscussionsConfigurationSettingsView` |
| Load discussions providers | GET | `/api/discussions/v0/course/{courseId}/providers` | `openedx.core.djangoapps.discussions.views.DiscussionsProvidersView` |

**Custom Pages**

| UI Action | Type | URL Path | Django View |
|---|---|---|---|
| List custom pages / tabs | GET | `/api/contentstore/v0/tabs/{courseId}` | `cms.djangoapps.contentstore.rest_api.v0.views.tabs.CourseTabListView` |
| Reorder custom pages | POST | `/api/contentstore/v0/tabs/{courseId}/reorder` | `cms.djangoapps.contentstore.rest_api.v0.views.tabs.CourseTabReorderView` |
| Toggle custom page visibility | POST | `/api/contentstore/v0/tabs/{courseId}/settings` | `cms.djangoapps.contentstore.rest_api.v0.views.tabs.CourseTabSettingsView` |
| Add custom page | PUT | `/xblock/` | `cms.djangoapps.contentstore.views.component.xblock_handler` * |
| Edit custom page | PUT | `/xblock/{blockId}` | `cms.djangoapps.contentstore.views.component.xblock_handler` * |
| Delete custom page | DELETE | `/xblock/{blockId}` | `cms.djangoapps.contentstore.views.component.xblock_handler` * |

**Textbooks**

| UI Action | Type | URL Path | Django View |
|---|---|---|---|
| List textbooks | GET | `/api/contentstore/v1/textbooks/{courseId}` | `cms.djangoapps.contentstore.rest_api.v1.views.textbooks.CourseTextbooksView` |
| Create/update textbook | POST | `/textbooks/{courseId}` | `cms.djangoapps.contentstore.views.course.textbooks_list_handler` |
| Edit textbook | POST | `/textbooks/{courseId}/{textbookId}` | `cms.djangoapps.contentstore.views.course.textbooks_detail_handler` |
| Delete textbook | DELETE | `/textbooks/{courseId}/{textbookId}` | `cms.djangoapps.contentstore.views.course.textbooks_detail_handler` |

\* Not modified in this PR — shared endpoints used by other features.

## Supporting information

Closes https://github.com/openedx/openedx-authz/issues/192.

## Testing instructions

**Automated tests:**

```sh
pytest --ds="cms.envs.test" \
  cms/djangoapps/contentstore/rest_api/v0/tests/test_tabs_permissions.py \
  cms/djangoapps/contentstore/rest_api/v1/views/tests/test_textbooks.py \
  cms/djangoapps/contentstore/views/tests/test_textbooks_permissions.py \
  openedx/core/djangoapps/course_apps/rest_api/tests/test_views_permissions.py \
  openedx/core/djangoapps/discussions/tests/test_views_permissions.py
```

**Manual tests:**

Prerequisite: Enable the `authz.enable_course_authoring` waffle flag for the test course. Assign users to authz roles: `course_admin`, `course_staff`, `course_auditor`, and one user with no role.

- **View Access** — Navigate to Pages & Resources from the Content dropdown. Admin, staff, and auditor should all see the page load with course app cards (Wiki, Discussions, Calculator, etc.). A user with no role should see a permission denied error.
- **Toggle Course Apps** — Toggle a course app (e.g., Wiki) on or off. Admin and staff should succeed. Auditor should be denied (toggle disabled or 403).
- **Discussion Settings** — Click the Discussion card. Admin, staff, and auditor should all view providers and current settings. Admin and staff should be able to save changes. Auditor should be denied when saving.
- **Custom Pages** — Navigate to Custom Pages. Admin, staff, and auditor should see the list of pages. Admin and staff should be able to reorder pages and toggle tab visibility. Auditor should be denied on write operations. A user with no role should not see the list at all. Note: creating, editing, and deleting custom pages go through `xblock_handler` which is out of scope for this PR.
- **Textbooks** — Navigate to Textbooks. Admin, staff, and auditor should see the list. Admin and staff should be able to create, edit, and delete textbooks. Auditor should be denied on all write operations. A user with no role should not see the list at all.

## Deadline

Verawood

## Other information

Co-authored with Kiro.
