### PR TITLE
fix: test isolation fixes for certificates and openedx-events test mixins

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_upstream_downstream_links.py
+++ b/cms/djangoapps/contentstore/tests/test_upstream_downstream_links.py
@@ -10,7 +10,7 @@ from django.core.management.base import CommandError
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryContainerLocator, LibraryUsageLocatorV2
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangolib.testing.utils import skip_unless_cms

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -11,7 +11,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 from path import Path as path
 from pytz import UTC
 from rest_framework import status

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -21,7 +21,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from openedx_events.content_authoring.data import DuplicatedXBlockData
 from openedx_events.content_authoring.signals import XBLOCK_DUPLICATED
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 from pytz import UTC
 from web_fragments.fragment import Fragment
 from webob import Response

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -743,7 +743,7 @@ class DuplicateHelper:
         return self.response_usage_key(resp)
 
 
-class TestDuplicateItem(ItemTest, DuplicateHelper, OpenEdxEventsTestMixin):
+class TestDuplicateItem(OpenEdxEventsTestMixin, ItemTest, DuplicateHelper):
     """
     Test the duplicate method.
     """
@@ -751,22 +751,6 @@ class TestDuplicateItem(ItemTest, DuplicateHelper, OpenEdxEventsTestMixin):
     ENABLED_OPENEDX_EVENTS = [
         "org.openedx.content_authoring.xblock.duplicated.v1",
     ]
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
-
-    @classmethod
-    def tearDownClass(cls):
-        """ Don't let our event isolation affect other test cases """
-        super().tearDownClass()
-        cls.enable_all_events()  # Re-enable events other than the ENABLED_OPENEDX_EVENTS subset we isolated.
 
     def setUp(self):
         """Creates the test course structure and a few components to 'duplicate'."""

--- a/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
+++ b/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
@@ -11,7 +11,7 @@ from openedx_events.content_authoring.signals import (
     XBLOCK_DELETED,
     XBLOCK_UPDATED,
 )
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 from openedx_tagging.models import Tag
 from organizations.models import Organization
 from rest_framework.test import APIClient

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -30,7 +30,7 @@ from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
 @skip_unless_lms
-class EnrollmentTest(UrlResetMixin, ModuleStoreTestCase, OpenEdxEventsTestMixin):
+class EnrollmentTest(OpenEdxEventsTestMixin, UrlResetMixin, ModuleStoreTestCase):
     """
     Test student enrollment, especially with different course modes.
     """
@@ -41,17 +41,6 @@ class EnrollmentTest(UrlResetMixin, ModuleStoreTestCase, OpenEdxEventsTestMixin)
     EMAIL = "bob@example.com"
     PASSWORD = "edx"
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -8,7 +8,7 @@ import ddt
 import pytest
 from django.conf import settings
 from django.urls import reverse
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -25,7 +25,7 @@ from openedx_events.learning.signals import (  # lint-amnesty, pylint: disable=w
     COURSE_ENROLLMENT_CREATED,
     COURSE_UNENROLLMENT_COMPLETED,
 )
-from openedx_events.tests.utils import OpenEdxEventsTestMixin  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx_events.testing import OpenEdxEventsTestMixin  # lint-amnesty, pylint: disable=wrong-import-order
 
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -211,7 +211,7 @@ class TestUserEvents(UserSettingsEventTestMixin, TestCase):
 
 
 @skip_unless_lms
