### PR TITLE
feat: Add enrollments actions endpoints

### DIFF
--- a/lms/djangoapps/instructor/docs/references/enrollment-v2-api-spec.yaml
+++ b/lms/djangoapps/instructor/docs/references/enrollment-v2-api-spec.yaml
@@ -152,7 +152,7 @@ paths:
 
         **Invalid identifiers:**
         - Identifiers that are neither a valid email nor a known username return
-          `invalidIdentifier: true` with no `before`/`after` state
+          `invalid_identifier: true` with no `before`/`after` state
 
         **Email Notifications:**
         - Controlled by `email_students` parameter
@@ -194,7 +194,7 @@ paths:
                     allowed: false
                     auto_enroll: false
                 - identifier: "not-an-email"
-                  invalidIdentifier: true
+                  invalid_identifier: true
         400:
           $ref: '#/responses/BadRequest'
         401:
@@ -416,7 +416,7 @@ definitions:
     type: object
     description: |
       Result for a single identifier. On success, contains `before` and `after` state.
-      On invalid identifier, contains `invalidIdentifier: true` with no state.
+      On invalid identifier, contains `invalid_identifier: true` with no state.
       On error, contains `error: true` with no state.
     required:
       - identifier
@@ -430,7 +430,7 @@ definitions:
       after:
         $ref: '#/definitions/EnrollmentState'
         description: Enrollment state after the operation (absent on error or invalid identifier)
-      invalidIdentifier:
+      invalid_identifier:
         type: boolean
         description: True if the identifier is not a valid email and not a known username
       error:

--- a/lms/djangoapps/instructor/docs/references/enrollment-v2-api-spec.yaml
+++ b/lms/djangoapps/instructor/docs/references/enrollment-v2-api-spec.yaml
@@ -14,9 +14,7 @@ info:
     - Follows Open edX REST API Conventions
 
     **Execution Model:**
-    - Operations that affect a single learner execute synchronously (< 5s typical)
-    - Operations that affect multiple learners queue a background task
-    - Use the task status endpoint to monitor background tasks
+    - All operations execute synchronously
 
     **Authentication:**
     - OAuth2 for mobile clients and micro-services
@@ -59,15 +57,13 @@ tags:
     description: Course enrollment operations
 
 paths:
-  # ==================== ENROLLMENT ENDPOINTS ====================
-
-  /api/enrollment/v2/courses/{course_key}/enrollments:
+  /api/instructor/v2/courses/{course_id}/enrollments:
     get:
       tags:
         - Enrollments
       summary: List course enrollments
       description: |
-        Retrieve a paginated list of all enrollments for a course.
+        Retrieve a paginated list of all active enrollments for a course.
 
         **Performance:** Returns basic enrollment data by default. Use `requested_fields`
         parameter to include additional data such as profile images or beta tester status.
@@ -78,7 +74,7 @@ paths:
       produces:
         - application/json
       parameters:
-        - $ref: '#/parameters/CourseKey'
+        - $ref: '#/parameters/CourseId'
         - name: page
           in: query
           description: Page number (1-indexed)
@@ -111,7 +107,7 @@ paths:
             application/json:
               count: 1035
               num_pages: 42
-              next: "/api/enrollment/v2/courses/course-v1:edX+DemoX+Demo_Course/enrollments?page=2"
+              next: "/api/instructor/v2/courses/course-v1:edX+DemoX+Demo_Course/enrollments?page=2"
               previous: null
               results:
                 - username: "bjohnson"
@@ -137,217 +133,86 @@ paths:
         404:
           $ref: '#/responses/NotFound'
 
+  /api/instructor/v2/courses/{course_id}/enrollments/modify:
     post:
       tags:
         - Enrollments
-      summary: Enroll learners in course
+      summary: Enroll or unenroll learners
       description: |
-        Enroll one or more learners in a course by email or username.
+        Enroll or unenroll one or more learners in a course by email or username.
 
-        **Behavior:**
-        - If user exists and is active: Enrolls immediately in specified mode (or default)
+        **Enroll behavior:**
+        - If user exists and is active: Enrolls immediately
         - If user does not exist: Creates CourseEnrollmentAllowed record
         - When the user registers, they will be auto-enrolled if `auto_enroll` is true
 
-        **Scope:**
-        - Single learner: Synchronous operation (~100-500ms)
-        - Multiple learners: Asynchronous task queued
+        **Unenroll behavior:**
+        - If user is enrolled: Deactivates the enrollment
+        - If user has CourseEnrollmentAllowed: Deletes the allowed enrollment
+
+        **Invalid identifiers:**
+        - Identifiers that are neither a valid email nor a known username return
+          `invalidIdentifier: true` with no `before`/`after` state
 
         **Email Notifications:**
-        - If user is already registered: Uses "enrolled_enroll" message type
-        - If user is not registered: Uses "allowed_enroll" message type
-      operationId: enrollLearners
+        - Controlled by `email_students` parameter
+        - Enroll (registered user): Uses "enrolled_enroll" message type
+        - Enroll (unregistered): Uses "allowed_enroll" message type
+        - Unenroll (enrolled): Uses "enrolled_unenroll" message type
+        - Unenroll (allowed): Uses "allowed_unenroll" message type
+      operationId: modifyEnrollments
       consumes:
         - application/json
       produces:
         - application/json
       parameters:
-        - $ref: '#/parameters/CourseKey'
+        - $ref: '#/parameters/CourseId'
         - name: body
           in: body
           required: true
           schema:
-            type: object
-            required:
-              - identifiers
-            properties:
-              identifiers:
-                type: array
-                description: List of email addresses or usernames to enroll
-                minItems: 1
-                items:
-                  type: string
-                example: ["john@example.com", "jane_doe"]
-              auto_enroll:
-                type: boolean
-                description: Auto-enroll user when they register (for non-registered users)
-                default: false
-              email_students:
-                type: boolean
-                description: Send email notification to learners
-                default: false
-              reason:
-                type: string
-                description: Reason for enrollment (included in email if email_students is true)
-                x-nullable: true
-              mode:
-                type: string
-                description: Enrollment mode (audit, honor, verified, professional, etc.)
-                x-nullable: true
-                example: "audit"
+            $ref: '#/definitions/EnrollmentModifyRequest'
       responses:
         200:
-          description: Single learner enrolled successfully (synchronous)
+          description: Per-identifier results returned (may include both successes and failures)
           schema:
-            $ref: '#/definitions/EnrollmentOperationResult'
+            $ref: '#/definitions/EnrollmentModifyResponse'
           examples:
             application/json:
               action: "enroll"
