### PR TITLE
build: rebalance unit test shards to reduce CI critical path (~29m --> ~23m) and use fewer workers (16 --> 10)

### DIFF
--- a/.github/workflows/unit-test-shards.json
+++ b/.github/workflows/unit-test-shards.json
@@ -2,168 +2,169 @@
   "lms-1": {
     "settings": "lms.envs.test",
     "paths": [
-      "lms/djangoapps/branding/",
-      "lms/djangoapps/bulk_email/",
-      "lms/djangoapps/bulk_enroll/",
-      "lms/djangoapps/bulk_user_retirement/",
-      "lms/djangoapps/ccx/",
-      "lms/djangoapps/certificates/",
-      "lms/djangoapps/commerce/"
+      "lms/djangoapps/discussion/rest_api/"
     ]
   },
   "lms-2": {
     "settings": "lms.envs.test",
     "paths": [
+      "lms/djangoapps/ccx/",
+      "lms/djangoapps/commerce/",
       "lms/djangoapps/course_api/",
-      "lms/djangoapps/course_blocks/",
-      "lms/djangoapps/course_goals/",
-      "lms/djangoapps/course_home_api/",
       "lms/djangoapps/course_wiki/",
-      "lms/djangoapps/coursewarehistoryextended/",
-      "lms/djangoapps/debug/"
+      "lms/djangoapps/discussion/notification_prefs/",
+      "lms/djangoapps/instructor_task/",
+      "lms/djangoapps/ora_staff_grader/",
+      "lms/djangoapps/survey/",
+      "lms/djangoapps/teams/",
+      "lms/djangoapps/verify_student/"
     ]
   },
   "lms-3": {
     "settings": "lms.envs.test",
     "paths": [
-      "lms/djangoapps/courseware/"
+      "lms/djangoapps/branding/",
+      "lms/djangoapps/bulk_enroll/",
+      "lms/djangoapps/courseware/",
+      "lms/djangoapps/instructor_analytics/",
+      "lms/djangoapps/learner_dashboard/",
+      "lms/djangoapps/lti_provider/",
+      "lms/djangoapps/program_enrollments/"
     ]
   },
   "lms-4": {
     "settings": "lms.envs.test",
     "paths": [
-      "lms/djangoapps/discussion/",
-      "lms/djangoapps/edxnotes/",
-      "lms/djangoapps/experiments/"
+      "lms/djangoapps/bulk_user_retirement/",
+      "lms/djangoapps/course_blocks/",
+      "lms/djangoapps/course_goals/",
+      "lms/djangoapps/course_home_api/",
+      "lms/djangoapps/coursewarehistoryextended/",
+      "lms/djangoapps/discussion/tests/",
+      "lms/djangoapps/experiments/",
+      "lms/djangoapps/grades/",
+      "lms/djangoapps/instructor/",
+      "lms/djangoapps/mfe_config_api/",
+      "lms/djangoapps/staticbook/",
+      "lms/lib/"
     ]
   },
   "lms-5": {
     "settings": "lms.envs.test",
     "paths": [
+      "lms/djangoapps/bulk_email/",
+      "lms/djangoapps/certificates/",
+      "lms/djangoapps/debug/",
+      "lms/djangoapps/discussion/django_comment_client/",
+      "lms/djangoapps/edxnotes/",
       "lms/djangoapps/gating/",
-      "lms/djangoapps/grades/",
-      "lms/djangoapps/instructor/",
-      "lms/djangoapps/instructor_analytics/"
-    ]
-  },
-  "lms-6": {
-    "settings": "lms.envs.test",
-    "paths": [
-      "lms/djangoapps/instructor_task/",
-      "lms/djangoapps/learner_dashboard/",
       "lms/djangoapps/learner_home/",
       "lms/djangoapps/lms_initialization/",
       "lms/djangoapps/lms_xblock/",
-      "lms/djangoapps/lti_provider/",
       "lms/djangoapps/mailing/",
       "lms/djangoapps/mobile_api/",
       "lms/djangoapps/monitoring/",
-      "lms/djangoapps/ora_staff_grader/",
-      "lms/djangoapps/program_enrollments/",
       "lms/djangoapps/rss_proxy/",
       "lms/djangoapps/static_template_view/",
-      "lms/djangoapps/staticbook/",
       "lms/djangoapps/support/",
-      "lms/djangoapps/survey/",
-      "lms/djangoapps/teams/",
       "lms/djangoapps/tests/",
       "lms/djangoapps/user_tours/",
-      "lms/djangoapps/verify_student/",
-      "lms/djangoapps/mfe_config_api/",
       "lms/envs/",
-      "lms/lib/",
       "lms/tests.py"
     ]
   },
