### PR TITLE
feat: add authz permission to search_reindex endpoint

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -31,7 +31,7 @@ from opaque_keys.edx.locator import BlockUsageLocator
 from openedx_authz.api import get_scopes_for_user_and_permission
 from openedx_authz.api.data import CourseOverviewData, OrgCourseOverviewGlobData, ScopeData
 from openedx_authz.constants.permissions import (
-    COURSES_CREATE_COURSE,
+    COURSES_PUBLISH_COURSE_CONTENT,
     COURSES_MANAGE_COURSE_UPDATES,
     COURSES_MANAGE_GROUP_CONFIGURATIONS,
     COURSES_MANAGE_PAGES_AND_RESOURCES,
@@ -193,7 +193,7 @@ def reindex_course_and_check_access(course_key, user):
     """
     if not user_has_course_permission(
         user=user,
-        authz_permission=COURSES_CREATE_COURSE.identifier,
+        authz_permission=COURSES_PUBLISH_COURSE_CONTENT.identifier,
         course_key=course_key,
         legacy_permission=LegacyAuthoringPermission.WRITE
     ):
@@ -375,9 +375,9 @@ def course_search_index_handler(request, course_key_string):
     course_key = CourseKey.from_string(course_key_string)
     is_authz_enabled = core_toggles.AUTHZ_COURSE_AUTHORING_FLAG.is_enabled(course_key)
     if not is_authz_enabled and not GlobalStaff().has_user(request.user):
-        # Under AuthZ, users with course authoring permissions can index courses,
-        # so no staff check is necessary.
-        # Under the legacy system, only global staff (PMs) can index courses.
+        # When AuthZ is disabled, restrict to global staff (legacy behavior).
+        # When AuthZ is enabled, access control is enforced by the AuthZ layer,
+        # which includes staff/superuser checks and course-level permissions.
         raise PermissionDenied()
     content_type = request.META.get('CONTENT_TYPE', None)
     if content_type is None:

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -31,6 +31,7 @@ from opaque_keys.edx.locator import BlockUsageLocator
 from openedx_authz.api import get_scopes_for_user_and_permission
 from openedx_authz.api.data import CourseOverviewData, OrgCourseOverviewGlobData, ScopeData
 from openedx_authz.constants.permissions import (
+    COURSES_CREATE_COURSE,
     COURSES_MANAGE_COURSE_UPDATES,
     COURSES_MANAGE_GROUP_CONFIGURATIONS,
     COURSES_MANAGE_PAGES_AND_RESOURCES,
@@ -56,7 +57,6 @@ from common.djangoapps.course_action_state.managers import CourseActionStateItem
 from common.djangoapps.course_action_state.models import CourseRerunState, CourseRerunUIStateManager
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import (
-    has_course_author_access,
     has_studio_advanced_settings_access,
     has_studio_read_access,
     has_studio_write_access,
@@ -191,7 +191,12 @@ def reindex_course_and_check_access(course_key, user):
     """
     Internal method used to restart indexing on a course.
     """
-    if not has_course_author_access(user, course_key):
+    if not user_has_course_permission(
+        user=user,
+        authz_permission=COURSES_CREATE_COURSE.identifier,
+        course_key=course_key,
+        legacy_permission=LegacyAuthoringPermission.WRITE
+    ):
         raise PermissionDenied()
     return CoursewareSearchIndexer.do_course_reindex(modulestore(), course_key)
 
@@ -368,9 +373,13 @@ def course_search_index_handler(request, course_key_string):
         json: return status of indexing task
     """
     # Only global staff (PMs) are able to index courses
-    if not GlobalStaff().has_user(request.user):
-        raise PermissionDenied()
     course_key = CourseKey.from_string(course_key_string)
+    is_authz_enabled = core_toggles.AUTHZ_COURSE_AUTHORING_FLAG.is_enabled(course_key)
+    if not is_authz_enabled:
+        # Fallback to legacy permission check if authz flag
+        # is not enabled for this course
+        if not GlobalStaff().has_user(request.user):
+            raise PermissionDenied()
     content_type = request.META.get('CONTENT_TYPE', None)
     if content_type is None:
         content_type = "application/json; charset=utf-8"

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -372,12 +372,12 @@ def course_search_index_handler(request, course_key_string):
         html: return status of indexing task
         json: return status of indexing task
     """
-    # Only global staff (PMs) are able to index courses
     course_key = CourseKey.from_string(course_key_string)
     is_authz_enabled = core_toggles.AUTHZ_COURSE_AUTHORING_FLAG.is_enabled(course_key)
     if not is_authz_enabled:
-        # Fallback to legacy permission check if authz flag
-        # is not enabled for this course
+        # Under AuthZ, users with course authoring permissions can index courses,
+        # so no staff check is necessary.
+        # Under the legacy system, only global staff (PMs) can index courses.
         if not GlobalStaff().has_user(request.user):
             raise PermissionDenied()
     content_type = request.META.get('CONTENT_TYPE', None)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -374,12 +374,11 @@ def course_search_index_handler(request, course_key_string):
     """
     course_key = CourseKey.from_string(course_key_string)
     is_authz_enabled = core_toggles.AUTHZ_COURSE_AUTHORING_FLAG.is_enabled(course_key)
-    if not is_authz_enabled:
+    if not is_authz_enabled and not GlobalStaff().has_user(request.user):
         # Under AuthZ, users with course authoring permissions can index courses,
         # so no staff check is necessary.
         # Under the legacy system, only global staff (PMs) can index courses.
-        if not GlobalStaff().has_user(request.user):
-            raise PermissionDenied()
+        raise PermissionDenied()
     content_type = request.META.get('CONTENT_TYPE', None)
     if content_type is None:
         content_type = "application/json; charset=utf-8"

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -31,10 +31,10 @@ from opaque_keys.edx.locator import BlockUsageLocator
 from openedx_authz.api import get_scopes_for_user_and_permission
 from openedx_authz.api.data import CourseOverviewData, OrgCourseOverviewGlobData, ScopeData
 from openedx_authz.constants.permissions import (
-    COURSES_PUBLISH_COURSE_CONTENT,
     COURSES_MANAGE_COURSE_UPDATES,
     COURSES_MANAGE_GROUP_CONFIGURATIONS,
     COURSES_MANAGE_PAGES_AND_RESOURCES,
+    COURSES_PUBLISH_COURSE_CONTENT,
     COURSES_VIEW_COURSE,
     COURSES_VIEW_COURSE_UPDATES,
     COURSES_VIEW_PAGES_AND_RESOURCES,

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -11,8 +11,8 @@ import ddt
 import pytz
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext as _
-from search.api import perform_search
 from openedx_authz.constants.roles import COURSE_STAFF
+from search.api import perform_search
 
 from cms.djangoapps.contentstore.courseware_index import CoursewareSearchIndexer, SearchIndexingError
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -623,7 +623,6 @@ class TestCourseReIndexAuthz(CourseAuthoringAuthzTestMixin, CourseTestCase):
             self.course.id
         )
         response = self.non_staff_client.get(self.url, HTTP_ACCEPT='application/json')
-
         assert not self.non_staff_user.is_staff
         assert response.status_code == 200
         assert self.SUCCESSFUL_RESPONSE in response.content.decode()

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -611,12 +611,3 @@ class TestCourseReIndexAuthz(CourseAuthoringAuthzTestMixin, CourseTestCase):
 
         assert not self.non_staff_user.is_staff
         assert response.status_code == 403
-
-    def test_empty_content_type(self):
-        """ Verify that content type is set to json if empty string is passed. """
-
-        response = self.client.get(self.url, CONTENT_TYPE='')
-
-        assert self.user.is_staff
-        assert response.status_code == 200
-        assert self.SUCCESSFUL_RESPONSE in response.content.decode()

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -14,10 +14,11 @@ from django.utils.translation import gettext as _
 from search.api import perform_search
 
 from cms.djangoapps.contentstore.courseware_index import CoursewareSearchIndexer, SearchIndexingError
-from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import VisibilityState, create_xblock_info
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
@@ -541,3 +542,81 @@ class TestCourseReIndex(CourseTestCase):
         # Start manual reindex and check error in response
         with self.assertRaises(SearchIndexingError):  # noqa: PT027
             CoursewareSearchIndexer.do_course_reindex(modulestore(), self.course.id)
+
+
+class TestCourseReIndexAuthz(CourseAuthoringAuthzTestMixin, CourseTestCase):
+    """
+    AuthZ-based tests for course reindex.
+    """
+
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+    SUCCESSFUL_RESPONSE = _("Course has been successfully reindexed.")
+    ENABLED_SIGNALS = ['course_published']
+
+    @mock.patch(
+        'cms.djangoapps.contentstore.signals.handlers.transaction.on_commit',
+        new=mock.Mock(side_effect=lambda func: func()),
+    )
+    def setUp(self):
+        super().setUp()
+
+        self.url = reverse_course_url('course_search_index_handler', self.course.id)
+
+        self.non_staff_client = AjaxEnabledTestClient()
+        self.non_staff_user, self.non_staff_password = self.create_non_staff_user()
+        self.non_staff_client.login(username=self.non_staff_user.username, password=self.non_staff_password)
+
+        self.course.start = datetime.datetime(2014, 1, 1, tzinfo=pytz.utc)
+        modulestore().update_item(self.course, self.user.id)
+
+        self.chapter = BlockFactory.create(
+            parent_location=self.course.location,
+            category='chapter',
+            display_name="Week 1"
+        )
+        self.sequential = BlockFactory.create(
+            parent_location=self.chapter.location,
+            category='sequential',
+            display_name="Lesson 1"
+        )
+        self.vertical = BlockFactory.create(
+            parent_location=self.sequential.location,
+            category='vertical',
+            display_name='Subsection 1'
+        )
+        self.video = BlockFactory.create(
+            parent_location=self.vertical.location,
+            category="video",
+            display_name="My Video"
+        )
+        self.html = BlockFactory.create(
+            parent_location=self.vertical.location,
+            category="html",
+            display_name="My HTML",
+            data="<div>This is my unique HTML content</div>",
+        )
+
+    def test_staff_user_can_reindex(self):
+        """ Verify that staff user can reindex the course. """
+
+        response = self.client.get(self.url, HTTP_ACCEPT='application/json')
+
+        assert self.user.is_staff
+        assert response.status_code == 200
+        assert self.SUCCESSFUL_RESPONSE in response.content.decode()
+
+    def test_non_staff_user_cannot_reindex(self):
+        """ Verify that non-staff user without course authoring permissions cannot reindex the course. """
+        response = self.non_staff_client.get(self.url, HTTP_ACCEPT='application/json')
+
+        assert not self.non_staff_user.is_staff
+        assert response.status_code == 403
+
+    def test_empty_content_type(self):
+        """ Verify that content type is set to json if empty string is passed. """
+
+        response = self.client.get(self.url, CONTENT_TYPE='')
+
+        assert self.user.is_staff
+        assert response.status_code == 200
+        assert self.SUCCESSFUL_RESPONSE in response.content.decode()

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -12,6 +12,7 @@ import pytz
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext as _
 from search.api import perform_search
+from openedx_authz.constants.roles import COURSE_STAFF
 
 from cms.djangoapps.contentstore.courseware_index import CoursewareSearchIndexer, SearchIndexingError
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase
@@ -611,3 +612,18 @@ class TestCourseReIndexAuthz(CourseAuthoringAuthzTestMixin, CourseTestCase):
 
         assert not self.non_staff_user.is_staff
         assert response.status_code == 403
+
+    def test_non_staff_user_can_reindex(self):
+        """ Verify that non-staff user with course authoring permissions can reindex the course. """
+
+        # Grant access helper
+        self.add_user_to_role_in_course(
+            self.non_staff_user,
+            COURSE_STAFF.external_key,
+            self.course.id
+        )
+        response = self.non_staff_client.get(self.url, HTTP_ACCEPT='application/json')
+
+        assert not self.non_staff_user.is_staff
+        assert response.status_code == 200
+        assert self.SUCCESSFUL_RESPONSE in response.content.decode()

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -256,7 +256,8 @@ def _has_content_creator_access(user, org):
     """
     if settings.FEATURES.get('DISABLE_COURSE_CREATION', False):
         return False
-    org_scope_key = f"course-v1:{org}+*"
+    # Using Org scope. e.g. "course-v1:{org}+*"
+    org_scope_key = authz_api.OrgCourseOverviewGlobData.build_external_key(org)
 
     return authz_api.is_user_allowed(
         user.username,

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -828,7 +828,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.8.0
+openedx-authz==1.11.0
     # via -r requirements/edx/kernel.in
 openedx-calc==5.0.0
     # via

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -828,7 +828,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.5.0
+openedx-authz==1.8.0
     # via -r requirements/edx/kernel.in
 openedx-calc==5.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1377,7 +1377,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.8.0
+openedx-authz==1.11.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1377,7 +1377,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.5.0
+openedx-authz==1.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1005,7 +1005,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.8.0
+openedx-authz==1.11.0
     # via -r requirements/edx/base.txt
 openedx-calc==5.0.0
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1005,7 +1005,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.5.0
+openedx-authz==1.8.0
     # via -r requirements/edx/base.txt
 openedx-calc==5.0.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1052,7 +1052,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.5.0
+openedx-authz==1.8.0
     # via -r requirements/edx/base.txt
 openedx-calc==5.0.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1052,7 +1052,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.8.0
+openedx-authz==1.11.0
     # via -r requirements/edx/base.txt
 openedx-calc==5.0.0
     # via


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds authorization enforcement to the search reindex endpoint as part of the course list page permissions work.

The original ticket introduced new permissions behind a feature flag for multiple course-related endpoints, but the following endpoint was not covered:

`GET /course/{course_id}/search_reindex/`

This change ensures the endpoint is now protected and aligned with the overall AuthZ strategy.

**Changes**

- Enforce AuthZ permission on search_reindex endpoint
- Guard the behavior behind the existing feature flag
- Keep consistency with previously implemented course-level permission

**Permission Applied**

`courses.create_course`

This permission is currently used as the closest available match for restricting access to this operation, ensuring that only authorized users can trigger a reindex.

## Supporting information

This PR completes the missing piece from the ticket: https://github.com/openedx/openedx-platform/issues/38129

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

Verawood

## Other information

Closes:
