### PR TITLE
feat: allow specifying search parameters in the URL

### DIFF
--- a/lms/static/js/discovery/discovery_factory.js
+++ b/lms/static/js/discovery/discovery_factory.js
@@ -21,7 +21,23 @@
                 userLanguage: userLanguage,
                 userTimezone: userTimezone
             };
-            if (setDefaultFilter && userLanguage) {
+            // Read facet filters from URL query parameters and apply them.
+            var urlParams = new URLSearchParams(window.location.search);
+            urlParams.forEach(function(value, key) {
+                if (key === 'search_query') {
+                    return; // handled separately via the searchQuery argument
+                }
+                if (key in meanings) {
+                    filters.add({
+                        type: key,
+                        query: value,
+                        name: refineSidebar.termName(key, value)
+                    });
+                }
+            });
+
+            // Apply the default language filter, except when provided via URL parameters.
+            if (setDefaultFilter && userLanguage && !filters.get('language')) {
                 filters.add({
                     type: 'language',
                     query: userLanguage,
@@ -29,6 +45,16 @@
                 });
             }
             listing = new CoursesListing({model: courseListingModel});
+
+            function updateUrl() {
+                var params = new URLSearchParams();
+                filters.each(function(filter) {
+                    params.set(filter.id, filter.get('query'));
+                });
+                var qs = params.toString();
+                var newUrl = window.location.pathname + (qs ? '?' + qs : '');
+                history.replaceState(null, '', newUrl);
+            }
 
             dispatcher.listenTo(form, "search", function (query) {
                 form.showLoadingIndicator();
@@ -79,6 +105,7 @@
                 form.hideLoadingIndicator();
                 listing.render();
                 refineSidebar.render();
+                updateUrl();
             });
 
             dispatcher.listenTo(search, 'error', function() {

--- a/lms/static/js/spec/discovery/discovery_factory_spec.js
+++ b/lms/static/js/spec/discovery/discovery_factory_spec.js
@@ -225,4 +225,100 @@ define([
             expect(request.requestBody).toMatch(/language=en/);
         });
     });
+
+    describe('discovery.DiscoveryFactory URL sync', function() {
+        var originalSearch;
+        var replaceStateSpy;
+
+        function setUrlSearch(search) {
+            // Override window.location.search for the factory to read
+            originalSearch = window.location.search;
+            // Use history.replaceState to set query parameters without navigation
+            history.replaceState(null, '', window.location.pathname + search);
+        }
+
+        beforeEach(function() {
+            originalSearch = window.location.search;
+            replaceStateSpy = spyOn(history, 'replaceState').and.callThrough();
+            loadFixtures('js/fixtures/discovery.html');
+            TemplateHelpers.installTemplates([
+                'templates/discovery/course_card',
+                'templates/discovery/facet',
+                'templates/discovery/facet_option',
+                'templates/discovery/filter',
+                'templates/discovery/filter_bar'
+            ]);
+            jasmine.clock().install();
+        });
+
+        afterEach(function() {
+            jasmine.clock().uninstall();
+            // Restore original URL
+            history.replaceState(null, '', window.location.pathname + originalSearch);
+        });
+
+        it('pre-populates filters from URL query params', function() {
+            setUrlSearch('?modes=honor');
+            DiscoveryFactory(MEANINGS);
+
+            var requests = AjaxHelpers.requests(this);
+            $('.discovery-submit').trigger('click');
+            var request = AjaxHelpers.currentRequest(requests);
+            expect(request.requestBody).toMatch(/modes=honor/);
+            expect($('.active-filter').length).toBe(1);
+        });
+
+        it('overrides default language filter with URL param', function() {
+            // Set URL with language filter different from the default
+            setUrlSearch('?language=hr');
+            // Call DiscoveryFactory with userLanguage='en' and setDefaultFilter=true
+            DiscoveryFactory(MEANINGS, '', 'en', 'Europe/Lisbon', true);
+
+            var requests = AjaxHelpers.requests(this);
+            $('.discovery-submit').trigger('click');
+            var request = AjaxHelpers.currentRequest(requests);
+            expect(request.requestBody).toMatch(/language=hr/);
+            expect(request.requestBody).not.toMatch(/language=en/);
+        });
+
+        it('ignores unrecognized URL params', function() {
+            setUrlSearch('?bogus=value');
+            DiscoveryFactory(MEANINGS);
+
+            var requests = AjaxHelpers.requests(this);
+            $('.discovery-submit').trigger('click');
+            var request = AjaxHelpers.currentRequest(requests);
+            expect(request.requestBody).not.toMatch(/bogus/);
+            expect($('.active-filter').length).toBe(0);
+        });
+
+        it('updates URL after search completes', function() {
+            setUrlSearch('');
+            DiscoveryFactory(MEANINGS);
+
+            var requests = AjaxHelpers.requests(this);
+            $('.discovery-input').val('test');
+            $('.discovery-submit').trigger('click');
+            AjaxHelpers.respondWithJson(requests, JSON_RESPONSE);
+            expect(replaceStateSpy).toHaveBeenCalled();
+            var lastCall = replaceStateSpy.calls.mostRecent();
+            expect(lastCall.args[2]).toMatch(/search_query=test/);
+        });
+
+        it('clears URL params when filters are reset', function() {
+            setUrlSearch('?language=en');
+            DiscoveryFactory(MEANINGS);
+
+            var requests = AjaxHelpers.requests(this);
+            // Trigger initial search to load results
+            $('.discovery-submit').trigger('click');
+            AjaxHelpers.respondWithJson(requests, JSON_RESPONSE);
+            // Clear all filters
+            $('#clear-all-filters').trigger('click');
+            // The clear triggers a new search with empty query
+            AjaxHelpers.respondWithJson(requests, JSON_RESPONSE);
+            var lastCall = replaceStateSpy.calls.mostRecent();
+            expect(lastCall.args[2]).toBe(window.location.pathname);
+        });
+    });
 });

