### PR TITLE
Feature/37905 instructor dashboard grading post endpoints

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_api_v2.py
@@ -1,13 +1,16 @@
 """
-Tests for Instructor API v2 GET endpoints.
+Tests for Instructor API v2 endpoints.
 """
 import json
+from textwrap import dedent
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, InstructorFactory, UserFactory
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.instructor_task.models import InstructorTask
@@ -382,33 +385,39 @@ class GradingConfigViewTestCase(ModuleStoreTestCase):
         self.client.force_authenticate(user=self.instructor)
 
     def test_get_grading_config(self):
-        """Test retrieving grading configuration returns graders and grade cutoffs"""
+        """Test retrieving grading configuration returns HTML summary from dump_grading_context"""
         url = reverse('instructor_api_v2:grading_config', kwargs={
             'course_id': str(self.course.id),
         })
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
-        data = response.json()
-        self.assertIn('graders', data)  # noqa: PT009
-        self.assertIn('grade_cutoffs', data)  # noqa: PT009
-        self.assertIsInstance(data['graders'], list)  # noqa: PT009
-        self.assertIsInstance(data['grade_cutoffs'], dict)  # noqa: PT009
+        self.assertEqual(response['Content-Type'], 'text/html')  # noqa: PT009
 
-    def test_get_grading_config_grader_fields(self):
-        """Test that each grader entry has the expected fields"""
-        url = reverse('instructor_api_v2:grading_config', kwargs={
-            'course_id': str(self.course.id),
-        })
-        response = self.client.get(url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
-        data = response.json()
-        for grader in data['graders']:
-            self.assertIn('type', grader)  # noqa: PT009
-            self.assertIn('min_count', grader)  # noqa: PT009
-            self.assertIn('drop_count', grader)  # noqa: PT009
-            self.assertIn('weight', grader)  # noqa: PT009
+        hbar = '-' * 77
+        expected_html = (
+            f'<pre>{hbar}\n'
+            'Course grader:\n'
+            '&lt;class &#39;xmodule.graders.WeightedSubsectionsGrader&#39;&gt;\n'
+            '\n'
+            'Graded sections:\n'
+            '  subgrader=&lt;class &#39;xmodule.graders.AssignmentFormatGrader&#39;&gt;,'
+            ' type=Homework, category=Homework, weight=0.15\n'
+            '  subgrader=&lt;class &#39;xmodule.graders.AssignmentFormatGrader&#39;&gt;,'
+            ' type=Lab, category=Lab, weight=0.15\n'
+            '  subgrader=&lt;class &#39;xmodule.graders.AssignmentFormatGrader&#39;&gt;,'
+            ' type=Midterm Exam, category=Midterm Exam, weight=0.3\n'
+            '  subgrader=&lt;class &#39;xmodule.graders.AssignmentFormatGrader&#39;&gt;,'
+            ' type=Final Exam, category=Final Exam, weight=0.4\n'
+            f'{hbar}\n'
+            f'Listing grading context for course {self.course.id}\n'
+            'graded sections:\n'
+            '[]\n'
+            'all graded blocks:\n'
+            'length=0\n'
+            '</pre>'
+        )
+        self.assertEqual(response.content.decode(), expected_html)  # noqa: PT009
 
     def test_get_grading_config_requires_authentication(self):
         """Test that endpoint requires authentication"""
@@ -420,3 +429,266 @@ class GradingConfigViewTestCase(ModuleStoreTestCase):
         response = self.client.get(url)
 
         self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])  # noqa: PT009