-              results:
-                - identifier: "john@example.com"
-                  before:
-                    enrolled: false
-                    allowed: false
-                  after:
-                    enrolled: true
-                    allowed: false
-                    mode: "audit"
-        202:
-          description: Multiple learner enrollment task queued (asynchronous)
-          schema:
-            $ref: '#/definitions/AsyncOperationResult'
-          examples:
-            application/json:
-              task_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-              status_url: "/api/enrollment/v2/courses/course-v1:edX+DemoX+Demo_Course/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-              action: "enroll"
-              count: 150
-        400:
-          $ref: '#/responses/BadRequest'
-        401:
-          $ref: '#/responses/Unauthorized'
-        403:
-          $ref: '#/responses/Forbidden'
-        404:
-          $ref: '#/responses/NotFound'
-
-  /api/enrollment/v2/courses/{course_key}/enrollments/{email_or_username}:
-    get:
-      tags:
-        - Enrollments
-      summary: Get learner enrollment details
-      description: |
-        Retrieve detailed enrollment information for a specific learner.
-
-        **Returns:**
-        - Current enrollment status
-        - CourseEnrollmentAllowed status (if applicable)
-        - Enrollment mode
-        - User profile information
-      operationId: getEnrollment
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/CourseKey'
-        - $ref: '#/parameters/LearnerIdentifierPath'
-      responses:
-        200:
-          description: Enrollment information retrieved successfully
-          schema:
-            $ref: '#/definitions/Enrollment'
-          examples:
-            application/json:
-              username: "john_harvard"
-              email: "john@example.com"
-              full_name: "John Harvard"
-              mode: "audit"
-              is_active: true
-              created: "2024-01-15T10:30:00Z"
-              enrollment_allowed: false
               auto_enroll: false
-              beta_tester: false
-        400:
-          $ref: '#/responses/BadRequest'
-        401:
-          $ref: '#/responses/Unauthorized'
-        403:
-          $ref: '#/responses/Forbidden'
-        404:
-          $ref: '#/responses/NotFound'
-
-    delete:
-      tags:
-        - Enrollments
-      summary: Unenroll learner from course
-      description: |
-        Unenroll a learner from a course.
-
-        **Behavior:**
-        - If user is enrolled: Unenrolls from course
-        - If user has CourseEnrollmentAllowed: Deletes the allowed enrollment
-        - Both operations are performed if both conditions exist
-        - Optionally sends notification email to learner
-
-        **Email Notifications:**
-        - If user was enrolled: Uses "enrolled_unenroll" message type
-        - If user had allowed enrollment: Uses "allowed_unenroll" message type
-      operationId: unenrollLearner
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/CourseKey'
-        - $ref: '#/parameters/LearnerIdentifierPath'
-        - name: email_student
-          in: query
-          description: Send email notification to learner
-          required: false
-          type: boolean
-          default: false
-      responses:
-        200:
-          description: Learner unenrolled successfully
-          schema:
-            $ref: '#/definitions/EnrollmentOperationResult'
-          examples:
-            application/json:
-              action: "unenroll"
               results:
                 - identifier: "john@example.com"
                   before:
-                    enrolled: true
+                    user: true
+                    enrollment: false
                     allowed: false
-                    mode: "audit"
+                    auto_enroll: false
                   after:
-                    enrolled: false
+                    user: true
+                    enrollment: true
                     allowed: false
+                    auto_enroll: false
+                - identifier: "not-an-email"
+                  invalidIdentifier: true
         400:
           $ref: '#/responses/BadRequest'
         401:
           $ref: '#/responses/Unauthorized'
         403:
           $ref: '#/responses/Forbidden'
-        404:
-          $ref: '#/responses/NotFound'
 
 # ==================== COMPONENTS ====================
 
 parameters:
-  CourseKey:
-    name: course_key
+  CourseId:
+    name: course_id
     in: path
     required: true
     description: Course identifier in format `course-v1:{org}+{course}+{run}`
     type: string
     pattern: '^course-v1:[^/+]+(\+[^/+]+)+(\+[^/]+)$'
     x-example: "course-v1:edX+DemoX+Demo_Course"
-
-  LearnerIdentifierPath:
-    name: email_or_username
-    in: path
-    required: true
-    description: Learner's username or email address
-    type: string
-    minLength: 1
 
 responses:
   BadRequest:
@@ -415,7 +280,7 @@ definitions:
         format: uri
         description: URL to the next page of results
         x-nullable: true
-        example: "/api/enrollment/v2/courses/course-v1:edX+DemoX+Demo_Course/enrollments?page=2"
+        example: "/api/instructor/v2/courses/course-v1:edX+DemoX+Demo_Course/enrollments?page=2"
       previous:
         type: string
         format: uri
@@ -464,14 +329,6 @@ definitions:
         description: Enrollment creation timestamp (ISO 8601 format with timezone)
         x-nullable: true
         example: "2024-01-15T10:30:00Z"
-      enrollment_allowed:
-        type: boolean
-        description: Whether user has a CourseEnrollmentAllowed record
-        example: false
-      auto_enroll:
-        type: boolean
-        description: Whether user will be auto-enrolled upon registration
-        example: false
       beta_tester:
         type: boolean
         description: Whether learner is a beta tester (only present if requested_fields includes beta_tester)
@@ -502,85 +359,105 @@ definitions:
             format: uri
             description: Small thumbnail URL
 
-  EnrollmentOperationResult:
+  EnrollmentModifyRequest:
     type: object
-    description: Result from an enrollment operation (enroll/unenroll)
+    description: Request body for enrolling or unenrolling learners
+    required:
+      - identifier
+      - action
+    properties:
+      identifier:
+        type: array
+        description: List of email addresses or usernames to enroll/unenroll
+        minItems: 1
+        items:
+          type: string
+          maxLength: 255
+        example: ["john@example.com", "jane_doe"]
+      action:
+        type: string
+        enum: ["enroll", "unenroll"]
+        description: The enrollment action to perform
+      auto_enroll:
+        type: boolean
+        description: Auto-enroll user when they register (for non-registered users, enroll action only)
+        default: false
+      email_students:
+        type: boolean
+        description: Send email notification to learners
+        default: false
+      reason:
+        type: string
+        description: Reason for the change (for audit trail)
+        default: ""
+
+  EnrollmentModifyResponse:
+    type: object
+    description: Result from an enrollment modify operation
     required:
       - action
+      - auto_enroll
       - results
     properties:
       action:
         type: string
         enum: ["enroll", "unenroll"]
         description: The action that was performed
+      auto_enroll:
+        type: boolean
+        description: The auto_enroll value from the request
       results:
         type: array
