### PR TITLE
feat: add data migration to sync DiscussionsConfiguration with modulestore tab.is_hidden

### DIFF
--- a/openedx/core/djangoapps/discussions/handlers.py
+++ b/openedx/core/djangoapps/discussions/handlers.py
@@ -8,6 +8,7 @@ from django.db import transaction
 from openedx_events.learning.data import CourseDiscussionConfigurationData
 from openedx_events.learning.signals import COURSE_DISCUSSIONS_CHANGED
 
+from openedx.core.djangoapps.course_apps.models import CourseAppStatus
 from openedx.core.djangoapps.discussions.models import (
     DiscussionsConfiguration,
     DiscussionTopicLink,
@@ -107,6 +108,15 @@ def update_course_discussion_config(configuration: CourseDiscussionConfiguration
             DiscussionsConfiguration.objects.filter(
                 context_key=course_key,
             ).update(enabled=configuration.enabled)
+
+        # Also update CourseAppStatus to keep the Pages & Resources UI in sync.
+        # The update_course_apps_status task may run before this handler due to
+        # the COURSE_PUBLISH_TASK_DELAY countdown, caching a stale enabled value.
+        CourseAppStatus.update_status_for_course_app(
+            course_key=course_key,
+            app_id="discussion",
+            enabled=configuration.enabled,
+        )
 
 
 COURSE_DISCUSSIONS_CHANGED.connect(handle_course_discussion_config_update)

--- a/openedx/core/djangoapps/discussions/migrations/0019_sync_discussion_config_enabled_with_tab.py
+++ b/openedx/core/djangoapps/discussions/migrations/0019_sync_discussion_config_enabled_with_tab.py
@@ -1,15 +1,15 @@
 """
-Sync DiscussionsConfiguration.enabled and CourseAppStatus.enabled with
-CourseOverviewTab.is_hidden.
+Backfill DiscussionsConfiguration.enabled and CourseAppStatus.enabled for
+existing courses to match CourseOverviewTab.is_hidden.
 
 When a course is imported, the discussion tab's is_hidden value is carried over
 from the source course. However, DiscussionsConfiguration.enabled and
 CourseAppStatus.enabled default to True and are not updated from the imported
 tab state, causing a desync.
 
-This migration reads each discussion tab from CourseOverviewTab (a DB cache of
-course tabs) and sets both DiscussionsConfiguration.enabled and
-CourseAppStatus.enabled to NOT is_hidden.
+This is a one-time backfill for existing courses. Going forward, the
+update_course_discussion_config handler keeps these values in sync on every
+course publish.
 """
 
 from django.db import migrations

--- a/openedx/core/djangoapps/discussions/migrations/0019_sync_discussion_config_enabled_with_tab.py
+++ b/openedx/core/djangoapps/discussions/migrations/0019_sync_discussion_config_enabled_with_tab.py
@@ -1,0 +1,51 @@
+"""
+Sync DiscussionsConfiguration.enabled and CourseAppStatus.enabled with
+CourseOverviewTab.is_hidden.
+
+When a course is imported, the discussion tab's is_hidden value is carried over
+from the source course. However, DiscussionsConfiguration.enabled and
+CourseAppStatus.enabled default to True and are not updated from the imported
+tab state, causing a desync.
+
+This migration reads each discussion tab from CourseOverviewTab (a DB cache of
+course tabs) and sets both DiscussionsConfiguration.enabled and
+CourseAppStatus.enabled to NOT is_hidden.
+"""
+
+from django.db import migrations
+
+
+def sync_enabled_from_course_overview_tab(apps, schema_editor):
+    CourseOverviewTab = apps.get_model("course_overviews", "CourseOverviewTab")
+    DiscussionsConfiguration = apps.get_model("discussions", "DiscussionsConfiguration")
+    CourseAppStatus = apps.get_model("course_apps", "CourseAppStatus")
+
+    discussion_tabs = CourseOverviewTab.objects.filter(tab_id="discussion").select_related("course_overview")
+
+    for tab in discussion_tabs.iterator():
+        course_key = tab.course_overview_id
+        expected_enabled = not tab.is_hidden
+        DiscussionsConfiguration.objects.filter(
+            context_key=course_key,
+        ).exclude(
+            enabled=expected_enabled,
+        ).update(enabled=expected_enabled)
+        CourseAppStatus.objects.filter(
+            course_key=course_key,
+            app_id="discussion",
+        ).exclude(
+            enabled=expected_enabled,
+        ).update(enabled=expected_enabled)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("discussions", "0018_auto_20230904_1054"),
+        ("course_overviews", "0030_backfill_new_catalog_courseruns"),
+        ("course_apps", "0002_alter_historicalcourseappstatus_options"),
+    ]
+
+    operations = [
+        migrations.RunPython(sync_enabled_from_course_overview_tab, migrations.RunPython.noop),
+    ]

--- a/openedx/core/djangoapps/discussions/tests/test_handlers.py
+++ b/openedx/core/djangoapps/discussions/tests/test_handlers.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 from openedx_events.learning.data import CourseDiscussionConfigurationData, DiscussionTopicContext
 
+from openedx.core.djangoapps.course_apps.models import CourseAppStatus
 from openedx.core.djangoapps.discussions.handlers import update_course_discussion_config
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, DiscussionTopicLink
 
@@ -222,3 +223,39 @@ class UpdateCourseDiscussionsConfigTestCase(TestCase):
         update_course_discussion_config(config_data)
         db_config = DiscussionsConfiguration.objects.get(context_key=self.course_key)
         assert db_config.enabled is False
+
+    def test_course_app_status_created_for_new_course(self):
+        """
+        When no CourseAppStatus row exists yet (new course), the handler should
+        create one with the correct enabled value.
+        """
+        new_key = CourseKey.from_string("course-v1:test+test+new_app_status")
+        assert not CourseAppStatus.objects.filter(course_key=new_key, app_id="discussion").exists()
+        config_data = CourseDiscussionConfigurationData(
+            course_key=new_key,
+            provider_type="openedx",
+            enabled=False,
+            plugin_configuration={},
+        )
+        update_course_discussion_config(config_data)
+        app_status = CourseAppStatus.objects.get(course_key=new_key, app_id="discussion")
+        assert app_status.enabled is False
+
+    def test_course_app_status_updated_for_existing_course(self):
+        """
+        When a CourseAppStatus row already exists (old course), the handler
+        should update it with the correct enabled value.
+        """
+        CourseAppStatus.objects.create(
+            course_key=self.course_key,
+            app_id="discussion",
+            enabled=True,
+        )
+        config_data = CourseDiscussionConfigurationData(
+            course_key=self.course_key,
+            provider_type="openedx",
+            enabled=False,
+        )
+        update_course_discussion_config(config_data)
+        app_status = CourseAppStatus.objects.get(course_key=self.course_key, app_id="discussion")
+        assert app_status.enabled is False


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

We introduced a fix in https://github.com/openedx/openedx-platform/pull/38084 to synchronize DiscussionsConfiguration.enabled (DB) with tab.is_hidden (modulestore) during course imports. While this resolves the issue for newly imported courses, existing courses that are currently out of sync still need to be updated so that course authors see the correct values.

This PR adds a data migration that reads each course's discussion tab from `CourseOverviewTab` (a DB-level cache of modulestore tabs) and updates both `DiscussionsConfiguration.enabled` and `CourseAppStatus.enabled` to match (`enabled = NOT is_hidden`). Only out-of-sync rows are updated. The migration uses `CourseOverviewTab` instead of the modulestore directly to avoid performance issues at scale.

Useful information to include:

- Which edX user roles will this change impact? Course Author"
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

https://github.com/openedx/openedx-platform/pull/38084#issuecomment-4194310589

## Testing instructions

1. Rollback 0019 if already applied:

```
python manage.py migrate discussions 0018
```

2. Create unsynced data in the shell:

```python
from openedx.core.djangoapps.content.course_overviews.models import CourseOverview, CourseOverviewTab
from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
from openedx.core.djangoapps.course_apps.models import CourseAppStatus
from opaque_keys.edx.keys import CourseKey

course_key = CourseKey.from_string("course-v1:U0X12+CS11013+UAI_22")

overview, _ = CourseOverview.objects.get_or_create(id=course_key, defaults={"version": 1})

tab, _ = CourseOverviewTab.objects.update_or_create(
    course_overview=overview,
    tab_id="discussion",
    defaults={"is_hidden": True},
)

config, _ = DiscussionsConfiguration.objects.update_or_create(
    context_key=course_key,
    defaults={"enabled": True},
)

app_status, _ = CourseAppStatus.objects.update_or_create(
    course_key=course_key,
    app_id="discussion",
    defaults={"enabled": True},
)

# Verify the desync
print(f"Tab is_hidden: {tab.is_hidden}")            # True
print(f"Config enabled: {config.enabled}")           # True  (should be False)
print(f"AppStatus enabled: {app_status.enabled}")    # True  (should be False)
```

3. Visit the `Pages and Resources` page in the authoring MFE and verify that the discussion configuration is unsynced

4. Run the migration:

```
python manage.py migrate discussions 0019
```

5. Verify the fix:

```python
from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
from opaque_keys.edx.keys import CourseKey

6. Repeat step 3 and verify that the configuration is now synced

config = DiscussionsConfiguration.objects.get(context_key=CourseKey.from_string("course-v1:TestOrg+Test101+2026"))
print(f"Config enabled: {config.enabled}")  # Should now be False
```
## Deadline

"None"

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