-  "openedx-1-with-lms": {
+  "shared-with-lms-1": {
+    "settings": "lms.envs.test",
+    "paths": [
+      "common/djangoapps/",
+      "openedx/core/djangoapps/agreements/",
+      "openedx/core/djangoapps/api_admin/",
+      "openedx/core/djangoapps/authz/",
+      "openedx/core/djangoapps/cache_toolbox/",
+      "openedx/core/djangoapps/ccxcon/",
+      "openedx/core/djangoapps/content/",
+      "openedx/core/djangoapps/content_libraries/",
+      "openedx/core/djangoapps/course_apps/",
+      "openedx/core/djangoapps/credentials/",
+      "openedx/core/djangoapps/credit/",
+      "openedx/core/djangoapps/dark_lang/",
+      "openedx/core/djangoapps/django_comment_common/",
+      "openedx/core/djangoapps/embargo/",
+      "openedx/core/djangoapps/header_control/",
+      "openedx/core/djangoapps/heartbeat/",
+      "openedx/core/djangoapps/models/",
+      "openedx/core/djangoapps/notifications/",
+      "openedx/core/djangoapps/oauth_dispatch/",
+      "openedx/core/djangoapps/safe_sessions/",
+      "openedx/core/djangoapps/schedules/",
+      "openedx/core/djangoapps/user_api/",
+      "openedx/core/djangoapps/util/",
+      "openedx/core/djangoapps/video_pipeline/",
+      "openedx/core/djangoapps/waffle_utils/",
+      "openedx/core/djangoapps/xblock/",
+      "openedx/core/tests/",
+      "openedx/features/",
+      "openedx/tests/"
+    ]
+  },
+  "shared-with-lms-2": {
     "settings": "lms.envs.test",
     "paths": [
       "openedx/core/djangoapps/ace_common/",
-      "openedx/core/djangoapps/cors_csrf/",
-      "openedx/core/djangoapps/agreements/",
-      "openedx/core/djangoapps/api_admin/",
       "openedx/core/djangoapps/auth_exchange/",
       "openedx/core/djangoapps/bookmarks/",
-      "openedx/core/djangoapps/cache_toolbox/",
       "openedx/core/djangoapps/catalog/",
-      "openedx/core/djangoapps/ccxcon/",
       "openedx/core/djangoapps/commerce/",
       "openedx/core/djangoapps/common_initialization/",
       "openedx/core/djangoapps/common_views/",
       "openedx/core/djangoapps/config_model_utils/",
-      "openedx/core/djangoapps/content/",
-      "openedx/core/djangoapps/content_libraries/",
       "openedx/core/djangoapps/contentserver/",
       "openedx/core/djangoapps/cookie_metadata/",
-      "openedx/core/djangoapps/course_apps/",
+      "openedx/core/djangoapps/cors_csrf/",
       "openedx/core/djangoapps/course_date_signals/",
       "openedx/core/djangoapps/course_groups/",
+      "openedx/core/djangoapps/course_live/",
       "openedx/core/djangoapps/courseware_api/",
       "openedx/core/djangoapps/crawlers/",
-      "openedx/core/djangoapps/credentials/",
-      "openedx/core/djangoapps/credit/",
-      "openedx/core/djangoapps/course_live/",
-      "openedx/core/djangoapps/dark_lang/",
       "openedx/core/djangoapps/debug/",
       "openedx/core/djangoapps/discussions/",
-      "openedx/core/djangoapps/django_comment_common/",
-      "openedx/core/djangoapps/embargo/",
       "openedx/core/djangoapps/enrollments/",
-      "openedx/core/djangoapps/external_user_ids/"
-    ]
-  },
-  "openedx-2-with-lms": {
-    "settings": "lms.envs.test",
-    "paths": [
+      "openedx/core/djangoapps/external_user_ids/",
       "openedx/core/djangoapps/geoinfo/",
-      "openedx/core/djangoapps/header_control/",
-      "openedx/core/djangoapps/heartbeat/",
       "openedx/core/djangoapps/lang_pref/",
-      "openedx/core/djangoapps/models/",
       "openedx/core/djangoapps/monkey_patch/",
-      "openedx/core/djangoapps/notifications/",
-      "openedx/core/djangoapps/oauth_dispatch/",
       "openedx/core/djangoapps/olx_rest_api/",
       "openedx/core/djangoapps/password_policy/",
       "openedx/core/djangoapps/plugin_api/",
       "openedx/core/djangoapps/plugins/",
       "openedx/core/djangoapps/profile_images/",
       "openedx/core/djangoapps/programs/",
-      "openedx/core/djangoapps/safe_sessions/",
-      "openedx/core/djangoapps/schedules/",
       "openedx/core/djangoapps/service_status/",
       "openedx/core/djangoapps/session_inactivity_timeout/",
       "openedx/core/djangoapps/signals/",
       "openedx/core/djangoapps/site_configuration/",
       "openedx/core/djangoapps/system_wide_roles/",
       "openedx/core/djangoapps/theming/",
-      "openedx/core/djangoapps/user_api/",
       "openedx/core/djangoapps/user_authn/",
-      "openedx/core/djangoapps/util/",
       "openedx/core/djangoapps/verified_track_content/",
       "openedx/core/djangoapps/video_config/",
-      "openedx/core/djangoapps/video_pipeline/",
-      "openedx/core/djangoapps/waffle_utils/",
-      "openedx/core/djangoapps/xblock/",
       "openedx/core/djangoapps/xmodule_django/",
       "openedx/core/djangoapps/zendesk_proxy/",
-      "openedx/core/djangoapps/authz/",
       "openedx/core/djangolib/",
       "openedx/core/lib/",
-      "openedx/core/tests/",
-      "openedx/features/",
       "openedx/testing/",
-      "openedx/tests/"
+      "xmodule/"
     ]
   },
-  "openedx-1-with-cms": {
+  "shared-with-cms-1": {
     "settings": "cms.envs.test",
     "paths": [
+      "common/djangoapps/",
       "openedx/core/djangoapps/ace_common/",
-      "openedx/core/djangoapps/cors_csrf/",
       "openedx/core/djangoapps/agreements/",
       "openedx/core/djangoapps/api_admin/",
       "openedx/core/djangoapps/auth_exchange/",
+      "openedx/core/djangoapps/authz/",
       "openedx/core/djangoapps/bookmarks/",
       "openedx/core/djangoapps/cache_toolbox/",
       "openedx/core/djangoapps/catalog/",
@@ -175,8 +176,10 @@
       "openedx/core/djangoapps/content/",
       "openedx/core/djangoapps/content_libraries/",
       "openedx/core/djangoapps/content_staging/",
+      "openedx/core/djangoapps/content_tagging/",
       "openedx/core/djangoapps/contentserver/",
       "openedx/core/djangoapps/cookie_metadata/",
+      "openedx/core/djangoapps/cors_csrf/",
       "openedx/core/djangoapps/course_apps/",
       "openedx/core/djangoapps/course_date_signals/",
       "openedx/core/djangoapps/course_groups/",
@@ -190,13 +193,7 @@
       "openedx/core/djangoapps/django_comment_common/",
       "openedx/core/djangoapps/embargo/",
       "openedx/core/djangoapps/enrollments/",
-      "openedx/core/djangoapps/external_user_ids/"
-    ]
-  },
-  "openedx-2-with-cms": {
-    "settings": "cms.envs.test",
-    "paths": [
-      "openedx/core/djangoapps/content_tagging/",
+      "openedx/core/djangoapps/external_user_ids/",
       "openedx/core/djangoapps/geoinfo/",
       "openedx/core/djangoapps/header_control/",
       "openedx/core/djangoapps/heartbeat/",
@@ -228,9 +225,9 @@
       "openedx/core/djangoapps/xblock/",
       "openedx/core/djangoapps/xmodule_django/",
       "openedx/core/djangoapps/zendesk_proxy/",
-      "openedx/core/djangoapps/authz/",
       "openedx/core/lib/",
-      "openedx/tests/"
+      "openedx/tests/",
+      "xmodule/"
     ]
   },
   "cms-1": {
@@ -238,44 +235,15 @@
     "paths": [
       "cms/djangoapps/api/",
       "cms/djangoapps/cms_user_tasks/",
+      "cms/djangoapps/contentstore/",
       "cms/djangoapps/course_creators/",
       "cms/djangoapps/export_course_metadata/",
-      "cms/djangoapps/modulestore_migrator/",
       "cms/djangoapps/models/",
+      "cms/djangoapps/modulestore_migrator/",
       "cms/djangoapps/pipeline_js/",
       "cms/djangoapps/xblock_config/",
       "cms/envs/",
       "cms/lib/"
-    ]
-  },
-  "cms-2": {
-    "settings": "cms.envs.test",
-    "paths": [
-      "cms/djangoapps/contentstore/"
-    ]
-  },
-  "common-with-lms": {
-    "settings": "lms.envs.test",
-    "paths": [
-      "common/djangoapps/"
-    ]
-  },
-  "common-with-cms": {
-    "settings": "cms.envs.test",
-    "paths": [
-      "common/djangoapps/"
-    ]
-  },
-  "xmodule-with-lms": {
-    "settings": "lms.envs.test",
-    "paths": [
-      "xmodule/"
-    ]
-  },
-  "xmodule-with-cms": {
-    "settings": "cms.envs.test",
-    "paths": [
-      "xmodule/"
     ]
   }
 }

--- a/.github/workflows/unit-test-shards.json
+++ b/.github/workflows/unit-test-shards.json
@@ -235,7 +235,6 @@
     "paths": [
       "cms/djangoapps/api/",
       "cms/djangoapps/cms_user_tasks/",
-      "cms/djangoapps/contentstore/",
       "cms/djangoapps/course_creators/",
       "cms/djangoapps/export_course_metadata/",
       "cms/djangoapps/models/",
@@ -244,6 +243,12 @@
       "cms/djangoapps/xblock_config/",
       "cms/envs/",
       "cms/lib/"
+    ]
+  },
+  "cms-2": {
+    "settings": "cms.envs.test",
+    "paths": [
+      "cms/djangoapps/contentstore/"
     ]
   }
 }

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -119,7 +119,16 @@ jobs:
       - name: run tests
         shell: bash
         run: |