-        description: Results for each identifier
+        description: Per-identifier results
         items:
-          type: object
-          required:
-            - identifier
-            - before
-            - after
-          properties:
-            identifier:
-              type: string
-              description: Email or username that was processed
-            before:
-              $ref: '#/definitions/EnrollmentState'
-            after:
-              $ref: '#/definitions/EnrollmentState'
-            error:
-              type: string
-              description: Error message if operation failed for this identifier
-              x-nullable: true
+          $ref: '#/definitions/EnrollmentModifyResult'
+
+  EnrollmentModifyResult:
+    type: object
+    description: |
+      Result for a single identifier. On success, contains `before` and `after` state.
+      On invalid identifier, contains `invalidIdentifier: true` with no state.
+      On error, contains `error: true` with no state.
+    required:
+      - identifier
+    properties:
+      identifier:
+        type: string
+        description: Email or username that was processed
+      before:
+        $ref: '#/definitions/EnrollmentState'
+        description: Enrollment state before the operation (absent on error or invalid identifier)
+      after:
+        $ref: '#/definitions/EnrollmentState'
+        description: Enrollment state after the operation (absent on error or invalid identifier)
+      invalidIdentifier:
+        type: boolean
+        description: True if the identifier is not a valid email and not a known username
+      error:
+        type: boolean
+        description: True if an unexpected error occurred processing this identifier
 
   EnrollmentState:
     type: object
-    description: Enrollment state snapshot
+    description: Snapshot of a learner's enrollment state (mirrors EmailEnrollmentState.to_dict)
     required:
-      - enrolled
+      - user
+      - enrollment
       - allowed
+      - auto_enroll
     properties:
-      enrolled:
+      user:
         type: boolean
-        description: Whether user is enrolled
+        description: Whether a registered user exists for this identifier
+      enrollment:
+        type: boolean
+        description: Whether the user has an active enrollment
       allowed:
         type: boolean
-        description: Whether user has CourseEnrollmentAllowed record
-      mode:
-        type: string
-        description: Enrollment mode (if enrolled)
-        x-nullable: true
+        description: Whether a CourseEnrollmentAllowed record exists
       auto_enroll:
         type: boolean