--- a/lms/static/js/spec/discovery/discovery_factory_spec.js
+++ b/lms/static/js/spec/discovery/discovery_factory_spec.js
@@ -233,4 +233,100 @@ define([
             expect(request.requestBody).toMatch(/language=en/);
         });
     });
+
+    describe('discovery.DiscoveryFactory URL sync', function() {
+        var originalSearch;
+        var replaceStateSpy;
+
+        function setUrlSearch(search) {
+            // Override window.location.search for the factory to read
+            originalSearch = window.location.search;
+            // Use history.replaceState to set query parameters without navigation
+            history.replaceState(null, '', window.location.pathname + search);
+        }
+
+        beforeEach(function() {
+            originalSearch = window.location.search;
+            replaceStateSpy = spyOn(history, 'replaceState').and.callThrough();
+            loadFixtures('js/fixtures/discovery.html');
+            TemplateHelpers.installTemplates([
+                'templates/discovery/course_card',
+                'templates/discovery/facet',
+                'templates/discovery/facet_option',
+                'templates/discovery/filter',
+                'templates/discovery/filter_bar'
+            ]);
+            jasmine.clock().install();
+        });
+
+        afterEach(function() {
+            jasmine.clock().uninstall();
+            // Restore original URL
+            history.replaceState(null, '', window.location.pathname + originalSearch);
+        });
+
+        it('pre-populates filters from URL query params', function() {
+            setUrlSearch('?modes=honor');
+            DiscoveryFactory(MEANINGS);
+
+            var requests = AjaxHelpers.requests(this);
+            $('.discovery-submit').trigger('click');
+            var request = AjaxHelpers.currentRequest(requests);
+            expect(request.requestBody).toMatch(/modes=honor/);
+            expect($('.active-filter').length).toBe(1);
+        });
+
+        it('overrides default language filter with URL param', function() {
+            // Set URL with language filter different from the default
+            setUrlSearch('?language=hr');
+            // Call DiscoveryFactory with userLanguage='en' and setDefaultFilter=true
+            DiscoveryFactory(MEANINGS, '', 'en', 'Europe/Lisbon', true);
+
+            var requests = AjaxHelpers.requests(this);
+            $('.discovery-submit').trigger('click');
+            var request = AjaxHelpers.currentRequest(requests);
+            expect(request.requestBody).toMatch(/language=hr/);
+            expect(request.requestBody).not.toMatch(/language=en/);
+        });
+
+        it('ignores unrecognized URL params', function() {
+            setUrlSearch('?bogus=value');
+            DiscoveryFactory(MEANINGS);
+
+            var requests = AjaxHelpers.requests(this);
+            $('.discovery-submit').trigger('click');
+            var request = AjaxHelpers.currentRequest(requests);
+            expect(request.requestBody).not.toMatch(/bogus/);
+            expect($('.active-filter').length).toBe(0);
+        });
+
+        it('updates URL after search completes', function() {
+            setUrlSearch('');
+            DiscoveryFactory(MEANINGS);
+
+            var requests = AjaxHelpers.requests(this);
+            $('.discovery-input').val('test');
+            $('.discovery-submit').trigger('click');
+            AjaxHelpers.respondWithJson(requests, JSON_RESPONSE);
+            expect(replaceStateSpy).toHaveBeenCalled();
+            var lastCall = replaceStateSpy.calls.mostRecent();
+            expect(lastCall.args[2]).toMatch(/search_query=test/);
+        });
+
+        it('clears URL params when filters are reset', function() {
+            setUrlSearch('?language=en');
+            DiscoveryFactory(MEANINGS);
+
+            var requests = AjaxHelpers.requests(this);
+            // Trigger initial search to load results
+            $('.discovery-submit').trigger('click');
+            AjaxHelpers.respondWithJson(requests, JSON_RESPONSE);
+            // Clear all filters
+            $('#clear-all-filters').trigger('click');
+            // The clear triggers a new search with empty query
+            AjaxHelpers.respondWithJson(requests, JSON_RESPONSE);
+            var lastCall = replaceStateSpy.calls.mostRecent();
+            expect(lastCall.args[2]).toBe(window.location.pathname);
+        });
+    });
 });


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This patch implements reading search facet filters (language, org, topic, etc.) from URL query parameters, and updating the browser address bar to reflect changes to search terms or filters, so the URL always reflects the current filters.

This allows searches to be shared or bookmarked via URLs like `/courses?search_query=foo&language=pt`.
It also adds an additional confirmation to the user about which filters are currently applied.

## Supporting information

I didn't find previous discussions or requests for this feature.

## Testing instructions

Unit tests have been added to cover the added behavior.

## Other information

For additional context, this change was motivated by me trying to bookmark a search in [WikiLearn](https://learn.wiki/courses), so that I could periodically revisit it to check out any new courses matching my preferences, or share a search results page with someone who might be interested in that specific set of courses.