-          python -Wd -m pytest -p no:randomly --ds=${{ env.settings_path }} ${{ env.unit_test_paths }} --cov=.
+          python -Wd -m pytest -p no:randomly --ds=${{ env.settings_path }} ${{ env.unit_test_paths }} --cov=. \
+            --report-log=reports/pytest-report-${{ matrix.shard_name }}.jsonl
+
+      - name: Upload pytest timing report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pytest-report-${{ matrix.shard_name }}-${{ matrix.python-version }}-${{ matrix.django-version }}-${{ matrix.mongo-version }}-${{ matrix.os-version }}
+          path: reports/pytest-report-${{ matrix.shard_name }}.jsonl
+          overwrite: true
 
       - name: rename warnings json file
         if: success()

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -111,15 +111,20 @@ jobs:
         shell: bash
         run: |
           echo "unit_test_paths=$(python scripts/unit_test_shards_parser.py --shard-name=${{ matrix.shard_name }} )" >> $GITHUB_ENV
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo "report_log_arg=--report-log=reports/pytest-report-${{ matrix.shard_name }}.jsonl" >> $GITHUB_ENV
+          else
+            echo "report_log_arg=" >> $GITHUB_ENV
+          fi
 
       - name: run tests
         shell: bash
         run: |
           python -Wd -m pytest -p no:randomly --ds=${{ env.settings_path }} ${{ env.unit_test_paths }} --cov=. \
-            --report-log=reports/pytest-report-${{ matrix.shard_name }}.jsonl
+            ${{ env.report_log_arg }}
 
       - name: Upload pytest timing report
-        if: always()
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v7
         with:
           name: pytest-report-${{ matrix.shard_name }}-${{ matrix.python-version }}-${{ matrix.django-version }}-${{ matrix.mongo-version }}-${{ matrix.os-version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -39,6 +39,7 @@ jobs:
           # https://github.com/openedx/openedx-platform/issues/38355
           - "shared-with-cms-1"
           - "cms-1"
+          - "cms-2"
         mongo-version:
           - "7.0"
         os-version:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,25 +25,20 @@ jobs:
           - "3.12"
         django-version:
           - "pinned"
-        # When updating the shards, remember to make the same changes in
-        # .github/workflows/unit-tests-gh-hosted.yml
         shard_name:
           - "lms-1"
           - "lms-2"
           - "lms-3"
           - "lms-4"
           - "lms-5"
-          - "lms-6"
-          - "openedx-1-with-lms"
-          - "openedx-2-with-lms"
-          - "openedx-1-with-cms"
-          - "openedx-2-with-cms"
+          - "shared-with-lms-1"
+          - "shared-with-lms-2"
+          # Note: The shared-with-cms-1 shard is currently a subset of both
+          # shared-with-lms-1 and shared-with-lms-2. Some shared tests are
+          # not run -with-cms at all.
+          # https://github.com/openedx/openedx-platform/issues/38355
+          - "shared-with-cms-1"
           - "cms-1"
-          - "cms-2"
-          - "common-with-lms"
-          - "common-with-cms"
-          - "xmodule-with-lms"
-          - "xmodule-with-cms"
         mongo-version:
           - "7.0"
         os-version:

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1724,6 +1724,7 @@ pytest==8.2.0
     #   pytest-json-report
     #   pytest-metadata
     #   pytest-randomly
+    #   pytest-reportlog
     #   pytest-xdist
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.txt
@@ -1738,6 +1739,8 @@ pytest-metadata==3.1.1
     #   -r requirements/edx/testing.txt
     #   pytest-json-report
 pytest-randomly==4.0.1
+    # via -r requirements/edx/testing.txt
+pytest-reportlog==1.0.0
     # via -r requirements/edx/testing.txt
 pytest-xdist[psutil]==3.8.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -38,6 +38,7 @@ pytest-django             # Django support for pytest
 pytest-json-report        # Output json formatted warnings after running pytest
 pytest-metadata           # To prevent 'make upgrade' failure, dependency of pytest-json-report
 pytest-randomly           # pytest plugin to randomly order tests
+pytest-reportlog          # Per-test timing data including setup/teardown (used for shard rebalancing)
 pytest-xdist[psutil]      # Parallel execution of tests on multiple CPU cores or hosts
 singledispatch            # Backport of functools.singledispatch from Python 3.4+, used in tests of XBlock rendering
 testfixtures              # Provides a LogCapture utility used by several tests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1310,6 +1310,7 @@ pytest==8.2.0
     #   pytest-json-report
     #   pytest-metadata
     #   pytest-randomly
+    #   pytest-reportlog
     #   pytest-xdist
 pytest-attrib==0.1.3
     # via -r requirements/edx/testing.in
@@ -1324,6 +1325,8 @@ pytest-metadata==3.1.1
     #   -r requirements/edx/testing.in
     #   pytest-json-report
 pytest-randomly==4.0.1
+    # via -r requirements/edx/testing.in
+pytest-reportlog==1.0.0
     # via -r requirements/edx/testing.in
 pytest-xdist[psutil]==3.8.0
     # via -r requirements/edx/testing.in


### PR DESCRIPTION
## Summary

Rebalances the unit test shard configuration to reduce the CI critical path from ~29 minutes down to ~23 minutes, measured across 3 consistent runs.

### What changed

- **Replaced 16 uneven shards with 10 balanced shards** targeting ~19–23 min each
- **New shard layout**: 5 LMS shards, 2 shared-with-LMS shards, 1 shared-with-CMS shard, and 2 CMS shards
  - \`cms-1\`: small CMS apps (api, cms_user_tasks, course_creators, envs, lib, etc.) — ~5–6 min
  - \`cms-2\`: \`contentstore/\` only — ~19–20 min (split out to avoid OOM on runners when combined with other CMS apps)
- **Also includes test isolation fixes** (also in openedx/openedx-platform#38347 for independent merging):
  - Moved \`CourseFactory()\` calls from \`setUp\` to \`setUpClass\` in three certificate test classes to avoid exhausting MongoDB connections across test methods
  - Updated to openedx-events 11.1.1 which adds \`tearDownClass\` to \`OpenEdxEventsTestMixin\`, preventing events from being left globally disabled between test classes

### Timing data — 3 runs on the new config (all passed)

| Shard | Run 1 | Run 2 | Run 3 | Avg |
|-------|-------|-------|-------|-----|
| `shared-with-cms-1` | 22m48s | 22m33s | 23m09s | ~22m50s |
| `shared-with-lms-1` | 21m57s | 22m49s | 23m01s | ~22m36s |
| `shared-with-lms-2` | 20m06s | 20m54s | 22m05s | ~21m02s |
| `lms-4` | 22m28s | 21m07s | 21m27s | ~21m41s |
| `lms-1` | 21m18s | 19m23s | 22m25s | ~21m02s |
| `lms-5` | 19m50s | 21m11s | 19m22s | ~20m08s |
| `cms-2` | 19m31s | 18m13s | 20m19s | ~19m21s |
| `lms-2` | 19m16s | 19m19s | 18m43s | ~19m06s |
| `lms-3` | 18m43s | 18m48s | 18m52s | ~18m48s |
| `cms-1` | 5m40s | 5m27s | 5m32s | ~5m33s |
| **Critical path** | **~23m** | **~23m** | **~23m** | **~23m** |

For comparison, the old config's critical path (visible in the #38347 run on unmodified master) was **~29m** on `lms-4`.

Future Issues: https://github.com/openedx/openedx-platform/issues/38355