-        description: Auto-enroll setting (if allowed)
-        x-nullable: true
-
-  AsyncOperationResult:
-    type: object
-    description: Task information for an asynchronous operation
-    required:
-      - task_id
-      - status_url
-    properties:
-      task_id:
-        type: string
-        description: Unique task identifier
-        example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-      status_url:
-        type: string
-        format: uri
-        description: URL to poll for task status (see Task API for details)
-        example: "/api/enrollment/v2/courses/course-v1:edX+DemoX+Demo_Course/tasks/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-      action:
-        type: string
-        description: The action being performed
-        example: "enroll"
-      count:
-        type: integer
-        description: Number of learners being processed
-        example: 150
+        description: Whether auto_enroll is set on the CourseEnrollmentAllowed record
 
   Error:
     type: object

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -17,7 +17,8 @@ from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
-from common.djangoapps.student.models.course_enrollment import CourseEnrollment
+from common.djangoapps.student.models import ManualEnrollmentAudit
+from common.djangoapps.student.models.course_enrollment import CourseEnrollment, CourseEnrollmentAllowed
 from common.djangoapps.student.roles import CourseBetaTesterRole, CourseDataResearcherRole, CourseInstructorRole
 from common.djangoapps.student.tests.factories import (
     AdminFactory,
@@ -2313,3 +2314,313 @@ class CourseEnrollmentsViewTest(SharedModuleStoreTestCase):
         data = response.data
         self.assertEqual(data['count'], 1)  # noqa: PT009
         self.assertTrue(data['results'][0]['is_beta_tester'])  # noqa: PT009
+
+
+class EnrollmentModifyViewTest(SharedModuleStoreTestCase):
+    """Tests for the EnrollmentModifyView v2 bulk POST endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course = CourseFactory.create()
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.instructor = InstructorFactory(course_key=self.course.id)
+        self.url = reverse(
+            'instructor_api_v2:enrollment_modify',
+            kwargs={'course_id': str(self.course.id)}
+        )
+
+    def _enroll(self, identifiers, **extra):
+        return self.client.post(
+            self.url,
+            {'identifier': identifiers, 'action': 'enroll', **extra},
+            format='json',
+        )
+
+    def _unenroll(self, identifiers, **extra):
+        return self.client.post(
+            self.url,
+            {'identifier': identifiers, 'action': 'unenroll', **extra},
+            format='json',
+        )
+
+    def test_unauthenticated_returns_401(self):
+        response = self._enroll(['test@example.com'])
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_student_returns_403(self):
+        self.client.force_authenticate(user=UserFactory())
+        response = self._enroll(['test@example.com'])
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_missing_fields_returns_400(self):
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {}, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_empty_identifier_list_returns_400(self):
+        self.client.force_authenticate(user=self.instructor)
+        response = self._enroll([])
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_invalid_action_returns_400(self):
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(
+            self.url,
+            {'identifier': ['a@b.com'], 'action': 'bogus'},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_enroll_existing_user(self):
+        learner = UserFactory()
+        self.client.force_authenticate(user=self.instructor)
+        response = self._enroll([learner.email])
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['action'] == 'enroll'
+        assert response.data['auto_enroll'] is False
+        result = response.data['results'][0]
+        assert result['identifier'] == learner.email
+        assert result['before'] == {'user': True, 'enrollment': False, 'allowed': False, 'auto_enroll': False}
+        assert result['after']['enrollment'] is True
+        assert result['after']['user'] is True
+        assert result['after']['allowed'] is False
+        assert CourseEnrollment.is_enrolled(learner, self.course.id)
+
+    def test_enroll_by_username(self):
+        learner = UserFactory()
+        self.client.force_authenticate(user=self.instructor)
+        response = self._enroll([learner.username])
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['results'][0]['after']['enrollment'] is True
+        assert CourseEnrollment.is_enrolled(learner, self.course.id)
+
+    def test_enroll_nonexistent_user_creates_cea(self):
+        email = 'newlearner@example.com'
+        self.client.force_authenticate(user=self.instructor)
+        response = self._enroll([email])
+        assert response.status_code == status.HTTP_200_OK
+        result = response.data['results'][0]
+        assert result['after']['user'] is False
+        assert result['after']['enrollment'] is False
+        assert result['after']['allowed'] is True
+        assert CourseEnrollmentAllowed.objects.filter(email=email, course_id=self.course.id).exists()
+
+    def test_enroll_invalid_email_returns_invalid_identifier(self):
+        self.client.force_authenticate(user=self.instructor)
+        response = self._enroll(['not-an-email'])
+        assert response.status_code == status.HTTP_200_OK
+        result = response.data['results'][0]
+        assert result.get('invalidIdentifier') is True
+        assert 'before' not in result
+        assert 'after' not in result
+
+    def test_enroll_already_enrolled_is_idempotent(self):
+        learner = UserFactory()
+        CourseEnrollmentFactory(user=learner, course_id=self.course.id, is_active=True)
+        self.client.force_authenticate(user=self.instructor)
+        response = self._enroll([learner.email])
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['results'][0]['after']['enrollment'] is True
+
+    def test_enroll_creates_audit_record(self):
+        learner = UserFactory()
+        self.client.force_authenticate(user=self.instructor)
+        response = self._enroll([learner.email], reason='Manual enrollment')
+        assert response.status_code == status.HTTP_200_OK
+
+        enrollment = CourseEnrollment.get_enrollment(learner, self.course.id)
+        audit = ManualEnrollmentAudit.objects.filter(enrollment=enrollment).first()
+        assert audit is not None
+        assert audit.reason == 'Manual enrollment'
+
+    def test_enroll_ambiguous_identifier_returns_error(self):
+        user_a = UserFactory(username='enroll_ambig@example.com')
+        UserFactory(email='enroll_ambig@example.com')
+        self.client.force_authenticate(user=self.instructor)
+        response = self._enroll([user_a.username])
+        assert response.status_code == status.HTTP_200_OK
+        result = response.data['results'][0]
+        assert result.get('error') is True
+
+    def test_enroll_auto_enroll_reflected_top_level(self):
+        learner = UserFactory()
+        self.client.force_authenticate(user=self.instructor)
+        response = self._enroll([learner.email], auto_enroll=True)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['auto_enroll'] is True
+
+    def test_enroll_mixed_success_and_failure(self):
+        learner = UserFactory()
+        self.client.force_authenticate(user=self.instructor)
+        response = self._enroll([learner.email, 'not-an-email'])
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data['results']
+        assert len(results) == 2
+        assert results[0]['identifier'] == learner.email
+        assert 'after' in results[0]
+        assert results[1]['identifier'] == 'not-an-email'
+        assert results[1].get('invalidIdentifier') is True
+
+    def test_unenroll_existing_user(self):
+        learner = UserFactory()
+        CourseEnrollmentFactory(user=learner, course_id=self.course.id, is_active=True)
+        self.client.force_authenticate(user=self.instructor)
+        response = self._unenroll([learner.email])
+        assert response.status_code == status.HTTP_200_OK
+        result = response.data['results'][0]
+        assert result['before']['enrollment'] is True
+        assert result['after']['enrollment'] is False
+        assert not CourseEnrollment.is_enrolled(learner, self.course.id)
+
+    def test_unenroll_not_enrolled_returns_200(self):
+        learner = UserFactory()
+        self.client.force_authenticate(user=self.instructor)
+        response = self._unenroll([learner.email])
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['results'][0]['after']['enrollment'] is False
+
+    def test_unenroll_creates_audit_record(self):
+        learner = UserFactory()
+        CourseEnrollmentFactory(user=learner, course_id=self.course.id, is_active=True)
+        self.client.force_authenticate(user=self.instructor)
+        response = self._unenroll([learner.email], reason='Manual unenrollment')
+        assert response.status_code == status.HTTP_200_OK
+
+        audits = ManualEnrollmentAudit.objects.filter(enrolled_email=learner.email)
+        assert audits.exists()
+
+    def test_staff_can_access(self):
+        staff = StaffFactory(course_key=self.course.id)
+        learner = UserFactory()
+        self.client.force_authenticate(user=staff)
+        response = self._enroll([learner.email])
+        assert response.status_code == status.HTTP_200_OK
+
+
+class BetaTesterModifyViewTest(SharedModuleStoreTestCase):
+    """Tests for the BetaTesterModifyView v2 bulk POST endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course = CourseFactory.create()
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.instructor = InstructorFactory(course_key=self.course.id)
+        self.url = reverse(
+            'instructor_api_v2:beta_tester_modify',
+            kwargs={'course_id': str(self.course.id)}
+        )
+
+    def _add(self, identifiers, **extra):
+        return self.client.post(
+            self.url,
+            {'identifier': identifiers, 'action': 'add', **extra},
+            format='json',
+        )
+
+    def _remove(self, identifiers, **extra):
+        return self.client.post(
+            self.url,
+            {'identifier': identifiers, 'action': 'remove', **extra},
+            format='json',
+        )
+
+    def test_unauthenticated_returns_401(self):
+        response = self._add(['test'])
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_student_returns_403(self):
+        self.client.force_authenticate(user=UserFactory())
+        response = self._add(['test'])
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_missing_fields_returns_400(self):
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(self.url, {}, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_invalid_action_returns_400(self):
+        self.client.force_authenticate(user=self.instructor)
+        response = self.client.post(
+            self.url,
+            {'identifier': ['someone'], 'action': 'bogus'},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_add_beta_tester(self):
+        learner = UserFactory()
+        self.client.force_authenticate(user=self.instructor)
+        response = self._add([learner.email])
+        assert response.status_code == status.HTTP_200_OK
+        result = response.data['results'][0]
+        assert result['identifier'] == learner.email
+        assert result['error'] is False
+        assert CourseBetaTesterRole(self.course.id).has_user(learner)
+
+    def test_add_beta_tester_with_auto_enroll(self):
+        learner = UserFactory()
+        self.client.force_authenticate(user=self.instructor)
+        response = self._add([learner.email], auto_enroll=True)
+        assert response.status_code == status.HTTP_200_OK
+        assert CourseEnrollment.is_enrolled(learner, self.course.id)
+
+    def test_add_beta_tester_auto_enroll_already_enrolled(self):
+        learner = UserFactory()
+        CourseEnrollmentFactory(user=learner, course_id=self.course.id, is_active=True)
+        self.client.force_authenticate(user=self.instructor)
+        response = self._add([learner.email], auto_enroll=True)
+        assert response.status_code == status.HTTP_200_OK
+        assert CourseEnrollment.objects.filter(user=learner, course_id=self.course.id).count() == 1
+
+    def test_add_nonexistent_user_returns_per_user_error(self):
+        self.client.force_authenticate(user=self.instructor)
+        response = self._add(['nobody@example.com'])
+        assert response.status_code == status.HTTP_200_OK
+        result = response.data['results'][0]
+        assert result['error'] is True
+        assert result['userDoesNotExist'] is True
+
+    def test_add_ambiguous_identifier_returns_per_user_error(self):
+        user_a = UserFactory(username='beta_ambig@example.com')
+        UserFactory(email='beta_ambig@example.com')
+        self.client.force_authenticate(user=self.instructor)
+        response = self._add([user_a.username])
+        assert response.status_code == status.HTTP_200_OK
+        result = response.data['results'][0]
+        assert result['error'] is True
+        assert result['userDoesNotExist'] is False
+
+    def test_remove_beta_tester(self):
+        learner = UserFactory()
+        CourseBetaTesterRole(self.course.id).add_users(learner)
+        self.client.force_authenticate(user=self.instructor)
+        response = self._remove([learner.email])
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['results'][0]['error'] is False
+        assert not CourseBetaTesterRole(self.course.id).has_user(learner)
+
+    def test_remove_nonexistent_user_returns_per_user_error(self):
+        self.client.force_authenticate(user=self.instructor)
+        response = self._remove(['nobody@example.com'])
+        assert response.status_code == status.HTTP_200_OK
+        result = response.data['results'][0]
+        assert result['error'] is True
+        assert result['userDoesNotExist'] is True
+
+    def test_add_mixed_success_and_failure(self):
+        learner = UserFactory()
+        self.client.force_authenticate(user=self.instructor)
+        response = self._add([learner.email, 'nobody@example.com'])
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data['results']
+        assert len(results) == 2
+        assert results[0]['error'] is False
+        assert results[1]['error'] is True

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -2414,7 +2414,7 @@ class EnrollmentModifyViewTest(SharedModuleStoreTestCase):
         response = self._enroll(['not-an-email'])
         assert response.status_code == status.HTTP_200_OK
         result = response.data['results'][0]
-        assert result.get('invalidIdentifier') is True
+        assert result.get('invalid_identifier') is True
         assert 'before' not in result
         assert 'after' not in result
 
@@ -2463,7 +2463,7 @@ class EnrollmentModifyViewTest(SharedModuleStoreTestCase):
         assert results[0]['identifier'] == learner.email
         assert 'after' in results[0]
         assert results[1]['identifier'] == 'not-an-email'
-        assert results[1].get('invalidIdentifier') is True
+        assert results[1].get('invalid_identifier') is True
 
     def test_unenroll_existing_user(self):
         learner = UserFactory()
@@ -2586,7 +2586,7 @@ class BetaTesterModifyViewTest(SharedModuleStoreTestCase):
         assert response.status_code == status.HTTP_200_OK
         result = response.data['results'][0]
         assert result['error'] is True
-        assert result['userDoesNotExist'] is True
+        assert result['user_does_not_exist'] is True
 
     def test_add_ambiguous_identifier_returns_per_user_error(self):
         user_a = UserFactory(username='beta_ambig@example.com')
@@ -2596,7 +2596,7 @@ class BetaTesterModifyViewTest(SharedModuleStoreTestCase):
         assert response.status_code == status.HTTP_200_OK
         result = response.data['results'][0]
         assert result['error'] is True
-        assert result['userDoesNotExist'] is False
+        assert result['user_does_not_exist'] is False
 
     def test_remove_beta_tester(self):
         learner = UserFactory()
@@ -2613,7 +2613,7 @@ class BetaTesterModifyViewTest(SharedModuleStoreTestCase):
         assert response.status_code == status.HTTP_200_OK
         result = response.data['results'][0]
         assert result['error'] is True
-        assert result['userDoesNotExist'] is True
+        assert result['user_does_not_exist'] is True
 
     def test_add_mixed_success_and_failure(self):
         learner = UserFactory()

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -111,6 +111,16 @@ v2_api_urls = [
         api_v2.GradingConfigView.as_view(),
         name='grading_config'
     ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/enrollments/modify$',
+        api_v2.EnrollmentModifyView.as_view(),
+        name='enrollment_modify'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/beta_testers/modify$',
+        api_v2.BetaTesterModifyView.as_view(),
+        name='beta_tester_modify'
+    ),
 ]
 
 urlpatterns = [

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -2147,7 +2147,7 @@ class EnrollmentModifyView(DeveloperErrorViewMixin, APIView):
         try:
             validate_email(email)
         except DjangoValidationError:
-            return {'identifier': identifier, 'invalidIdentifier': True}
+            return {'identifier': identifier, 'invalid_identifier': True}
 
         try:
             email_params = {}
@@ -2181,7 +2181,7 @@ class EnrollmentModifyView(DeveloperErrorViewMixin, APIView):
         try:
             validate_email(email)
         except DjangoValidationError:
-            return {'identifier': identifier, 'invalidIdentifier': True}
+            return {'identifier': identifier, 'invalid_identifier': True}
 
         try:
             email_params = {}
@@ -2321,7 +2321,7 @@ class BetaTesterModifyView(DeveloperErrorViewMixin, APIView):
         return {
             'identifier': identifier,
             'error': error,
-            'userDoesNotExist': user_does_not_exist,
+            'user_does_not_exist': user_does_not_exist,
             'is_active': user_active,
         }
 

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -17,6 +17,8 @@ from typing import Optional, Tuple  # noqa: UP035
 import edx_api_doc_tools as apidocs
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import validate_email
 from django.db import transaction
 from django.db.models import Q
 from django.urls import reverse
@@ -36,7 +38,18 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.models import (
+    ALLOWEDTOENROLL_TO_ENROLLED,
+    ALLOWEDTOENROLL_TO_UNENROLLED,
+    DEFAULT_TRANSITION_STATE,
+    ENROLLED_TO_ENROLLED,
+    ENROLLED_TO_UNENROLLED,
+    UNENROLLED_TO_ALLOWEDTOENROLL,
+    UNENROLLED_TO_ENROLLED,
+    UNENROLLED_TO_UNENROLLED,
+    CourseEnrollment,
+    ManualEnrollmentAudit,
+)
 from common.djangoapps.student.models.user import get_user_by_username_or_email
 from common.djangoapps.student.roles import CourseBetaTesterRole
 from common.djangoapps.util.json_request import JsonResponseBadRequest
@@ -52,7 +65,15 @@ from lms.djangoapps.course_home_api.toggles import course_home_mfe_progress_tab_
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.tabs import get_course_tab_list
 from lms.djangoapps.instructor import permissions
+from lms.djangoapps.instructor.access import allow_access, revoke_access
 from lms.djangoapps.instructor.constants import ReportType
+from lms.djangoapps.instructor.enrollment import (
+    enroll_email,
+    get_email_params,
+    get_user_email_language,
+    send_beta_role_email,
+    unenroll_email,
+)
 from lms.djangoapps.instructor.ora import get_open_response_assessment_list, get_ora_summary
 from lms.djangoapps.instructor.views.api import _display_unit, get_student_from_identifier
 from lms.djangoapps.instructor.views.instructor_task_helpers import extract_task_features
@@ -72,10 +93,14 @@ from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from .filters_v2 import CourseEnrollmentFilter
 from .serializers_v2 import (
+    BetaTesterModifyRequestSerializerV2,
+    BetaTesterModifyResponseSerializerV2,
     BlockDueDateSerializerV2,
     CertificateGenerationHistorySerializer,
     CourseEnrollmentSerializerV2,
     CourseInformationSerializerV2,
+    EnrollmentModifyRequestSerializerV2,
+    EnrollmentModifyResponseSerializerV2,
     GradingConfigSerializer,
     InstructorTaskListSerializer,
     IssuedCertificateSerializer,
@@ -90,6 +115,7 @@ from .serializers_v2 import (
 from .tools import find_unit, get_units_with_due_date, keep_field_private, set_due_date_extension, title_or_url
 
 log = logging.getLogger(__name__)
+User = get_user_model()
 
 
 class CourseMetadataView(DeveloperErrorViewMixin, APIView):
@@ -2032,3 +2058,306 @@ class GradingConfigView(DeveloperErrorViewMixin, APIView):
         }
         serializer = GradingConfigSerializer(config_data)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class EnrollmentModifyView(DeveloperErrorViewMixin, APIView):
+    """
+    Enroll or unenroll one or more learners in a course.
+
+    **Example Request**
+
+        POST /api/instructor/v2/courses/{course_id}/enrollments/modify
+
+    **Parameters**
+
+        * identifier (required): List of emails or usernames of learners
+        * action (required): 'enroll' or 'unenroll'
+        * auto_enroll (optional): Auto-enroll in verified track (enroll action; default: false)
+        * email_students (optional): Send email notification (default: false)
+        * reason (optional): Reason for the change
+
+    **Response Values**
+
+        {
+            "action": "enroll",
+            "results": [
+                {
+                    "identifier": "learner@example.com",
+                    "success": true,
+                    "user_is_registered": true,
+                    "enrollment": true,
+                    "allowed": false,
+                    "auto_enroll": false
+                },
+                {
+                    "identifier": "bad@",
+                    "success": false,
+                    "error": "Invalid email address: bad@"
+                }
+            ]
+        }
+
+    **Returns**
+
+        * 200: OK - Per-identifier results returned (successes and failures)
+        * 400: Bad Request - Invalid top-level parameters
+        * 401: Unauthorized - User is not authenticated
+        * 403: Forbidden - User lacks staff permissions
+    """
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.CAN_ENROLL
+
+    def _compute_enroll_state_transition(self, before, after):
+        """Compute the state transition constant for an enroll action."""
+        if before.user:
+            if after.enrollment:
+                if before.enrollment:
+                    return ENROLLED_TO_ENROLLED
+                if before.allowed:
+                    return ALLOWEDTOENROLL_TO_ENROLLED
+                return UNENROLLED_TO_ENROLLED
+        if after.allowed:
+            return UNENROLLED_TO_ALLOWEDTOENROLL
+        return DEFAULT_TRANSITION_STATE
+
+    def _compute_unenroll_state_transition(self, before):
+        """Compute the state transition constant for an unenroll action."""
+        if before.enrollment:
+            return ENROLLED_TO_UNENROLLED
+        if before.allowed:
+            return ALLOWEDTOENROLL_TO_UNENROLLED
+        return UNENROLLED_TO_UNENROLLED
+
+    def _resolve_identifier(self, identifier):
+        """Resolve identifier to (user, email, language); returns (None, identifier, None) if user not found."""
+        try:
+            user = get_student_from_identifier(identifier)
+            return user, user.email, get_user_email_language(user)
+        except User.DoesNotExist:
+            return None, identifier, None
+
+    def _enroll_one(self, course_key, course, identifier, auto_enroll, email_students, reason, request_user, is_secure):
+        """Enroll a single identifier. Returns a v1-shaped result dict."""
+        try:
+            identified_user, email, language = self._resolve_identifier(identifier)
+        except User.MultipleObjectsReturned:
+            log.exception("Ambiguous identifier while enrolling: %s", identifier)
+            return {'identifier': identifier, 'error': True}
+
+        try:
+            validate_email(email)
+        except DjangoValidationError:
+            return {'identifier': identifier, 'invalidIdentifier': True}
+
+        try:
+            email_params = {}
+            if email_students:
+                email_params = get_email_params(course, auto_enroll, secure=is_secure)
+
+            before, after, enrollment_obj = enroll_email(
+                course_key, email, auto_enroll, email_students, email_params, language=language
+            )
+            ManualEnrollmentAudit.create_manual_enrollment_audit(
+                request_user, email, self._compute_enroll_state_transition(before, after), reason, enrollment_obj
+            )
+        except Exception:  # pylint: disable=broad-except
+            log.exception("Error while enrolling student")
+            return {'identifier': identifier, 'error': True}
+
+        return {
+            'identifier': identifier,
+            'before': before.to_dict(),
+            'after': after.to_dict(),
+        }
+
+    def _unenroll_one(self, course_key, course, identifier, email_students, reason, request_user, is_secure):
+        """Unenroll a single identifier. Returns a v1-shaped result dict."""
+        try:
+            identified_user, email, language = self._resolve_identifier(identifier)
+        except User.MultipleObjectsReturned:
+            log.exception("Ambiguous identifier while unenrolling: %s", identifier)
+            return {'identifier': identifier, 'error': True}
+
+        try:
+            validate_email(email)
+        except DjangoValidationError:
+            return {'identifier': identifier, 'invalidIdentifier': True}
+
+        try:
+            email_params = {}
+            if email_students:
+                email_params = get_email_params(course, False, secure=is_secure)
+
+            before, after = unenroll_email(
+                course_key, email, email_students, email_params, language=language
+            )
+            enrollment_obj = (
+                CourseEnrollment.get_enrollment(identified_user, course_key)
+                if identified_user else None
+            )
+            ManualEnrollmentAudit.create_manual_enrollment_audit(
+                request_user, email, self._compute_unenroll_state_transition(before), reason, enrollment_obj
+            )
+        except Exception:  # pylint: disable=broad-except
+            log.exception("Error while unenrolling student")
+            return {'identifier': identifier, 'error': True}
+
+        return {
+            'identifier': identifier,
+            'before': before.to_dict(),
+            'after': after.to_dict(),
+        }
+
+    @apidocs.schema(
+        body=EnrollmentModifyRequestSerializerV2,
+        responses={
+            200: EnrollmentModifyResponseSerializerV2,
+            400: "Invalid parameters",
+            403: "User does not have permission",
+        },
+    )
+    def post(self, request, course_id):
+        """
+        Enroll or unenroll one or more learners in the course.
+        """
+        course_key = CourseKey.from_string(course_id)
+
+        serializer = EnrollmentModifyRequestSerializerV2(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        identifiers = serializer.validated_data['identifier']
+        action = serializer.validated_data['action']
+        auto_enroll = serializer.validated_data['auto_enroll']
+        email_students = serializer.validated_data['email_students']
+        reason = serializer.validated_data.get('reason', '')
+
+        course = get_course_by_id(course_key) if email_students else None
+        is_secure = request.is_secure()
+
+        results = []
+        for identifier in identifiers:
+            if action == 'enroll':
+                results.append(self._enroll_one(
+                    course_key, course, identifier, auto_enroll, email_students, reason, request.user, is_secure
+                ))
+            else:
+                results.append(self._unenroll_one(
+                    course_key, course, identifier, email_students, reason, request.user, is_secure
+                ))
+
+        response_serializer = EnrollmentModifyResponseSerializerV2({
+            'action': action,
+            'auto_enroll': auto_enroll,
+            'results': results,
+        })
+        return Response(response_serializer.data)
+
+
+@method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True), name='dispatch')
+class BetaTesterModifyView(DeveloperErrorViewMixin, APIView):
+    """
+    Add or remove one or more beta testers for a course.
+
+    **Example Request**
+
+        POST /api/instructor/v2/courses/{course_id}/beta_testers/modify
+
+    **Parameters**
+
+        * identifier (required): List of emails or usernames of learners
+        * action (required): 'add' or 'remove'
+        * email_students (optional): Send email notification (default: false)
+        * auto_enroll (optional): Auto-enroll in the course (add action; default: false)
+
+    **Response Values**
+
+        {
+            "action": "add",
+            "results": [
+                {"identifier": "learner@example.com", "success": true, "is_active": true},
+                {"identifier": "missing", "success": false, "error": "User not found: missing"}
+            ]
+        }
+
+    **Returns**
+
+        * 200: OK - Per-identifier results returned (successes and failures)
+        * 400: Bad Request - Invalid top-level parameters
+        * 401: Unauthorized - User is not authenticated
+        * 403: Forbidden - User lacks instructor permissions
+    """
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.CAN_BETATEST
+
+    def _modify_one(self, action, course, course_key, identifier, email_students, auto_enroll, is_secure):
+        """Add or remove a single identifier as a beta tester. Returns a v1-shaped result dict."""
+        error = False
+        user_does_not_exist = False
+        user_active = None
+        try:
+            user = get_student_from_identifier(identifier)
+            user_active = user.is_active
+            if action == 'add':
+                allow_access(course, user, 'beta')
+            else:
+                revoke_access(course, user, 'beta')
+        except User.DoesNotExist:
+            error = True
+            user_does_not_exist = True
+        except User.MultipleObjectsReturned:
+            log.exception("Ambiguous identifier for beta tester action: %s", identifier)
+            error = True
+        except Exception:  # pylint: disable=broad-except
+            log.exception("Error while modifying beta tester")
+            error = True
+        else:
+            if email_students:
+                email_params = get_email_params(course, False, secure=is_secure)
+                send_beta_role_email(action, user, email_params)
+            if auto_enroll and action == 'add' and not CourseEnrollment.is_enrolled(user, course_key):
+                CourseEnrollment.enroll(user, course_key)
+
+        return {
+            'identifier': identifier,
+            'error': error,
+            'userDoesNotExist': user_does_not_exist,
+            'is_active': user_active,
+        }
+
+    @apidocs.schema(
+        body=BetaTesterModifyRequestSerializerV2,
+        responses={
+            200: BetaTesterModifyResponseSerializerV2,
+            400: "Invalid parameters",
+            403: "User does not have permission",
+        },
+    )
+    def post(self, request, course_id):
+        """
+        Add or remove one or more beta testers for the course.
+        """
+        course_key = CourseKey.from_string(course_id)
+
+        serializer = BetaTesterModifyRequestSerializerV2(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        identifiers = serializer.validated_data['identifier']
+        action = serializer.validated_data['action']
+        email_students = serializer.validated_data['email_students']
+        auto_enroll = serializer.validated_data['auto_enroll']
+
+        course = get_course_by_id(course_key)
+        is_secure = request.is_secure()
+
+        results = [
+            self._modify_one(action, course, course_key, identifier, email_students, auto_enroll, is_secure)
+            for identifier in identifiers
+        ]
+
+        response_serializer = BetaTesterModifyResponseSerializerV2({
+            'action': action,
+            'results': results,
+        })
+        return Response(response_serializer.data)

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -861,3 +861,89 @@ class TaskStatusSerializer(serializers.Serializer):
     updated_at = serializers.DateTimeField(
         help_text="Last update timestamp"
     )
+
+
+class EnrollmentModifyRequestSerializerV2(serializers.Serializer):
+    """Validates request body for enrolling/unenrolling one or more learners."""
+    identifier = serializers.ListField(
+        child=serializers.CharField(max_length=255, allow_blank=False),
+        allow_empty=False,
+        help_text="List of email addresses or usernames of learners to enroll/unenroll.",
+    )
+    action = serializers.ChoiceField(
+        choices=('enroll', 'unenroll'),
+        help_text="The enrollment action to perform: 'enroll' or 'unenroll'.",
+    )
+    auto_enroll = serializers.BooleanField(
+        default=False,
+        help_text="Whether to auto-enroll in the verified track (enroll action only).",
+    )
+    email_students = serializers.BooleanField(
+        default=False,
+        help_text="Whether to send an email notification.",
+    )
+    reason = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default='',
+        help_text="Reason for the change (for audit trail).",
+    )
+
+
+class EnrollmentStateSerializerV2(serializers.Serializer):
+    """Documents the before/after enrollment state shape (mirrors EmailEnrollmentState.to_dict)."""
+    user = serializers.BooleanField()
+    enrollment = serializers.BooleanField()
+    allowed = serializers.BooleanField()
+    auto_enroll = serializers.BooleanField()
+
+
+class EnrollmentModifyResultSerializerV2(serializers.Serializer):
+    """Documents the per-identifier result shape for enrollment modifications (mirrors v1)."""
+    identifier = serializers.CharField()
+    before = EnrollmentStateSerializerV2(required=False)
+    after = EnrollmentStateSerializerV2(required=False)
+    invalidIdentifier = serializers.BooleanField(required=False)
+    error = serializers.BooleanField(required=False)
+
+
+class EnrollmentModifyResponseSerializerV2(serializers.Serializer):
+    """Documents the response shape for the bulk enroll/unenroll endpoint (mirrors v1)."""
+    action = serializers.CharField()
+    auto_enroll = serializers.BooleanField()
+    results = EnrollmentModifyResultSerializerV2(many=True)
+
+
+class BetaTesterModifyRequestSerializerV2(serializers.Serializer):
+    """Validates request body for adding/removing one or more beta testers."""
+    identifier = serializers.ListField(
+        child=serializers.CharField(max_length=255, allow_blank=False),
+        allow_empty=False,
+        help_text="List of email addresses or usernames of learners to add/remove as beta testers.",
+    )
+    action = serializers.ChoiceField(
+        choices=('add', 'remove'),
+        help_text="The beta tester action to perform: 'add' or 'remove'.",
+    )
+    email_students = serializers.BooleanField(
+        default=False,
+        help_text="Whether to send an email notification.",
+    )
+    auto_enroll = serializers.BooleanField(
+        default=False,
+        help_text="Whether to auto-enroll the user in the course (add action only).",
+    )
+
+
+class BetaTesterModifyResultSerializerV2(serializers.Serializer):
+    """Documents the per-identifier result shape for beta tester modifications (mirrors v1)."""
+    identifier = serializers.CharField()
+    error = serializers.BooleanField()
+    userDoesNotExist = serializers.BooleanField()
+    is_active = serializers.BooleanField(allow_null=True)
+
+
+class BetaTesterModifyResponseSerializerV2(serializers.Serializer):
+    """Documents the response shape for the bulk beta tester add/remove endpoint (mirrors v1)."""
+    action = serializers.CharField()
+    results = BetaTesterModifyResultSerializerV2(many=True)

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -903,7 +903,7 @@ class EnrollmentModifyResultSerializerV2(serializers.Serializer):
     identifier = serializers.CharField()
     before = EnrollmentStateSerializerV2(required=False)
     after = EnrollmentStateSerializerV2(required=False)
-    invalidIdentifier = serializers.BooleanField(required=False)
+    invalid_identifier = serializers.BooleanField(required=False)
     error = serializers.BooleanField(required=False)
 
 
@@ -939,7 +939,7 @@ class BetaTesterModifyResultSerializerV2(serializers.Serializer):
     """Documents the per-identifier result shape for beta tester modifications (mirrors v1)."""
     identifier = serializers.CharField()
     error = serializers.BooleanField()
-    userDoesNotExist = serializers.BooleanField()
+    user_does_not_exist = serializers.BooleanField()
     is_active = serializers.BooleanField(allow_null=True)
 
 


### PR DESCRIPTION
## Description

Adds two new v2 instructor API endpoints to support the **Enrollments Actions** tab in the Instructor Dashboard MFE, along with updated API spec documentation.

These endpoints provide structured JSON responses for MFE consumption, enabling bulk enroll/unenroll and beta tester management operations.

### New Endpoints

**1. `POST /api/instructor/v2/courses/{course_id}/enrollments/modify`**

Enroll or unenroll one or more learners in a course by email or username.

- Permission: `CAN_ENROLL` (course staff, instructors)
- Accepts `identifier` (list of emails/usernames), `action` (`enroll` or `unenroll`), `auto_enroll`, `email_students`, and `reason`
- Returns per-identifier `before`/`after` enrollment state (`user`, `enrollment`, `allowed`, `auto_enroll`)
- Invalid identifiers return `invalidIdentifier: true`; errors return `error: true`
- Creates `ManualEnrollmentAudit` records for traceability

```json
{
    "action": "enroll",
    "auto_enroll": false,
    "results": [
        {
            "identifier": "learner@example.com",
            "before": {"user": true, "enrollment": false, "allowed": false, "auto_enroll": false},
            "after": {"user": true, "enrollment": true, "allowed": false, "auto_enroll": false}
        },
        {
            "identifier": "not-an-email",
            "invalidIdentifier": true
        }
    ]
}
```

**2. `POST /api/instructor/v2/courses/{course_id}/beta_testers/modify`**

Add or remove one or more beta testers for a course.

- Permission: `CAN_BETATEST` (course staff, instructors)
- Accepts `identifier` (list of emails/usernames), `action` (`add` or `remove`), `email_students`, and `auto_enroll`
- Returns per-identifier results with `error` (bool) and `userDoesNotExist` (bool) fields
- Optionally auto-enrolls users when adding as beta testers

```json
{
    "action": "add",
    "results": [
        {"identifier": "learner@example.com", "error": false, "userDoesNotExist": false, "is_active": true},
        {"identifier": "nobody@example.com", "error": true, "userDoesNotExist": true, "is_active": null}
    ]
}
```

### Other Changes

- Updated `enrollment-v2-api-spec.yaml` to match the actual implemented API surface
- Removed the `EnrollmentStatusView` endpoint (the existing v1 `get_student_enrollment_status` is sufficient)
- Removed the `ChangeEnrollmentModeView` endpoint (mode changes will be handled through a different workflow)

### Impacted Roles
- **Course Staff / Instructors**: New API endpoints for enrollment and beta tester management
- **Developers**: New v2 API surface for MFE integration

## Supporting information

- Closes: [Enrollments API - Actions #37537](https://github.com/openedx/openedx-platform/issues/37537)

## Testing instructions

1. **Enroll learners**:
   - As course staff, POST `/api/instructor/v2/courses/{course_id}/enrollments/modify` with `{"identifier": ["learner@example.com"], "action": "enroll"}`
   - Verify `before`/`after` state shows enrollment change
   - Verify `ManualEnrollmentAudit` record is created
   - Test with non-existent email to verify `CourseEnrollmentAllowed` is created
   - Test with invalid identifier (e.g. `"not-an-email"`) to verify `invalidIdentifier: true`

2. **Unenroll learners**:
   - POST with `"action": "unenroll"` for an enrolled learner
   - Verify `before.enrollment` is `true` and `after.enrollment` is `false`

3. **Add beta testers**:
   - POST `/api/instructor/v2/courses/{course_id}/beta_testers/modify` with `{"identifier": ["learner@example.com"], "action": "add"}`
   - Verify learner is added to beta tester role
   - Test with `auto_enroll: true` to verify auto-enrollment
   - Test with non-existent user to verify per-user error response

4. **Remove beta testers**:
   - POST with `"action": "remove"` for an existing beta tester
   - Verify beta tester role is revoked

## Deadline

None

## Other information

- No database migrations required
- No breaking changes to existing endpoints
- All operations are synchronous