-class EnrollmentEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+class EnrollmentEventsTest(OpenEdxEventsTestMixin, SharedModuleStoreTestCase):
     """
     Tests for the Open edX Events associated with the enrollment process through the enroll method.
 
@@ -228,17 +228,6 @@ class EnrollmentEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
         "org.openedx.learning.course.enrollment.changed.v1",
         "org.openedx.learning.course.unenrollment.completed.v1",
     ]
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()
@@ -391,7 +380,7 @@ class EnrollmentEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
 
 @skip_unless_lms
 @ddt.ddt
-class TestCourseAccessRoleEvents(TestCase, OpenEdxEventsTestMixin):
+class TestCourseAccessRoleEvents(OpenEdxEventsTestMixin, TestCase):
     """
     Tests for the events associated with the CourseAccessRole model.
     """
@@ -399,11 +388,6 @@ class TestCourseAccessRoleEvents(TestCase, OpenEdxEventsTestMixin):
         'org.openedx.learning.user.course_access_role.added.v1',
         'org.openedx.learning.user.course_access_role.removed.v1',
     ]
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         self.course_key = CourseKey.from_string("course-v1:test+blah+blah")

--- a/lms/djangoapps/certificates/tests/test_events.py
+++ b/lms/djangoapps/certificates/tests/test_events.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 
 from openedx_events.learning.data import CertificateData, CourseData, UserData, UserPersonalData
 from openedx_events.learning.signals import CERTIFICATE_CHANGED, CERTIFICATE_CREATED, CERTIFICATE_REVOKED
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 
 from common.djangoapps.student.tests.factories import UserFactory
 from common.test.utils import assert_dict_contains_subset

--- a/lms/djangoapps/certificates/tests/test_events.py
+++ b/lms/djangoapps/certificates/tests/test_events.py
@@ -23,7 +23,7 @@ from xmodule.modulestore.tests.django_utils import (
 
 
 @skip_unless_lms
-class CertificateEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+class CertificateEventTest(OpenEdxEventsTestMixin, SharedModuleStoreTestCase):
     """
     Tests for the Open edX Events associated with the student's certification
     process.
@@ -42,17 +42,6 @@ class CertificateEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
         "org.openedx.learning.certificate.changed.v1",
         "org.openedx.learning.certificate.revoked.v1",
     ]
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()

--- a/lms/djangoapps/certificates/tests/test_filters.py
+++ b/lms/djangoapps/certificates/tests/test_filters.py
@@ -71,9 +71,13 @@ class CertificateFiltersTest(SharedModuleStoreTestCase):
     - CertificateCreationRequested
     """
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course_run = CourseFactory()
+
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()
-        self.course_run = CourseFactory()
         self.user = UserFactory.create(
             username="somestudent",
             first_name="Student",

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -13,7 +13,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.test.utils import override_settings
 from opaque_keys.edx.locator import CourseKey, CourseLocator
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 from path import Path as path
 
 from common.djangoapps.course_modes.models import CourseMode

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -381,10 +381,10 @@ class CertificateInvalidationTest(SharedModuleStoreTestCase, OpenEdxEventsTestMi
         """
         super().setUpClass()
         cls.start_events_isolation()
+        cls.course = CourseFactory()
 
     def setUp(self):
         super().setUp()
-        self.course = CourseFactory()
         self.course_overview = CourseOverviewFactory.create(
             id=self.course.id
         )
