### PR TITLE
chore: Update default start date to January 1, 2040

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_proctoring.py
@@ -15,6 +15,7 @@ from cms.djangoapps.contentstore.tests.test_utils import AuthorizeStaffTestCase
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from openedx.core import toggles as core_toggles
 from openedx.core.djangoapps.course_apps.toggles import EXAMS_IDA
+from xmodule.course_metadata_utils import DEFAULT_START_DATE
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import (  # lint-amnesty, pylint: disable=wrong-import-order
     ModuleStoreTestCase,
@@ -59,7 +60,7 @@ class ProctoringExamSettingsGetTests(
                 "proctoring_escalation_email": course.proctoring_escalation_email,
                 "create_zendesk_tickets": course.create_zendesk_tickets,
             },
-            "course_start_date": "2030-01-01T00:00:00Z",
+            "course_start_date": DEFAULT_START_DATE.strftime('%Y-%m-%dT%H:%M:%SZ'),
             "available_proctoring_providers": ["null"],
             "requires_escalation_email_providers": [],
         }
@@ -98,7 +99,7 @@ class ProctoringExamSettingsGetTests(
                 "proctoring_escalation_email": self.course.proctoring_escalation_email,
                 "create_zendesk_tickets": self.course.create_zendesk_tickets,
             },
-            "course_start_date": "2030-01-01T00:00:00Z",
+            "course_start_date": DEFAULT_START_DATE.strftime('%Y-%m-%dT%H:%M:%SZ'),
             "available_proctoring_providers": ["null"],
             "requires_escalation_email_providers": [],
         }
@@ -121,7 +122,7 @@ class ProctoringExamSettingsGetTests(
                 "proctoring_escalation_email": self.course.proctoring_escalation_email,
                 "create_zendesk_tickets": self.course.create_zendesk_tickets,
             },
-            "course_start_date": "2030-01-01T00:00:00Z",
+            "course_start_date": DEFAULT_START_DATE.strftime('%Y-%m-%dT%H:%M:%SZ'),
             "available_proctoring_providers": ["lti_external", "null"],
             "requires_escalation_email_providers": ["lti_external"],
         }

--- a/cms/djangoapps/contentstore/signals/tests/test_handlers.py
+++ b/cms/djangoapps/contentstore/signals/tests/test_handlers.py
@@ -9,6 +9,7 @@ from opaque_keys.edx.locator import CourseLocator, LibraryLocator
 from openedx_events.content_authoring.data import CourseCatalogData, CourseScheduleData
 
 import cms.djangoapps.contentstore.signals.handlers as sh
+from xmodule.course_metadata_utils import DEFAULT_START_DATE
 from xmodule.modulestore.django import SignalHandler
 from xmodule.modulestore.edit_info import EditInfoMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -34,7 +35,7 @@ class TestCatalogInfoSignal(ModuleStoreTestCase):
             course_key=CourseLocator(org='TestU', course='sig101', run='Summer2022', branch=None, version_guid=None),
             name='Signals 101',
             schedule_data=CourseScheduleData(
-                start=datetime.fromisoformat('2030-01-01T00:00+00:00'),
+                start=DEFAULT_START_DATE,
                 pacing='instructor',
                 end=None,
                 enrollment_start=None,

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -593,11 +593,11 @@ class TestCreateItem(ItemTest):
         self.assertEqual(resp.status_code, 200)  # noqa: PT009
 
     def test_create_with_future_date(self):
-        self.assertEqual(self.course.start, datetime(2030, 1, 1, tzinfo=UTC))  # noqa: PT009
+        self.assertEqual(self.course.start, DEFAULT_START_DATE)  # noqa: PT009
         resp = self.create_xblock(category="chapter")
         usage_key = self.response_usage_key(resp)
         obj = self.get_item_from_modulestore(usage_key)
-        self.assertEqual(obj.start, datetime(2030, 1, 1, tzinfo=UTC))  # noqa: PT009
+        self.assertEqual(obj.start, DEFAULT_START_DATE)  # noqa: PT009
 
     def test_static_tabs_initialization(self):
         """
@@ -3395,7 +3395,7 @@ class TestXBlockInfo(ItemTest):
             xblock_info["course_graders"],
             ["Homework", "Lab", "Midterm Exam", "Final Exam"],
         )
-        self.assertEqual(xblock_info["start"], "2030-01-01T00:00:00Z")  # noqa: PT009
+        self.assertEqual(xblock_info["start"], DEFAULT_START_DATE.strftime('%Y-%m-%dT%H:%M:%SZ'))  # noqa: PT009
         self.assertEqual(xblock_info["graded"], False)  # noqa: PT009
         self.assertEqual(xblock_info["due"], None)  # noqa: PT009
         self.assertEqual(xblock_info["format"], None)  # noqa: PT009

--- a/xmodule/course_metadata_utils.py
+++ b/xmodule/course_metadata_utils.py
@@ -14,7 +14,7 @@ from zoneinfo import ZoneInfo
 
 import dateutil.parser
 
-DEFAULT_START_DATE = datetime(2030, 1, 1, tzinfo=ZoneInfo("UTC"))
+DEFAULT_START_DATE = datetime(2040, 1, 1, tzinfo=ZoneInfo("UTC"))
 
 """
 Default grading policy for a course run.


### PR DESCRIPTION
Push this forward so things don't automatically in a few years for future courses.