+
+
+class GradingEndpointTestBase(ModuleStoreTestCase):
+    """
+    Base test class for grading endpoints with real course structures,
+    real permissions, and real StudentModule records.
+    """
+
+    PROBLEM_XML = dedent("""\
+        <problem>
+          <optionresponse>
+            <optioninput options="('Option 1','Option 2')" correct="Option 1" />
+          </optionresponse>
+        </problem>
+    """)
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.course = CourseFactory.create(display_name='Test Course')
+        self.chapter = BlockFactory.create(
+            parent=self.course,
+            category='chapter',
+            display_name='Week 1'
+        )
+        self.sequential = BlockFactory.create(
+            parent=self.chapter,
+            category='sequential',
+            display_name='Homework 1'
+        )
+        self.problem = BlockFactory.create(
+            parent=self.sequential,
+            category='problem',
+            display_name='Test Problem',
+            data=self.PROBLEM_XML,
+        )
+
+        # Real instructor with real course permissions
+        self.instructor = InstructorFactory(course_key=self.course.id)
+        self.client.force_authenticate(user=self.instructor)
+
+        # Real enrolled student with real module state
+        self.student = UserFactory(username='test_student', email='student@example.com')
+        CourseEnrollment.enroll(self.student, self.course.id)
+        self.student_module = StudentModule.objects.create(
+            student=self.student,
+            course_id=self.course.id,
+            module_state_key=self.problem.location,
+            state=json.dumps({'attempts': 10}),
+        )
+
+
+class ResetAttemptsViewTestCase(GradingEndpointTestBase):
+    """
+    Tests for POST /api/instructor/v2/courses/{course_key}/{problem}/grading/attempts/reset
+    """
+
+    def _get_url(self, problem=None):
+        return reverse('instructor_api_v2:reset_attempts', kwargs={
+            'course_id': str(self.course.id),
+            'problem': problem or str(self.problem.location),
+        })
+
+    def test_reset_single_learner(self):
+        """Single learner reset zeroes attempt count and returns 200."""
+        response = self.client.post(self._get_url() + '?learner=test_student')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['success'] is True
+        assert data['learner'] == 'test_student'
+        assert data['message'] == 'Attempts reset successfully'
+
+        # Verify the actual StudentModule was modified
+        self.student_module.refresh_from_db()
+        assert json.loads(self.student_module.state)['attempts'] == 0
+
+    @patch('lms.djangoapps.instructor_task.tasks.reset_problem_attempts.apply_async')
+    def test_reset_all_learners(self, mock_apply):
+        """Bulk reset queues a background task and returns 202."""
+        response = self.client.post(self._get_url())
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        data = response.json()
+        assert 'task_id' in data
+        assert 'status_url' in data
+        assert data['scope']['learners'] == 'all'
+        mock_apply.assert_called_once()
+
+
+class DeleteStateViewTestCase(GradingEndpointTestBase):
+    """
+    Tests for DELETE /api/instructor/v2/courses/{course_key}/{problem}/grading/state
+    """
+
+    def _get_url(self, problem=None):
+        return reverse('instructor_api_v2:delete_state', kwargs={
+            'course_id': str(self.course.id),
+            'problem': problem or str(self.problem.location),
+        })
+
+    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send')
+    def test_delete_state(self, _mock_signal):  # noqa: PT019
+        """Delete state removes the StudentModule record and returns 200."""
+        response = self.client.delete(self._get_url() + '?learner=test_student')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['success'] is True
+        assert data['learner'] == 'test_student'
+        assert data['message'] == 'State deleted successfully'
+
+        # Verify the StudentModule was actually deleted
+        assert not StudentModule.objects.filter(pk=self.student_module.pk).exists()
+
+    def test_delete_state_requires_learner_param(self):
+        """DELETE without learner query param returns 400."""
+        response = self.client.delete(self._get_url())
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send')
+    def test_delete_state_learner_in_body(self, _mock_signal):  # noqa: PT019
+        """DELETE with learner in request body (form data) also works."""
+        response = self.client.delete(self._get_url(), data={'learner': 'test_student'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['success'] is True
+
+
+class RescoreViewTestCase(GradingEndpointTestBase):
+    """
+    Tests for POST /api/instructor/v2/courses/{course_key}/{problem}/grading/scores/rescore
+    """
+
+    def _get_url(self, problem=None):
+        return reverse('instructor_api_v2:rescore', kwargs={
+            'course_id': str(self.course.id),
+            'problem': problem or str(self.problem.location),
+        })
+
+    @patch('lms.djangoapps.instructor_task.tasks.rescore_problem.apply_async')
+    def test_rescore_single_learner(self, mock_apply):
+        """Single learner rescore queues a task and returns 202."""
+        response = self.client.post(self._get_url() + '?learner=test_student')
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        data = response.json()
+        assert 'task_id' in data
+        assert data['scope']['learners'] == 'test_student'
+        mock_apply.assert_called_once()
+
+    @patch('lms.djangoapps.instructor_task.api.submit_rescore_problem_for_student')
+    def test_rescore_only_if_higher(self, mock_submit):
+        """Rescore with only_if_higher=true passes the flag through."""
+        mock_task = MagicMock()
+        mock_task.task_id = str(uuid4())
+        mock_submit.return_value = mock_task
+
+        response = self.client.post(self._get_url() + '?learner=test_student&only_if_higher=true')
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert mock_submit.call_args[0][3] is True
+
+    @patch('lms.djangoapps.instructor_task.tasks.rescore_problem.apply_async')
+    def test_rescore_all_learners(self, mock_apply):
+        """Bulk rescore queues a task and returns 202."""
+        response = self.client.post(self._get_url())
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        data = response.json()
+        assert data['scope']['learners'] == 'all'
+        mock_apply.assert_called_once()
+
+
+class ScoreOverrideViewTestCase(GradingEndpointTestBase):
+    """
+    Tests for PUT /api/instructor/v2/courses/{course_key}/{problem}/grading/scores
+    """
+
+    def _get_url(self, problem=None):
+        return reverse('instructor_api_v2:score_override', kwargs={
+            'course_id': str(self.course.id),
+            'problem': problem or str(self.problem.location),
+        })
+
+    @patch('lms.djangoapps.instructor_task.tasks.override_problem_score.apply_async')
+    def test_override_score(self, mock_apply):
+        """Score override queues a task and returns 202."""
+        response = self.client.put(
+            self._get_url() + '?learner=test_student',
+            data={'score': 0.5},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        data = response.json()
+        assert 'task_id' in data
+        assert data['scope']['learners'] == 'test_student'
+        mock_apply.assert_called_once()
+
+        task = InstructorTask.objects.get(task_id=data['task_id'])
+        assert json.loads(task.task_input)['score'] == 0.5
+
+    @patch('lms.djangoapps.instructor_task.tasks.override_problem_score.apply_async')
+    def test_override_score_with_new_score_field(self, mock_apply):
+        """Score override also accepts 'new_score' field name (frontend compat)."""
+        response = self.client.put(
+            self._get_url(),
+            data={'new_score': 0.5, 'learner': 'test_student'},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        mock_apply.assert_called_once()
+
+        task = InstructorTask.objects.get(task_id=response.json()['task_id'])
+        assert json.loads(task.task_input)['score'] == 0.5
+
+    @patch('lms.djangoapps.instructor_task.tasks.override_problem_score.apply_async')
+    def test_override_score_zero(self, mock_apply):
+        """Score of 0 via 'score' field is a valid override."""
+        response = self.client.put(
+            self._get_url() + '?learner=test_student',
+            data={'score': 0},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        mock_apply.assert_called_once()
+
+        task = InstructorTask.objects.get(task_id=response.json()['task_id'])
+        assert json.loads(task.task_input)['score'] == 0
+
+    @patch('lms.djangoapps.instructor_task.tasks.override_problem_score.apply_async')
+    def test_override_new_score_zero(self, mock_apply):
+        """Score of 0 via 'new_score' field is a valid override."""
+        response = self.client.put(
+            self._get_url() + '?learner=test_student',
+            data={'new_score': 0},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        mock_apply.assert_called_once()
+
+        task = InstructorTask.objects.get(task_id=response.json()['task_id'])
+        assert json.loads(task.task_input)['score'] == 0
+
+    def test_override_requires_learner_param(self):
+        """PUT without learner query param returns 400."""
+        response = self.client.put(
+            self._get_url(),
+            data={'score': 8.5},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_override_requires_score_in_body(self):
+        """PUT without score in body returns 400."""
+        response = self.client.put(
+            self._get_url() + '?learner=test_student',
+            data={},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_override_rejects_negative_score(self):
+        """PUT with negative score returns 400."""
+        response = self.client.put(
+            self._get_url() + '?learner=test_student',
+            data={'score': -1},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -136,6 +136,27 @@ v2_api_urls = [
         api_v2.CourseTeamView.as_view(),
         name='course_team'
     ),
+    # Grading endpoints
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/(?P<problem>.+)/grading/attempts/reset$',
+        api_v2.ResetAttemptsView.as_view(),
+        name='reset_attempts'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/(?P<problem>.+)/grading/state$',
+        api_v2.DeleteStateView.as_view(),
+        name='delete_state'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/(?P<problem>.+)/grading/scores/rescore$',
+        api_v2.RescoreView.as_view(),
+        name='rescore'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/(?P<problem>.+)/grading/scores$',
+        api_v2.ScoreOverrideView.as_view(),
+        name='score_override'
+    ),
 ]
 
 urlpatterns = [

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -21,6 +21,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import validate_email
 from django.db import transaction
 from django.db.models import Q
+from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.html import strip_tags
@@ -38,6 +39,7 @@ from rest_framework.generics import GenericAPIView, ListAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from submissions import api as sub_api
 
 from common.djangoapps.student.api import is_user_enrolled_in_course
 from common.djangoapps.student.models import (
@@ -64,9 +66,11 @@ from lms.djangoapps.certificates.models import (
     GeneratedCertificate,
 )
 from lms.djangoapps.course_home_api.toggles import course_home_mfe_progress_tab_is_active
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_with_access
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.tabs import get_course_tab_list
-from lms.djangoapps.instructor import permissions
+from lms.djangoapps.instructor import enrollment, permissions
 from lms.djangoapps.instructor.access import (
     FORUM_ROLES,
     ROLE_DISPLAY_NAMES,
@@ -106,6 +110,7 @@ from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from .filters_v2 import CourseEnrollmentFilter
 from .serializers_v2 import (
+    AsyncOperationResultSerializer,
     BetaTesterModifyRequestSerializerV2,
     BetaTesterModifyResponseSerializerV2,
     BlockDueDateSerializerV2,
@@ -116,7 +121,6 @@ from .serializers_v2 import (
     CourseTeamRevokeSerializer,
     EnrollmentModifyRequestSerializerV2,
     EnrollmentModifyResponseSerializerV2,
-    GradingConfigSerializer,
     InstructorTaskListSerializer,
     IssuedCertificateSerializer,
     LearnerSerializer,
@@ -124,6 +128,8 @@ from .serializers_v2 import (
     ORASummarySerializer,
     ProblemSerializer,
     RegenerateCertificatesSerializer,
+    ScoreOverrideRequestSerializer,
+    SyncOperationResultSerializer,
     TaskStatusSerializer,
     UnitExtensionSerializer,
 )
@@ -2031,32 +2037,17 @@ class GradingConfigView(DeveloperErrorViewMixin, APIView):
     """
     API view for retrieving course grading configuration.
 
-    **GET Example Response:**
-    ```json
-    {
-        "graders": [
-            {
-                "type": "Homework",
-                "short_label": "HW",
-                "min_count": 12,
-                "drop_count": 2,
-                "weight": 0.15
-            },
-            {
-                "type": "Final Exam",
-                "short_label": "Final",
-                "min_count": 1,
-                "drop_count": 0,
-                "weight": 0.40
-            }
-        ],
-        "grade_cutoffs": {
-            "A": 0.9,
-            "B": 0.8,
-            "C": 0.7
-        }
-    }
-    ```
+    Returns an HTML-formatted summary of the course grading context, including
+    the course grader type, graded sections with assignment types and weights,
+    and all graded blocks.
+
+    **GET** returns ``text/html`` content type.
+
+    Note: The response is a pre-formatted text string produced by
+    ``instructor_analytics_basic.dump_grading_context``, which is a debugging
+    utility carried over from the v1 instructor API.  It is served as
+    ``text/html`` so the MFE can render it directly inside a ``<pre>`` block
+    without additional parsing.
     """
     permission_classes = (IsAuthenticated, permissions.InstructorPermission)
     permission_name = permissions.VIEW_DASHBOARD
@@ -2070,7 +2061,7 @@ class GradingConfigView(DeveloperErrorViewMixin, APIView):
             ),
         ],
         responses={
-            200: 'Grading configuration retrieved successfully',
+            200: 'HTML-formatted grading configuration summary',
             400: "Invalid parameters provided.",
             401: "The requesting user is not authenticated.",
             403: "The requesting user lacks instructor access to the course.",
@@ -2079,8 +2070,7 @@ class GradingConfigView(DeveloperErrorViewMixin, APIView):
     )
     def get(self, request, course_id):
         """
-        Retrieve the grading configuration for a course, including assignment type
-        weights and grade cutoff thresholds.
+        Retrieve the grading configuration for a course as an HTML summary.
         """
         try:
             course_key = CourseKey.from_string(course_id)
@@ -2091,13 +2081,8 @@ class GradingConfigView(DeveloperErrorViewMixin, APIView):
             )
 
         course = get_course_by_id(course_key)
-        grading_policy = course.grading_policy
-        config_data = {
-            'graders': grading_policy.get('GRADER', []),
-            'grade_cutoffs': grading_policy.get('GRADE_CUTOFFS', {}),
-        }
-        serializer = GradingConfigSerializer(config_data)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        grading_config_summary = instructor_analytics_basic.dump_grading_context(course)
+        return HttpResponse(grading_config_summary, content_type='text/html')
 
 
 class EnrollmentModifyView(DeveloperErrorViewMixin, APIView):
@@ -2777,3 +2762,483 @@ class CourseTeamMemberView(DeveloperErrorViewMixin, APIView):
             'action': 'revoke',
             'success': True,
         }, status=status.HTTP_200_OK)
+
+
+def _get_learner_identifier(request):
+    """
+    Extract the learner identifier from query params or request body.
+    """
+    return request.query_params.get('learner') or request.data.get('learner')
+
+
+def _parse_course_and_problem(course_id, problem):
+    """
+    Parse and validate course_id and problem location strings.
+
+    Returns (course_key, usage_key) tuple on success.
+    Returns (None, Response) if validation fails — caller should return the Response.
+    """
+    try:
+        course_key = CourseKey.from_string(course_id)
+    except InvalidKeyError:
+        return None, Response(
+            {'error': 'Invalid course key'},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+
+    try:
+        usage_key = UsageKey.from_string(problem).map_into_course(course_key)
+    except InvalidKeyError:
+        return None, Response(
+            {'error': 'Invalid problem location'},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+
+    return (course_key, usage_key), None
+
+
+def _resolve_learner(learner_identifier):
+    """
+    Resolve a learner identifier (username or email) to a User object.
+
+    Returns (User, None) on success, or (None, Response) on failure.
+    """
+    UserModel = get_user_model()
+    try:
+        return get_user_by_username_or_email(learner_identifier), None
+    except UserModel.DoesNotExist:
+        return None, Response(
+            {'error': 'Learner not found'},
+            status=status.HTTP_404_NOT_FOUND
+        )
+    except UserModel.MultipleObjectsReturned:
+        return None, Response(
+            {'error': 'Multiple learners found for the given identifier'},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+
+
+def _build_async_response(instructor_task, course_id, problem_location, learner_scope='all'):
+    """
+    Build a 202 Accepted response for an async task.
+    """
+    task_id = str(instructor_task.task_id)
+    status_url = reverse(
+        'instructor_api_v2:task_status',
+        kwargs={'course_id': course_id, 'task_id': task_id}
+    )
+    data = {
+        'task_id': task_id,
+        'status_url': status_url,
+        'scope': {
+            'learners': learner_scope,
+            'problem_location': str(problem_location),
+        }
+    }
+    serializer = AsyncOperationResultSerializer(data)
+    return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
+
+
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
+class ResetAttemptsView(DeveloperErrorViewMixin, APIView):
+    """
+    Reset problem attempts for a learner or all learners.
+
+    **POST** with `learner` query param: resets a single learner's attempts (synchronous).
+    **POST** without `learner`: queues a background task to reset all learners (asynchronous).
+    """
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.GIVE_STUDENT_EXTENSION
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+            apidocs.string_parameter(
+                'problem',
+                apidocs.ParameterLocation.PATH,
+                description="Problem block usage key.",
+            ),
+            apidocs.string_parameter(
+                'learner',
+                apidocs.ParameterLocation.QUERY,
+                description="Optional: Learner username or email. If omitted, resets all learners (async).",
+            ),
+        ],
+        responses={
+            200: SyncOperationResultSerializer,
+            202: AsyncOperationResultSerializer,
+            400: "Invalid parameters provided.",
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks permission.",
+            404: "Learner not found.",
+        },
+    )
+    def post(self, request, course_id, problem):
+        """Reset problem attempts for one or all learners."""
+        parsed, error_response = _parse_course_and_problem(course_id, problem)
+        if error_response:
+            return error_response
+        course_key, usage_key = parsed
+
+        learner_identifier = _get_learner_identifier(request)
+
+        if learner_identifier:
+            student, error_response = _resolve_learner(learner_identifier)
+            if error_response:
+                return error_response
+
+            try:
+                enrollment.reset_student_attempts(
+                    course_key,
+                    student,
+                    usage_key,
+                    requesting_user=request.user,
+                    delete_module=False,
+                )
+            except StudentModule.DoesNotExist:
+                return Response(
+                    {'error': 'No state found for this learner and problem'},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            except sub_api.SubmissionError:
+                return Response(
+                    {'error': 'An error occurred while resetting attempts'},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                )
+
+            data = {
+                'success': True,
+                'learner': student.username,
+                'problem_location': str(usage_key),
+                'message': 'Attempts reset successfully',
+            }
+            serializer = SyncOperationResultSerializer(data)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+
+        else:
+            course = get_course_with_access(request.user, 'staff', course_key, depth=None)
+            if not has_access(request.user, 'instructor', course):
+                return Response(
+                    {'error': 'Instructor access required for bulk operations'},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
+            try:
+                instructor_task = task_api.submit_reset_problem_attempts_for_all_students(
+                    request, usage_key
+                )
+            except AlreadyRunningError:
+                return Response(
+                    {'error': 'A reset task is already running for this problem'},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            except ItemNotFoundError:
+                return Response(
+                    {'error': 'Problem not found'},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
+            return _build_async_response(instructor_task, course_id, usage_key)
+
+
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
+class DeleteStateView(DeveloperErrorViewMixin, APIView):
+    """
+    Delete a learner's problem state permanently.
+
+    The `learner` query parameter is required. This operation is destructive
+    and cannot be undone.
+    """
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.GIVE_STUDENT_EXTENSION
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+            apidocs.string_parameter(
+                'problem',
+                apidocs.ParameterLocation.PATH,
+                description="Problem block usage key.",
+            ),
+            apidocs.string_parameter(
+                'learner',
+                apidocs.ParameterLocation.QUERY,
+                description="Learner username or email (required).",
+            ),
+        ],
+        responses={
+            200: SyncOperationResultSerializer,
+            400: "Invalid parameters or missing learner.",
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks permission.",
+            404: "Learner not found.",
+        },
+    )
+    def delete(self, request, course_id, problem):
+        """Delete learner problem state."""
+        parsed, error_response = _parse_course_and_problem(course_id, problem)
+        if error_response:
+            return error_response
+        course_key, usage_key = parsed
+
+        learner_identifier = _get_learner_identifier(request)
+        if not learner_identifier:
+            return Response(
+                {'error': 'The learner parameter is required'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        student, error_response = _resolve_learner(learner_identifier)
+        if error_response:
+            return error_response
+
+        try:
+            enrollment.reset_student_attempts(
+                course_key,
+                student,
+                usage_key,
+                requesting_user=request.user,
+                delete_module=True,
+            )
+        except StudentModule.DoesNotExist:
+            return Response(
+                {'error': 'No state found for this learner and problem'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except sub_api.SubmissionError:
+            return Response(
+                {'error': 'An error occurred while deleting state'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        data = {
+            'success': True,
+            'learner': student.username,
+            'problem_location': str(usage_key),
+            'message': 'State deleted successfully',
+        }
+        serializer = SyncOperationResultSerializer(data)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
+class RescoreView(DeveloperErrorViewMixin, APIView):
+    """
+    Rescore problem submissions for a learner or all learners.
+
+    **POST** with `learner` query param: rescores a single learner (asynchronous task).
+    **POST** without `learner`: rescores all learners (asynchronous task).
+
+    Optionally accepts `only_if_higher=true` query param to only update if new score is higher.
+    """
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.OVERRIDE_GRADES
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+            apidocs.string_parameter(
+                'problem',
+                apidocs.ParameterLocation.PATH,
+                description="Problem block usage key.",
+            ),
+            apidocs.string_parameter(
+                'learner',
+                apidocs.ParameterLocation.QUERY,
+                description="Optional: Learner username or email. If omitted, rescores all learners.",
+            ),
+            apidocs.string_parameter(
+                'only_if_higher',
+                apidocs.ParameterLocation.QUERY,
+                description="Optional: If 'true', only update scores that are higher than current.",
+            ),
+        ],
+        responses={
+            202: AsyncOperationResultSerializer,
+            400: "Invalid parameters provided.",
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks permission.",
+            404: "Learner not found.",
+        },
+    )
+    def post(self, request, course_id, problem):
+        """Rescore problem submissions."""
+        parsed, error_response = _parse_course_and_problem(course_id, problem)
+        if error_response:
+            return error_response
+        course_key, usage_key = parsed
+
+        only_if_higher = request.query_params.get('only_if_higher', 'false').lower() == 'true'
+        learner_identifier = _get_learner_identifier(request)
+
+        if learner_identifier:
+            student, error_response = _resolve_learner(learner_identifier)
+            if error_response:
+                return error_response
+
+            try:
+                instructor_task = task_api.submit_rescore_problem_for_student(
+                    request, usage_key, student, only_if_higher,
+                )
+            except NotImplementedError as exc:
+                return Response(
+                    {'error': str(exc)},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            except ItemNotFoundError:
+                return Response(
+                    {'error': 'Problem not found'},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            except AlreadyRunningError:
+                return Response(
+                    {'error': 'A rescore task is already running for this learner and problem'},
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            return _build_async_response(
+                instructor_task, course_id, usage_key, learner_scope=student.username
+            )
+
+        else:
+            course = get_course_with_access(request.user, 'staff', course_key)
+            if not has_access(request.user, 'instructor', course):
+                return Response(
+                    {'error': 'Instructor access required for bulk operations'},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
+            try:
+                instructor_task = task_api.submit_rescore_problem_for_all_students(
+                    request, usage_key, only_if_higher,
+                )
+            except NotImplementedError as exc:
+                return Response(
+                    {'error': str(exc)},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            except ItemNotFoundError:
+                return Response(
+                    {'error': 'Problem not found'},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            except AlreadyRunningError:
+                return Response(
+                    {'error': 'A rescore task is already running for this problem'},
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            return _build_async_response(instructor_task, course_id, usage_key)
+
+
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
+class ScoreOverrideView(DeveloperErrorViewMixin, APIView):
+    """
+    Override a learner's score for a specific problem.
+
+    The `learner` query parameter is required. Accepts a JSON body with `score` field.
+    """
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.OVERRIDE_GRADES
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+            apidocs.string_parameter(
+                'problem',
+                apidocs.ParameterLocation.PATH,
+                description="Problem block usage key.",
+            ),
+            apidocs.string_parameter(
+                'learner',
+                apidocs.ParameterLocation.QUERY,
+                description="Learner username or email (required).",
+            ),
+        ],
+        responses={
+            202: AsyncOperationResultSerializer,
+            400: "Invalid parameters or invalid score.",
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks permission.",
+            404: "Learner not found.",
+        },
+    )
+    def put(self, request, course_id, problem):
+        """Override a learner's score."""
+        parsed, error_response = _parse_course_and_problem(course_id, problem)
+        if error_response:
+            return error_response
+        course_key, usage_key = parsed
+
+        learner_identifier = _get_learner_identifier(request)
+        if not learner_identifier:
+            return Response(
+                {'error': 'The learner parameter is required'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        student, error_response = _resolve_learner(learner_identifier)
+        if error_response:
+            return error_response
+
+        body_serializer = ScoreOverrideRequestSerializer(data=request.data)
+        if not body_serializer.is_valid():
+            return Response(
+                {'error': 'Invalid request body', 'field_errors': body_serializer.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        score = body_serializer.validated_data['score']
+
+        try:
+            block = modulestore().get_item(usage_key)
+        except ItemNotFoundError:
+            return Response(
+                {'error': 'Problem not found'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if not has_access(request.user, 'staff', block):
+            return Response(
+                {'error': 'You do not have permission to override scores for this problem'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        try:
+            instructor_task = task_api.submit_override_score(
+                request, usage_key, student, score,
+            )
+        except NotImplementedError as exc:
+            return Response(
+                {'error': str(exc)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except ValueError as exc:
+            return Response(
+                {'error': str(exc)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except AlreadyRunningError:
+            return Response(
+                {'error': 'A score override task is already running for this learner and problem'},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        return _build_async_response(
+            instructor_task, course_id, usage_key, learner_scope=student.username
+        )

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -766,44 +766,6 @@ class LearnerSerializer(serializers.Serializer):
     )
 
 
-class GraderSerializer(serializers.Serializer):
-    """Serializer for a single grader configuration entry."""
-    type = serializers.CharField(
-        help_text="Assignment type (e.g. Homework, Lab, Midterm Exam)"
-    )
-    short_label = serializers.CharField(
-        required=False,
-        allow_null=True,
-        help_text="Short label used when displaying assignment names"
-    )
-    min_count = serializers.IntegerField(
-        help_text="Minimum number of assignments counted in this category"
-    )
-    drop_count = serializers.IntegerField(
-        help_text="Number of lowest scores dropped from this category"
-    )
-    weight = serializers.FloatField(
-        help_text="Weight of this assignment type in the final grade (0.0 to 1.0)"
-    )
-
-
-class GradingConfigSerializer(serializers.Serializer):
-    """
-    Serializer for course grading configuration.
-
-    Returns structured grading policy data including assignment type weights
-    and grade cutoff thresholds.
-    """
-    graders = GraderSerializer(
-        many=True,
-        help_text="List of grader configurations by assignment type"
-    )
-    grade_cutoffs = serializers.DictField(
-        child=serializers.FloatField(),
-        help_text="Grade cutoffs mapping letter grades to minimum score thresholds (0.0 to 1.0)"
-    )
-
-
 class ProblemSerializer(serializers.Serializer):
     """
     Serializer for problem metadata and location.
@@ -980,3 +942,69 @@ class CourseTeamRevokeSerializer(serializers.Serializer):
         allow_empty=False,
         help_text="One or more roles to revoke (course access role or forum role)"
     )
+
+
+class SyncOperationResultSerializer(serializers.Serializer):
+    """
+    Serializer for synchronous grading operation results.
+    """
+    success = serializers.BooleanField(
+        help_text="Whether the operation succeeded"
+    )
+    learner = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="Learner identifier (if applicable)"
+    )
+    problem_location = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text="Problem location (if applicable)"
+    )
+    score = serializers.FloatField(
+        allow_null=True,
+        required=False,
+        help_text="Updated score (for override operations)"
+    )
+    previous_score = serializers.FloatField(
+        allow_null=True,
+        required=False,
+        help_text="Previous score (for override operations)"
+    )
+    message = serializers.CharField(
+        help_text="Human-readable result message"
+    )
+
+
+class AsyncOperationResultSerializer(serializers.Serializer):
+    """
+    Serializer for asynchronous grading operation results.
+    """
+    task_id = serializers.CharField(
+        help_text="Unique task identifier"
+    )
+    status_url = serializers.CharField(
+        help_text="URL to poll for task status"
+    )
+    scope = serializers.DictField(
+        required=False,
+        help_text="Scope of the operation"
+    )
+
+
+class ScoreOverrideRequestSerializer(serializers.Serializer):
+    """
+    Serializer for score override request body.
+    """
+    score = serializers.FloatField(
+        min_value=0,
+        help_text="New score value (out of problem's total possible points)"
+    )
+
+    def to_internal_value(self, data):
+        # The frontend sends `new_score` but the field is `score`.
+        # Convert here, before field level validation, so that DRF's required
+        # check and min_value constraint apply to whichever name was provided.
+        if "score" not in data and "new_score" in data:
+            data = {**data, "score": data["new_score"]}
+        return super().to_internal_value(data)


### PR DESCRIPTION
### Description
Adds grading write endpoints to the Instructor API v2, enabling the instructor dashboard MFE to reset attempts, delete state, rescore submissions, and override scores.

**New endpoints:**
| Method | Path | Description |                                                                                                                                 
|--------|------|-------------|
| `POST` | `…/{problem}/grading/attempts/reset` | Reset attempts for one learner (sync) or all learners (async task) |
| `DELETE` | `…/{problem}/grading/state` | Delete a learner's problem state |
| `POST` | `…/{problem}/grading/scores/rescore` | Rescore one learner or all learners (async task) |
| `PUT` | `…/{problem}/grading/scores` | Override a learner's score (async task) |

### Supporting information
Closes: https://github.com/openedx/openedx-platform/issues/37905

### Deadline
None

### Other Information
- No database migrations