@@ -708,6 +708,7 @@ class CertificateAllowlistTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
         """
         super().setUpClass()
         cls.start_events_isolation()
+        cls.course_run = CourseFactory()
 
     def setUp(self):
         super().setUp()
@@ -716,7 +717,6 @@ class CertificateAllowlistTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
         self.user = UserFactory(username=self.username, email=self.user_email)
         self.second_user = UserFactory()
 
-        self.course_run = CourseFactory()
         self.course_run_key = self.course_run.id  # pylint: disable=no-member
 
     def test_get_allowlist_empty(self):

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -57,7 +57,7 @@ TEST_DATA_ROOT = PLATFORM_ROOT / TEST_DATA_DIR
 name_affirmation_service = get_name_affirmation_service()
 
 
-class ExampleCertificateTest(TestCase, OpenEdxEventsTestMixin):
+class ExampleCertificateTest(OpenEdxEventsTestMixin, TestCase):
     """Tests for the ExampleCertificate model. """
 
     COURSE_KEY = CourseLocator(org='test', course='test', run='test')
@@ -68,17 +68,6 @@ class ExampleCertificateTest(TestCase, OpenEdxEventsTestMixin):
     ERROR_REASON = 'Kaboom!'
 
     ENABLED_OPENEDX_EVENTS = []
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()
@@ -127,23 +116,12 @@ class ExampleCertificateTest(TestCase, OpenEdxEventsTestMixin):
         assert result is None
 
 
-class CertificateHtmlViewConfigurationTest(TestCase, OpenEdxEventsTestMixin):
+class CertificateHtmlViewConfigurationTest(OpenEdxEventsTestMixin, TestCase):
     """
     Test the CertificateHtmlViewConfiguration model.
     """
 
     ENABLED_OPENEDX_EVENTS = []
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()
@@ -234,24 +212,13 @@ class CertificateTemplateAssetTest(TestCase):
         assert certificate_template_asset.asset == 'certificate_template_assets/1/picture2.jpg'
 
 
-class EligibleCertificateManagerTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+class EligibleCertificateManagerTest(OpenEdxEventsTestMixin, SharedModuleStoreTestCase):
     """
     Test the GeneratedCertificate model's object manager for filtering
     out ineligible certs.
     """
 
     ENABLED_OPENEDX_EVENTS = []
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()
@@ -292,23 +259,12 @@ class EligibleCertificateManagerTest(SharedModuleStoreTestCase, OpenEdxEventsTes
 
 
 @ddt.ddt
-class TestCertificateGenerationHistory(TestCase, OpenEdxEventsTestMixin):
+class TestCertificateGenerationHistory(OpenEdxEventsTestMixin, TestCase):
     """
     Test the CertificateGenerationHistory model's methods
     """
 
     ENABLED_OPENEDX_EVENTS = []
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     @ddt.data(
         ({"student_set": "allowlisted_not_generated"}, "For exceptions", True),
@@ -364,7 +320,7 @@ class TestCertificateGenerationHistory(TestCase, OpenEdxEventsTestMixin):
         assert certificate_generation_history.get_task_name() == expected
 
 
-class CertificateInvalidationTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+class CertificateInvalidationTest(OpenEdxEventsTestMixin, SharedModuleStoreTestCase):
     """
     Test for the Certificate Invalidation model.
     """
@@ -373,14 +329,7 @@ class CertificateInvalidationTest(SharedModuleStoreTestCase, OpenEdxEventsTestMi
 
     @classmethod
     def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
         super().setUpClass()
-        cls.start_events_isolation()
         cls.course = CourseFactory()
 
     def setUp(self):
@@ -434,23 +383,12 @@ class CertificateInvalidationTest(SharedModuleStoreTestCase, OpenEdxEventsTestMi
 
 
 @ddt.ddt
-class GeneratedCertificateTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+class GeneratedCertificateTest(OpenEdxEventsTestMixin, SharedModuleStoreTestCase):
     """
     Test GeneratedCertificates
     """
 
     ENABLED_OPENEDX_EVENTS = []
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()
@@ -691,7 +629,7 @@ class GeneratedCertificateTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
         self._assert_event_data(mock_emit_certificate_event, expected_event_data)
 
 
-class CertificateAllowlistTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+class CertificateAllowlistTest(OpenEdxEventsTestMixin, SharedModuleStoreTestCase):
     """
     Tests for the CertificateAllowlist model.
     """
@@ -700,14 +638,7 @@ class CertificateAllowlistTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin
 
     @classmethod
     def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
         super().setUpClass()
-        cls.start_events_isolation()
         cls.course_run = CourseFactory()
 
     def setUp(self):

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -13,7 +13,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from openedx_events.data import EventsMetadata
 from openedx_events.learning.data import ExamAttemptData, UserData, UserPersonalData
 from openedx_events.learning.signals import EXAM_ATTEMPT_REJECTED
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.certificates.api import has_self_generated_certificates_enabled

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -300,16 +300,11 @@ class FailingGradeCertsTest(ModuleStoreTestCase):
         assert cert.status == CertificateStatuses.downloadable
 
 
-class LearnerIdVerificationTest(ModuleStoreTestCase, OpenEdxEventsTestMixin):
+class LearnerIdVerificationTest(OpenEdxEventsTestMixin, ModuleStoreTestCase):
     """
     Tests for certificate generation task firing on learner id verification
     """
     ENABLED_OPENEDX_EVENTS = ['org.openedx.learning.idv_attempt.approved.v1']
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()

--- a/lms/djangoapps/grades/tests/test_events.py
+++ b/lms/djangoapps/grades/tests/test_events.py
@@ -32,7 +32,7 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-class PersistentGradeEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+class PersistentGradeEventsTest(OpenEdxEventsTestMixin, SharedModuleStoreTestCase):
     """
     Tests for the Open edX Events associated with the persistant grade process through the update_or_create method.
 
