### PR TITLE
fix: Migrations failing with: 'Draft' object has no attribute 'log_record'

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -829,7 +829,7 @@ openedx-calc==5.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   xblocks-contrib
-openedx-core==0.38.0
+openedx-core==0.38.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1382,7 +1382,7 @@ openedx-calc==5.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   xblocks-contrib
-openedx-core==0.38.0
+openedx-core==0.38.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1007,7 +1007,7 @@ openedx-calc==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-openedx-core==0.38.0
+openedx-core==0.38.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1056,7 +1056,7 @@ openedx-calc==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-openedx-core==0.38.0
+openedx-core==0.38.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
Was due to a broken migration file, fixed in openedx-core==0.38.2

Bugfix: https://github.com/openedx/openedx-core/commit/4c1a9f1ce990fc3f2ef55937f7e4146e5299d2c1
Diff: https://github.com/openedx/openedx-core/compare/v0.38.0...v0.38.2