@@ -44,17 +44,6 @@ class PersistentGradeEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixi
     ENABLED_OPENEDX_EVENTS = [
         "org.openedx.learning.course.persistent_grade_summary.changed.v1",
     ]
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()
@@ -113,21 +102,13 @@ class PersistentGradeEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixi
         )
 
 
-class CoursePassingStatusEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+class CoursePassingStatusEventsTest(OpenEdxEventsTestMixin, SharedModuleStoreTestCase):
     """
     Tests for Open edX passing status update event.
     """
     ENABLED_OPENEDX_EVENTS = [
         "org.openedx.learning.course.passing.status.updated.v1",
     ]
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()
@@ -179,7 +160,7 @@ class CoursePassingStatusEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTest
 
 
 class CCXCoursePassingStatusEventsTest(
-    SharedModuleStoreTestCase, OpenEdxEventsTestMixin
+    OpenEdxEventsTestMixin, SharedModuleStoreTestCase
 ):
     """
     Tests for Open edX passing status update event in a CCX course.
@@ -187,14 +168,6 @@ class CCXCoursePassingStatusEventsTest(
     ENABLED_OPENEDX_EVENTS = [
         "org.openedx.learning.ccx.course.passing.status.updated.v1",
     ]
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()

--- a/lms/djangoapps/grades/tests/test_events.py
+++ b/lms/djangoapps/grades/tests/test_events.py
@@ -20,7 +20,7 @@ from openedx_events.learning.signals import (
     COURSE_PASSING_STATUS_UPDATED,
     PERSISTENT_GRADE_SUMMARY_CHANGED,
 )
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
 from common.test.utils import assert_dict_contains_subset

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -30,29 +30,12 @@ from ..tests.helpers import CohortFactory, CourseCohortFactory, config_course_co
 
 
 @patch("openedx.core.djangoapps.course_groups.cohorts.tracker", autospec=True)
-class TestCohortSignals(TestCase, OpenEdxEventsTestMixin):
+class TestCohortSignals(OpenEdxEventsTestMixin, TestCase):
     """
     Test cases to validate event emissions for various cohort-related workflows
     """
 
     ENABLED_OPENEDX_EVENTS = []
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
-
-    @classmethod
-    def tearDownClass(cls):
-        """ Don't let our event isolation affect other test cases """
-        super().tearDownClass()
-        cls.enable_all_events()  # Re-enable events other than the ENABLED_OPENEDX_EVENTS subset we isolated.
 
     def setUp(self):
         super().setUp()

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -13,7 +13,7 @@ from django.http import Http404
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory

--- a/openedx/core/djangoapps/course_groups/tests/test_events.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_events.py
@@ -29,7 +29,7 @@ from xmodule.modulestore.tests.django_utils import (
 
 
 @skip_unless_lms
-class CohortEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+class CohortEventTest(OpenEdxEventsTestMixin, SharedModuleStoreTestCase):
     """
     Tests for the Open edX Events associated with the cohort update process.
 
@@ -42,23 +42,6 @@ class CohortEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
     ENABLED_OPENEDX_EVENTS = [
         "org.openedx.learning.cohort_membership.changed.v1",
     ]
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
-
-    @classmethod
-    def tearDownClass(cls):
-        """ Don't let our event isolation affect other test cases """
-        super().tearDownClass()
-        cls.enable_all_events()  # Re-enable events other than the ENABLED_OPENEDX_EVENTS subset we isolated.
 
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()

--- a/openedx/core/djangoapps/course_groups/tests/test_events.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_events.py
@@ -15,7 +15,7 @@ from openedx_events.learning.data import (  # lint-amnesty, pylint: disable=wron
 from openedx_events.learning.signals import (
     COHORT_MEMBERSHIP_CHANGED,  # lint-amnesty, pylint: disable=wrong-import-order
 )
-from openedx_events.tests.utils import OpenEdxEventsTestMixin  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx_events.testing import OpenEdxEventsTestMixin  # lint-amnesty, pylint: disable=wrong-import-order
 
 from common.djangoapps.student.tests.factories import UserFactory
 from common.test.utils import assert_dict_contains_subset

--- a/openedx/core/djangoapps/user_authn/views/tests/test_events.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_events.py
@@ -22,7 +22,7 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
 @skip_unless_lms
-class RegistrationEventTest(UserAPITestCase, OpenEdxEventsTestMixin):
+class RegistrationEventTest(OpenEdxEventsTestMixin, UserAPITestCase):
     """
     Tests for the Open edX Events associated with the registration process through
     the registration view.
@@ -35,19 +35,6 @@ class RegistrationEventTest(UserAPITestCase, OpenEdxEventsTestMixin):
     """
 
     ENABLED_OPENEDX_EVENTS = ["org.openedx.learning.student.registration.completed.v1"]
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        So the Open edX Events Isolation starts, the setUpClass must be explicitly
-        called with the method that executes the isolation. We do this to avoid
-        MRO resolution conflicts with other sibling classes while ensuring the
-        isolation process begins.
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()
@@ -104,7 +91,7 @@ class RegistrationEventTest(UserAPITestCase, OpenEdxEventsTestMixin):
 
 
 @skip_unless_lms
-class LoginSessionEventTest(UserAPITestCase, OpenEdxEventsTestMixin):
+class LoginSessionEventTest(OpenEdxEventsTestMixin, UserAPITestCase):
     """
     Tests for the Open edX Events associated with the login process through the
     login_user view.
@@ -117,17 +104,6 @@ class LoginSessionEventTest(UserAPITestCase, OpenEdxEventsTestMixin):
     """
 
     ENABLED_OPENEDX_EVENTS = ["org.openedx.learning.auth.session.login.completed.v1"]
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()

--- a/openedx/core/djangoapps/user_authn/views/tests/test_events.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_events.py
@@ -13,7 +13,7 @@ from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imp
 from django.urls import reverse
 from openedx_events.learning.data import UserData, UserPersonalData
 from openedx_events.learning.signals import SESSION_LOGIN_COMPLETED, STUDENT_REGISTRATION_COMPLETED
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 
 from common.djangoapps.student.tests.factories import UserFactory, UserProfileFactory
 from common.test.utils import assert_dict_contains_subset

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -53,7 +53,7 @@ from openedx.features.enterprise_support.tests.factories import EnterpriseCustom
     ENABLE_AUTHN_LOGIN_BLOCK_HIBP_POLICY=False,
     ENABLE_AUTHN_LOGIN_NUDGE_HIBP_POLICY=False,
 )
-class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
+class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
     """
     Test login_user() view
     """
@@ -66,17 +66,6 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
     username = 'test'
     user_email = 'test@edx.org'
     password = 'test_password'
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         """Setup a test user along with its registration and profile"""
@@ -1046,7 +1035,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
 
 @ddt.ddt
 @skip_unless_lms
-class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
+class LoginSessionViewTest(OpenEdxEventsTestMixin, ApiTestCase):
     """Tests for the login end-points of the user API. """
 
     ENABLED_OPENEDX_EVENTS = []
@@ -1054,17 +1043,6 @@ class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
     USERNAME = "bob"
     EMAIL = "bob@example.com"
     PASSWORD = "password"
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -21,7 +21,7 @@ from django.test.utils import override_settings
 from django.urls import NoReverseMatch, reverse
 from edx_toggles.toggles.testutils import override_waffle_switch
 from freezegun import freeze_time
-from openedx_events.tests.utils import OpenEdxEventsTestMixin  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx_events.testing import OpenEdxEventsTestMixin  # lint-amnesty, pylint: disable=wrong-import-order
 
 from common.djangoapps.student.models import LoginFailures
 from common.djangoapps.student.tests.factories import RegistrationFactory, UserFactory, UserProfileFactory

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -74,7 +74,7 @@ ENABLE_AUTO_GENERATED_USERNAME['ENABLE_AUTO_GENERATED_USERNAME'] = True
 @ddt.ddt
 @skip_unless_lms
 class RegistrationViewValidationErrorTest(
-    ThirdPartyAuthTestMixin, UserAPITestCase, RetirementTestCase, OpenEdxEventsTestMixin
+    OpenEdxEventsTestMixin, ThirdPartyAuthTestMixin, UserAPITestCase, RetirementTestCase
 ):
     """
     Tests for catching duplicate email and username validation errors within
@@ -95,17 +95,6 @@ class RegistrationViewValidationErrorTest(
     CITY = "Springfield"
     COUNTRY = "US"
     GOALS = "Learn all the things!"
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()
@@ -497,7 +486,7 @@ class RegistrationViewValidationErrorTest(
 @ddt.ddt
 @skip_unless_lms
 class RegistrationViewTestV1(
-    ThirdPartyAuthTestMixin, UserAPITestCase, OpenEdxEventsTestMixin
+    OpenEdxEventsTestMixin, ThirdPartyAuthTestMixin, UserAPITestCase
 ):
     """Tests for the registration end-points of the User API. """
 
@@ -562,17 +551,6 @@ class RegistrationViewTestV1(
         }
     ]
     link_template = "<a href='/honor' rel='noopener' target='_blank'>{link_label}</a>"
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()
@@ -2077,17 +2055,6 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
 
     # pylint: disable=test-inherits-tests
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
-
     def setUp(self):  # pylint: disable=arguments-differ
         super(RegistrationViewTestV1, self).setUp()  # lint-amnesty, pylint: disable=bad-super-call
         self.url = reverse("user_api_registration_v2")
@@ -2513,7 +2480,7 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
 @httpretty.activate
 @ddt.ddt
 class ThirdPartyRegistrationTestMixin(
-    ThirdPartyOAuthTestMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin
+    OpenEdxEventsTestMixin, ThirdPartyOAuthTestMixin, CacheIsolationTestCase
 ):
     """
     Tests for the User API registration endpoint with 3rd party authentication.
@@ -2525,17 +2492,6 @@ class ThirdPartyRegistrationTestMixin(
     ENABLED_CACHES = ['default']
 
     __test__ = False
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()
@@ -2731,24 +2687,13 @@ class ThirdPartyRegistrationTestMixin(
 
 @skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
 class TestFacebookRegistrationView(
-    ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinFacebook, TransactionTestCase, OpenEdxEventsTestMixin
+    OpenEdxEventsTestMixin, ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinFacebook, TransactionTestCase
 ):
     """Tests the User API registration endpoint with Facebook authentication."""
 
     ENABLED_OPENEDX_EVENTS = []
 
     __test__ = True
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def test_social_auth_exception(self):
         """
@@ -2763,7 +2708,7 @@ class TestFacebookRegistrationView(
 
 @skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
 class TestGoogleRegistrationView(
-    ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinGoogle, TransactionTestCase, OpenEdxEventsTestMixin
+    OpenEdxEventsTestMixin, ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinGoogle, TransactionTestCase
 ):
     """Tests the User API registration endpoint with Google authentication."""
 
@@ -2771,20 +2716,9 @@ class TestGoogleRegistrationView(
 
     __test__ = True
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
-
 
 @ddt.ddt
-class RegistrationValidationViewTests(test_utils.ApiTestCase, OpenEdxEventsTestMixin):
+class RegistrationValidationViewTests(OpenEdxEventsTestMixin, test_utils.ApiTestCase):
     """
     Tests for validity of user data in registration forms.
     """
@@ -2793,17 +2727,6 @@ class RegistrationValidationViewTests(test_utils.ApiTestCase, OpenEdxEventsTestM
 
     endpoint_name = 'registration_validation'
     path = reverse(endpoint_name)
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -2687,7 +2687,7 @@ class ThirdPartyRegistrationTestMixin(
 
 @skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
 class TestFacebookRegistrationView(
-    OpenEdxEventsTestMixin, ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinFacebook, TransactionTestCase
+    ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinFacebook, TransactionTestCase
 ):
     """Tests the User API registration endpoint with Facebook authentication."""
 
@@ -2708,7 +2708,7 @@ class TestFacebookRegistrationView(
 
 @skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
 class TestGoogleRegistrationView(
-    OpenEdxEventsTestMixin, ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinGoogle, TransactionTestCase
+    ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinGoogle, TransactionTestCase
 ):
     """Tests the User API registration endpoint with Google authentication."""
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -16,7 +16,7 @@ from django.test import TransactionTestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 from social_django.models import Partial, UserSocialAuth
 from testfixtures import LogCapture
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -842,7 +842,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/kernel.in
-openedx-events==11.1.0
+openedx-events==11.1.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1402,7 +1402,7 @@ openedx-django-wiki==3.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-events==11.1.0
+openedx-events==11.1.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1021,7 +1021,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/base.txt
-openedx-events==11.1.0
+openedx-events==11.1.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1068,7 +1068,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/base.txt
-openedx-events==11.1.0
+openedx-events==11.1.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -33,7 +33,7 @@ from openedx_events.content_authoring.signals import (
     XBLOCK_PUBLISHED,
     XBLOCK_UPDATED,
 )
-from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx_events.testing import OpenEdxEventsTestMixin
 from web_fragments.fragment import Fragment
 from xblock.core import XBlockAside
 from xblock.fields import Scope, ScopeIds, String

--- a/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -69,7 +69,7 @@ if not settings.configured:
 log = logging.getLogger(__name__)
 
 
-class CommonMixedModuleStoreSetup(CourseComparisonTest, OpenEdxEventsTestMixin):
+class CommonMixedModuleStoreSetup(OpenEdxEventsTestMixin, CourseComparisonTest):
     """
     Quasi-superclass which tests Location based apps against both split and mongo dbs (Locator and
     Location-based dbs)
@@ -122,16 +122,6 @@ class CommonMixedModuleStoreSetup(CourseComparisonTest, OpenEdxEventsTestMixin):
         "org.openedx.content_authoring.xblock.deleted.v1",
         "org.openedx.content_authoring.xblock.published.v1",
     ]
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Set up class method for the Test class.
-        This method starts manually events isolation. Explanation here:
-        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
-        """
-        super().setUpClass()
-        cls.start_events_isolation()
 
     def setUp(self):
         """


### PR DESCRIPTION
## Summary

These fixes address two pre-existing test isolation bugs that were exposed when rebalancing the CI test shards (openedx/openedx-platform#38287). They are independent of the rebalancing work and safe to merge now.

### Bug 1: `SharedModuleStoreTestCase` misuse in certificate tests

Three certificate test classes called `CourseFactory()` in `setUp()` instead of `setUpClass()`. With `SharedModuleStoreTestCase`, the modulestore is shared across all tests in the class and connections are only closed at `tearDownClass`. Calling `CourseFactory()` in `setUp()` accumulated open MongoDB connections across every test method, eventually exhausting file descriptors when run in the same process as other tests.

Fixed in `test_filters.py` and `test_models.py` — moved `CourseFactory()` to `setUpClass()` in `CertificateFiltersTest`, `CertificateInvalidationTest`, and `CertificateAllowlistTest`. Safe because tests only read the course from MongoDB; per-test data (enrollments, certificates) is in the Django ORM and is rolled back between tests.

### Bug 2: `OpenEdxEventsTestMixin` leaving events globally disabled

`OpenEdxEventsTestMixin.setUpClass()` called `disable_all_events()` then enabled only `ENABLED_OPENEDX_EVENTS`, but had no `tearDownClass` to restore event state. Certificate test classes with `ENABLED_OPENEDX_EVENTS = []` left all OpenEdX events globally disabled for subsequent tests in the same process.

Fixed upstream in openedx/openedx-events#559 (released as 11.1.1). This PR updates to 11.1.1 and cleans up the interim workarounds (manual `tearDownClass` overrides and duplicate mixin includes) from the affected test classes.