### PR TITLE
feat: Add special exams v2 API to instructor dashboard

### DIFF
--- a/lms/djangoapps/instructor/docs/references/instructor-v2-special-exams-api-spec.yaml
+++ b/lms/djangoapps/instructor/docs/references/instructor-v2-special-exams-api-spec.yaml
@@ -1,0 +1,661 @@
+swagger: '2.0'
+info:
+  title: Instructor Dashboard Special Exams API v2
+  version: 2.0.0
+  description: |
+    REST API for managing proctored and timed exams in the Instructor Dashboard.
+    Designed to support the Instructor Dashboard Micro-Frontend (MFE).
+
+    **Design Principles:**
+    - RESTful resource-oriented URLs
+    - Course-scoped endpoints
+    - Delegation to edx_proctoring plugin
+    - Centralized permission checks
+    - Consistent error handling
+
+host: courses.example.com
+basePath: /
+schemes:
+  - https
+
+securityDefinitions:
+  JWTAuth:
+    type: apiKey
+    in: header
+    name: Authorization
+    description: JWT token authentication (e.g. `JWT <token>`).
+
+security:
+  - JWTAuth: []
+
+tags:
+  - name: Special Exams
+    description: Proctored and timed exam management
+  - name: Proctoring Settings
+    description: Course proctoring configuration
+
+paths:
+  /api/instructor/v2/courses/{course_id}/special_exams:
+    get:
+      tags:
+        - Special Exams
+      summary: List all special exams in a course
+      description: |
+        Retrieve all proctored and timed exams for the specified course.
+        Supports filtering by exam type.
+      operationId: listSpecialExams
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseId'
+        - name: exam_type
+          in: query
+          required: false
+          type: string
+          enum: [proctored, timed, practice]
+          description: Filter by exam type
+      responses:
+        200:
+          description: List of special exams
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/SpecialExam'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+
+  /api/instructor/v2/courses/{course_id}/special_exams/{exam_id}:
+    get:
+      tags:
+        - Special Exams
+      summary: Get special exam details
+      description: |
+        Retrieve details for a specific proctored or timed exam.
+      operationId: getSpecialExam
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseId'
+        - $ref: '#/parameters/ExamId'
+      responses:
+        200:
+          description: Exam details
+          schema:
+            $ref: '#/definitions/SpecialExam'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+        404:
+          $ref: '#/responses/NotFound'
+
+  /api/instructor/v2/courses/{course_id}/special_exams/{exam_id}/reset/{username}:
+    post:
+      tags:
+        - Special Exams
+      summary: Reset a student's exam attempt
+      description: |
+        Reset a student's proctored exam attempt, removing the attempt record
+        and clearing platform-side state.
+      operationId: resetExamAttempt
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseId'
+        - $ref: '#/parameters/ExamId'
+        - name: username
+          in: path
+          required: true
+          type: string
+          description: Student's username
+      responses:
+        200:
+          description: Attempt reset successfully
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+              message:
+                type: string
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+        404:
+          $ref: '#/responses/NotFound'
+
+  /api/instructor/v2/courses/{course_id}/special_exams/{exam_id}/attempts:
+    get:
+      tags:
+        - Special Exams
+      summary: List exam attempts
+      description: |
+        List all attempts for a specific proctored exam with review status.
+      operationId: listExamAttempts
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseId'
+        - $ref: '#/parameters/ExamId'
+      responses:
+        200:
+          description: List of exam attempts
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ExamAttempt'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+
+  /api/instructor/v2/courses/{course_id}/proctoring_settings:
+    get:
+      tags:
+        - Proctoring Settings
+      summary: Get proctoring settings
+      description: |
+        Retrieve proctoring configuration for the course.
+      operationId: getProctoringSettings
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseId'
+      responses:
+        200:
+          description: Proctoring settings
+          schema:
+            $ref: '#/definitions/ProctoringSettings'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+    patch:
+      tags:
+        - Proctoring Settings
+      summary: Update proctoring settings
+      description: |
+        Update proctoring settings for the course.
+      operationId: updateProctoringSettings
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseId'
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ProctoringSettingsUpdate'
+      responses:
+        200:
+          description: Settings updated
+          schema:
+            $ref: '#/definitions/ProctoringSettings'
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+
+  /api/instructor/v2/courses/{course_id}/special_exams/{exam_id}/allowance:
+    post:
+      tags:
+        - Special Exams
+      summary: Grant or update exam allowance
+      description: |
+        Grant or update a time extension or accommodation for a student on a proctored exam.
+        This is an upsert — if an allowance of the same type already exists for the user,
+        it will be updated with the new value.
+      operationId: grantExamAllowance
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseId'
+        - $ref: '#/parameters/ExamId'
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ExamAllowanceRequest'
+      responses:
+        200:
+          description: Allowance granted or updated
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+              message:
+                type: string
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+        404:
+          $ref: '#/responses/NotFound'
+    delete:
+      tags:
+        - Special Exams
+      summary: Remove exam allowance
+      description: |
+        Remove an allowance for a student on a proctored exam.
+      operationId: removeExamAllowance
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseId'
+        - $ref: '#/parameters/ExamId'
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ExamAllowanceDeleteRequest'
+      responses:
+        200:
+          description: Allowance removed
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+              message:
+                type: string
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+        404:
+          $ref: '#/responses/NotFound'
+
+  /api/instructor/v2/courses/{course_id}/special_exams/allowances:
+    get:
+      tags:
+        - Special Exams
+      summary: List all exam allowances for a course
+      description: |
+        Retrieve all exam allowances granted across all exams in the course.
+        Supports search by username or email and pagination.
+      operationId: listCourseAllowances
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseId'
+        - $ref: '#/parameters/Search'
+        - $ref: '#/parameters/Page'
+        - $ref: '#/parameters/PageSize'
+      responses:
+        200:
+          description: Paginated list of exam allowances
+          schema:
+            $ref: '#/definitions/PaginatedExamAllowanceList'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+    post:
+      tags:
+        - Special Exams
+      summary: Bulk-create allowances across multiple exams and users
+      description: |
+        Grant allowances for multiple users across multiple exams in a single request.
+      operationId: bulkCreateAllowances
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseId'
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/BulkAllowanceRequest'
+      responses:
+        200:
+          description: Bulk operation results
+          schema:
+            type: object
+            properties:
+              successes:
+                type: integer
+              failures:
+                type: integer
+              data:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    exam_id:
+                      type: integer
+                    user_id:
+                      type: string
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+
+  /api/instructor/v2/courses/{course_id}/special_exams/attempts:
+    get:
+      tags:
+        - Special Exams
+      summary: List all exam attempts for a course
+      description: |
+        Retrieve all exam attempts across all exams in the course.
+        Supports search by username or email and pagination.
+      operationId: listCourseExamAttempts
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/CourseId'
+        - $ref: '#/parameters/Search'
+        - $ref: '#/parameters/Page'
+        - $ref: '#/parameters/PageSize'
+      responses:
+        200:
+          description: Paginated list of exam attempts
+          schema:
+            $ref: '#/definitions/PaginatedExamAttemptList'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+
+parameters:
+  CourseId:
+    name: course_id
+    in: path
+    required: true
+    description: Course identifier in format `course-v1:{org}+{course}+{run}`
+    type: string
+    x-example: "course-v1:edX+DemoX+Demo_Course"
+
+  ExamId:
+    name: exam_id
+    in: path
+    required: true
+    description: Proctored exam identifier
+    type: integer
+    x-example: 1
+
+  Search:
+    name: search
+    in: query
+    required: false
+    description: Filter by username or email (case-insensitive partial match)
+    type: string
+    x-example: "student1"
+
+  Page:
+    name: page
+    in: query
+    required: false
+    description: Page number for pagination
+    type: integer
+    x-example: 1
+
+  PageSize:
+    name: page_size
+    in: query
+    required: false
+    description: Number of results per page
+    type: integer
+    x-example: 10
+
+responses:
+  BadRequest:
+    description: Bad request
+    schema:
+      $ref: '#/definitions/Error'
+
+  Unauthorized:
+    description: Authentication required
+    schema:
+      $ref: '#/definitions/Error'
+
+  Forbidden:
+    description: Insufficient permissions
+    schema:
+      $ref: '#/definitions/Error'
+
+  NotFound:
+    description: Resource not found
+    schema:
+      $ref: '#/definitions/Error'
+
+definitions:
+  SpecialExam:
+    type: object
+    properties:
+      id:
+        type: integer
+      course_id:
+        type: string
+      content_id:
+        type: string
+      exam_name:
+        type: string
+      time_limit_mins:
+        type: integer
+      due_date:
+        type: string
+        format: date-time
+        x-nullable: true
+      exam_type:
+        type: string
+      is_proctored:
+        type: boolean
+      is_practice_exam:
+        type: boolean
+      is_active:
+        type: boolean
+      hide_after_due:
+        type: boolean
+      backend:
+        type: string
+        x-nullable: true
+
+  ExamAttempt:
+    type: object
+    properties:
+      id:
+        type: integer
+      user:
+        type: object
+        properties:
+          id:
+            type: integer
+          username:
+            type: string
+          email:
+            type: string
+      exam_id:
+        type: integer
+      status:
+        type: string
+      start_time:
+        type: string
+        format: date-time
+        x-nullable: true
+      end_time:
+        type: string
+        format: date-time
+        x-nullable: true
+      allowed_time_limit_mins:
+        type: integer
+        x-nullable: true
+
+  ProctoringSettings:
+    type: object
+    properties:
+      proctoring_provider:
+        type: string
+        x-nullable: true
+      proctoring_escalation_email:
+        type: string
+        x-nullable: true
+      create_zendesk_tickets:
+        type: boolean
+      enable_proctored_exams:
+        type: boolean
+
+  ProctoringSettingsUpdate:
+    type: object
+    properties:
+      proctoring_escalation_email:
+        type: string
+      create_zendesk_tickets:
+        type: boolean
+      enable_proctored_exams:
+        type: boolean
+
+  ExamAllowanceRequest:
+    type: object
+    required:
+      - user_ids
+      - allowance_type
+      - value
+    properties:
+      user_ids:
+        type: array
+        items:
+          type: string
+        description: List of usernames or emails of the students
+      allowance_type:
+        type: string
+        description: Type of allowance (e.g. 'additional_time_granted')
+      value:
+        type: string
+        description: Allowance value
+
+  ExamAllowanceDeleteRequest:
+    type: object
+    required:
+      - user_ids
+      - allowance_type
+    properties:
+      user_ids:
+        type: array
+        items:
+          type: string
+        description: List of usernames, emails, or numeric user IDs
+      allowance_type:
+        type: string
+        description: Type of allowance to remove
+
+  BulkAllowanceRequest:
+    type: object
+    required:
+      - exam_ids
+      - user_ids
+      - allowance_type
+      - value
+    properties:
+      exam_ids:
+        type: array
+        items:
+          type: integer
+        description: List of exam IDs
+      user_ids:
+        type: array
+        items:
+          type: string
+        description: List of usernames or emails of the students
+      allowance_type:
+        type: string
+        description: Type of allowance (e.g. 'additional_time_granted')
+      value:
+        type: string
+        description: Allowance value
+
+  ExamAllowance:
+    type: object
+    properties:
+      id:
+        type: integer
+      created:
+        type: string
+        format: date-time
+      modified:
+        type: string
+        format: date-time
+      user:
+        type: object
+        properties:
+          id:
+            type: integer
+          username:
+            type: string
+          email:
+            type: string
+      key:
+        type: string
+        description: Allowance type key
+      value:
+        type: string
+        description: Allowance value
+      proctored_exam:
+        $ref: '#/definitions/SpecialExam'
+
+  PaginatedExamAllowanceList:
+    type: object
+    properties:
+      count:
+        type: integer
+      next:
+        type: string
+        format: uri
+        x-nullable: true
+      previous:
+        type: string
+        format: uri
+        x-nullable: true
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/ExamAllowance'
+
+  PaginatedExamAttemptList:
+    type: object
+    properties:
+      count:
+        type: integer
+      next:
+        type: string
+        format: uri
+        x-nullable: true
+      previous:
+        type: string
+        format: uri
+        x-nullable: true
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/ExamAttempt'
+
+  Error:
+    type: object
+    properties:
+      error:
+        type: string
+      message:
+        type: string
+      status_code:
+        type: integer

--- a/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
@@ -245,9 +245,9 @@ class SpecialExamAttemptsViewTest(ModuleStoreTestCase):
         response = self.client.get(self._url())
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert len(data) == 1
-        assert data[0]['exam_id'] == self.exam_id
-        assert data[0]['user']['username'] == 'student1'
+        assert data['count'] == 1
+        assert data['results'][0]['exam_id'] == self.exam_id
+        assert data['results'][0]['user']['username'] == 'student1'
 
     def test_list_attempts_filters_by_exam(self):
         """Only attempts for the requested exam_id are returned."""
@@ -264,8 +264,8 @@ class SpecialExamAttemptsViewTest(ModuleStoreTestCase):
 
         response = self.client.get(self._url())
         data = response.json()
-        assert len(data) == 1
-        assert data[0]['exam_id'] == self.exam_id
+        assert data['count'] == 1
+        assert data['results'][0]['exam_id'] == self.exam_id
 
 
 @override_settings(**PROCTORING_SETTINGS)

--- a/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
@@ -1,0 +1,591 @@
+"""
+Tests for Instructor API v2 Special Exams endpoints.
+"""
+from unittest.mock import patch
+
+import ddt
+from django.conf import settings
+from django.test.utils import override_settings
+from django.urls import reverse
+from edx_proctoring.api import (
+    add_allowance_for_user,
+    create_exam,
+    create_exam_attempt,
+)
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from common.djangoapps.student.tests.factories import InstructorFactory, UserFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+PROCTORING_SETTINGS = {
+    'PROCTORING_BACKENDS': {
+        'DEFAULT': 'null',
+        'null': {},
+    },
+}
+
+
+@override_settings(**PROCTORING_SETTINGS)
+@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+@ddt.ddt
+class SpecialExamsListViewTest(ModuleStoreTestCase):
+    """Tests for GET /api/instructor/v2/courses/{course_key}/special_exams"""
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.course = CourseFactory.create(enable_proctored_exams=True)
+        self.instructor = InstructorFactory.create(course_key=self.course.id)
+        self.client.force_authenticate(user=self.instructor)
+        self.course_id = str(self.course.id)
+        self.timed_exam_id = create_exam(
+            course_id=self.course_id,
+            content_id='block-v1:test+test+test+type@sequential+block@timed',
+            exam_name='Timed Exam',
+            time_limit_mins=60,
+            is_proctored=False,
+        )
+        self.proctored_exam_id = create_exam(
+            course_id=self.course_id,
+            content_id='block-v1:test+test+test+type@sequential+block@proctored',
+            exam_name='Proctored Exam',
+            time_limit_mins=90,
+            is_proctored=True,
+        )
+        self.practice_exam_id = create_exam(
+            course_id=self.course_id,
+            content_id='block-v1:test+test+test+type@sequential+block@practice',
+            exam_name='Practice Exam',
+            time_limit_mins=30,
+            is_proctored=True,
+            is_practice_exam=True,
+        )
+
+    def _url(self):
+        return reverse('instructor_api_v2:special_exams_list', kwargs={
+            'course_id': self.course_id,
+        })
+
+    def test_list_exams(self):
+        response = self.client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 3
+        exams_by_name = {e['exam_name']: e for e in data}
+
+        timed = exams_by_name['Timed Exam']
+        assert timed['id'] == self.timed_exam_id
+        assert timed['course_id'] == self.course_id
+        assert timed['content_id'] == 'block-v1:test+test+test+type@sequential+block@timed'
+        assert timed['time_limit_mins'] == 60
+        assert timed['is_proctored'] is False
+        assert timed['is_practice_exam'] is False
+        assert timed['is_active'] is True
+        assert timed['hide_after_due'] is False
+
+        proctored = exams_by_name['Proctored Exam']
+        assert proctored['id'] == self.proctored_exam_id
+        assert proctored['time_limit_mins'] == 90
+        assert proctored['is_proctored'] is True
+        assert proctored['is_practice_exam'] is False
+
+        practice = exams_by_name['Practice Exam']
+        assert practice['id'] == self.practice_exam_id
+        assert practice['time_limit_mins'] == 30
+        assert practice['is_proctored'] is True
+        assert practice['is_practice_exam'] is True
+
+    def test_unauthenticated(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.get(self._url())
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_unauthorized_student(self):
+        student = UserFactory()
+        self.client.force_authenticate(user=student)
+        response = self.client.get(self._url())
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @ddt.data(
+        ('timed', 'Timed Exam'),
+        ('proctored', 'Proctored Exam'),
+        ('practice', 'Practice Exam'),
+    )
+    @ddt.unpack
+    def test_filter_by_exam_type(self, exam_type, expected_name):
+        response = self.client.get(self._url(), {'exam_type': exam_type})
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]['exam_name'] == expected_name
+
+
+@override_settings(**PROCTORING_SETTINGS)
+@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+class SpecialExamDetailViewTest(ModuleStoreTestCase):
+    """Tests for GET /api/instructor/v2/courses/{course_key}/special_exams/{exam_id}"""
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.course = CourseFactory.create(enable_proctored_exams=True)
+        self.instructor = InstructorFactory.create(course_key=self.course.id)
+        self.client.force_authenticate(user=self.instructor)
+        self.course_id = str(self.course.id)
+        self.exam_id = create_exam(
+            course_id=self.course_id,
+            content_id='block-v1:test+test+test+type@sequential+block@exam1',
+            exam_name='Midterm Exam',
+            time_limit_mins=60,
+            is_proctored=False,
+        )
+
+    def _url(self, exam_id=None):
+        return reverse('instructor_api_v2:special_exam_detail', kwargs={
+            'course_id': self.course_id,
+            'exam_id': exam_id or self.exam_id,
+        })
+
+    def test_get_exam(self):
+        response = self.client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['exam_name'] == 'Midterm Exam'
+
+    def test_exam_not_found(self):
+        response = self.client.get(self._url(exam_id=99999))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_exam_wrong_course(self):
+        other_course = CourseFactory.create()
+        other_exam_id = create_exam(
+            course_id=str(other_course.id),
+            content_id='block-v1:other+other+other+type@sequential+block@exam1',
+            exam_name='Other Exam',
+            time_limit_mins=30,
+            is_proctored=False,
+        )
+        response = self.client.get(self._url(exam_id=other_exam_id))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@override_settings(**PROCTORING_SETTINGS)
+@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+class SpecialExamResetViewTest(ModuleStoreTestCase):
+    """Tests for POST /api/instructor/v2/courses/{course_key}/special_exams/{exam_id}/reset/{username}"""
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.course = CourseFactory.create(enable_proctored_exams=True)
+        self.instructor = InstructorFactory.create(course_key=self.course.id)
+        self.student = UserFactory(username='student1')
+        self.client.force_authenticate(user=self.instructor)
+        self.course_id = str(self.course.id)
+        self.exam_id = create_exam(
+            course_id=self.course_id,
+            content_id='block-v1:test+test+test+type@sequential+block@exam1',
+            exam_name='Midterm Exam',
+            time_limit_mins=60,
+            is_proctored=False,
+        )
+
+    def _url(self, exam_id=None, username='student1'):
+        return reverse('instructor_api_v2:special_exam_reset', kwargs={
+            'course_id': self.course_id,
+            'exam_id': exam_id or self.exam_id,
+            'username': username,
+        })
+
+    def test_reset_attempt(self):
+        create_exam_attempt(self.exam_id, self.student.id)
+        response = self.client.post(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['success'] is True
+
+    def test_reset_user_not_found(self):
+        response = self.client.post(self._url(username='nonexistent'))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_reset_no_attempts(self):
+        response = self.client.post(self._url())
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@override_settings(**PROCTORING_SETTINGS)
+@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+class SpecialExamAttemptsViewTest(ModuleStoreTestCase):
+    """Tests for GET /api/instructor/v2/courses/{course_key}/special_exams/{exam_id}/attempts"""
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.course = CourseFactory.create(enable_proctored_exams=True)
+        self.instructor = InstructorFactory.create(course_key=self.course.id)
+        self.student = UserFactory(username='student1', email='student1@example.com')
+        self.client.force_authenticate(user=self.instructor)
+        self.course_id = str(self.course.id)
+        self.exam_id = create_exam(
+            course_id=self.course_id,
+            content_id='block-v1:test+test+test+type@sequential+block@exam1',
+            exam_name='Midterm Exam',
+            time_limit_mins=60,
+            is_proctored=False,
+        )
+
+    def _url(self, exam_id=None):
+        return reverse('instructor_api_v2:special_exam_attempts', kwargs={
+            'course_id': self.course_id,
+            'exam_id': exam_id or self.exam_id,
+        })
+
+    def test_list_attempts(self):
+        create_exam_attempt(self.exam_id, self.student.id)
+        response = self.client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]['exam_id'] == self.exam_id
+        assert data[0]['user']['username'] == 'student1'
+
+    def test_list_attempts_filters_by_exam(self):
+        """Only attempts for the requested exam_id are returned."""
+        other_exam_id = create_exam(
+            course_id=self.course_id,
+            content_id='block-v1:test+test+test+type@sequential+block@exam2',
+            exam_name='Final Exam',
+            time_limit_mins=120,
+            is_proctored=False,
+        )
+        create_exam_attempt(self.exam_id, self.student.id)
+        other_student = UserFactory(username='student2')
+        create_exam_attempt(other_exam_id, other_student.id)
+
+        response = self.client.get(self._url())
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]['exam_id'] == self.exam_id
+
+
+@override_settings(**PROCTORING_SETTINGS)
+@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+class ProctoringSettingsViewTest(ModuleStoreTestCase):
+    """Tests for GET/PATCH /api/instructor/v2/courses/{course_key}/proctoring_settings"""
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.course = CourseFactory.create(
+            enable_proctored_exams=True,
+            proctoring_provider='null',
+        )
+        self.instructor = InstructorFactory.create(course_key=self.course.id)
+        self.client.force_authenticate(user=self.instructor)
+        self.course_id = str(self.course.id)
+
+    def _url(self):
+        return reverse('instructor_api_v2:proctoring_settings', kwargs={
+            'course_id': self.course_id,
+        })
+
+    def test_get_settings(self):
+        response = self.client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['enable_proctored_exams'] is True
+
+    def test_patch_settings(self):
+        response = self.client.patch(
+            self._url(),
+            data={'proctoring_escalation_email': 'proctor@example.com'},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['proctoring_escalation_email'] == 'proctor@example.com'
+
+    def test_patch_invalid_data(self):
+        response = self.client.patch(
+            self._url(),
+            data={'enable_proctored_exams': 'not_a_boolean'},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@override_settings(**PROCTORING_SETTINGS)
+@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+class ExamAllowanceViewTest(ModuleStoreTestCase):
+    """Tests for POST /api/instructor/v2/courses/{course_key}/special_exams/{exam_id}/allowance"""
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.course = CourseFactory.create(enable_proctored_exams=True)
+        self.instructor = InstructorFactory.create(course_key=self.course.id)
+        self.student = UserFactory(username='student1')
+        self.client.force_authenticate(user=self.instructor)
+        self.course_id = str(self.course.id)
+        self.exam_id = create_exam(
+            course_id=self.course_id,
+            content_id='block-v1:test+test+test+type@sequential+block@exam1',
+            exam_name='Midterm Exam',
+            time_limit_mins=60,
+            is_proctored=False,
+        )
+
+    def _url(self, exam_id=None):
+        return reverse('instructor_api_v2:exam_allowance', kwargs={
+            'course_id': self.course_id,
+            'exam_id': exam_id or self.exam_id,
+        })
+
+    def test_grant_allowance(self):
+        response = self.client.post(
+            self._url(),
+            data={
+                'user_ids': [self.student.username],
+                'allowance_type': 'additional_time_granted',
+                'value': '30',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['allowance_type'] == 'additional_time_granted'
+        assert len(data['results']) == 1
+        assert data['results'][0]['identifier'] == self.student.username
+        assert data['results'][0]['success'] is True
+
+    def test_grant_allowance_multiple_users(self):
+        student2 = UserFactory(username='student2')
+        response = self.client.post(
+            self._url(),
+            data={
+                'user_ids': [self.student.username, student2.username],
+                'allowance_type': 'additional_time_granted',
+                'value': '30',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data['results']) == 2
+        assert all(r['success'] is True for r in data['results'])
+
+    def test_grant_allowance_missing_fields(self):
+        response = self.client.post(
+            self._url(),
+            data={'user_ids': ['student1']},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_grant_allowance_exam_not_found(self):
+        response = self.client.post(
+            self._url(exam_id=99999),
+            data={
+                'user_ids': ['student1'],
+                'allowance_type': 'additional_time_granted',
+                'value': '30',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_update_allowance(self):
+        """POST is an upsert — calling it twice updates the existing allowance."""
+        self.client.post(
+            self._url(),
+            data={
+                'user_ids': [self.student.username],
+                'allowance_type': 'additional_time_granted',
+                'value': '30',
+            },
+            format='json',
+        )
+        response = self.client.post(
+            self._url(),
+            data={
+                'user_ids': [self.student.username],
+                'allowance_type': 'additional_time_granted',
+                'value': '60',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['results'][0]['success'] is True
+
+    def test_delete_allowance(self):
+        add_allowance_for_user(self.exam_id, self.student.username, 'additional_time_granted', '30')
+        response = self.client.delete(
+            self._url(),
+            data={
+                'user_ids': [self.student.username],
+                'allowance_type': 'additional_time_granted',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['allowance_type'] == 'additional_time_granted'
+        assert len(data['results']) == 1
+        assert data['results'][0]['success'] is True
+
+    def test_delete_allowance_multiple_users(self):
+        student2 = UserFactory(username='student2')
+        add_allowance_for_user(self.exam_id, self.student.username, 'additional_time_granted', '30')
+        add_allowance_for_user(self.exam_id, student2.username, 'additional_time_granted', '30')
+        response = self.client.delete(
+            self._url(),
+            data={
+                'user_ids': [self.student.username, student2.username],
+                'allowance_type': 'additional_time_granted',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()['results']) == 2
+        assert all(r['success'] is True for r in response.json()['results'])
+
+    def test_delete_allowance_missing_fields(self):
+        response = self.client.delete(
+            self._url(),
+            data={'user_ids': [self.student.username]},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@override_settings(**PROCTORING_SETTINGS)
+@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+class CourseAllowancesViewTest(ModuleStoreTestCase):
+    """Tests for GET /api/instructor/v2/courses/{course_key}/special_exams/allowances"""
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.course = CourseFactory.create(enable_proctored_exams=True)
+        self.instructor = InstructorFactory.create(course_key=self.course.id)
+        self.student = UserFactory(username='student1', email='student1@example.com')
+        self.client.force_authenticate(user=self.instructor)
+        self.course_id = str(self.course.id)
+        self.exam_id = create_exam(
+            course_id=self.course_id,
+            content_id='block-v1:test+test+test+type@sequential+block@exam1',
+            exam_name='Midterm Exam',
+            time_limit_mins=60,
+            is_proctored=False,
+        )
+
+    def _url(self):
+        return reverse('instructor_api_v2:course_allowances', kwargs={
+            'course_id': self.course_id,
+        })
+
+    def test_list_allowances(self):
+        add_allowance_for_user(self.exam_id, self.student.username, 'additional_time_granted', '30')
+        response = self.client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['count'] == 1
+        assert data['results'][0]['key'] == 'additional_time_granted'
+        assert data['results'][0]['user']['username'] == 'student1'
+
+    def test_list_allowances_empty(self):
+        response = self.client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['count'] == 0
+
+    def test_search_allowances_by_username(self):
+        add_allowance_for_user(self.exam_id, self.student.username, 'additional_time_granted', '30')
+        response = self.client.get(self._url(), {'search': 'student1'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['count'] == 1
+
+    def test_search_allowances_no_match(self):
+        add_allowance_for_user(self.exam_id, self.student.username, 'additional_time_granted', '30')
+        response = self.client.get(self._url(), {'search': 'nonexistent'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['count'] == 0
+
+    def test_bulk_create_allowances(self):
+        exam_id_2 = create_exam(
+            course_id=self.course_id,
+            content_id='block-v1:test+test+test+type@sequential+block@exam2',
+            exam_name='Final Exam',
+            time_limit_mins=120,
+            is_proctored=False,
+        )
+        student2 = UserFactory(username='student2')
+        response = self.client.post(
+            self._url(),
+            data={
+                'exam_ids': [self.exam_id, exam_id_2],
+                'user_ids': [self.student.username, student2.username],
+                'allowance_type': 'additional_time_granted',
+                'value': '30',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['allowance_type'] == 'additional_time_granted'
+        assert data['value'] == '30'
+        assert len(data['results']) == 4
+        assert all(r['success'] is True for r in data['results'])
+
+    def test_bulk_create_allowances_missing_fields(self):
+        response = self.client.post(
+            self._url(),
+            data={'exam_ids': [self.exam_id]},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@override_settings(**PROCTORING_SETTINGS)
+@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+class CourseExamAttemptsViewTest(ModuleStoreTestCase):
+    """Tests for GET /api/instructor/v2/courses/{course_key}/special_exams/attempts"""
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.course = CourseFactory.create(enable_proctored_exams=True)
+        self.instructor = InstructorFactory.create(course_key=self.course.id)
+        self.student = UserFactory(username='student1', email='student1@example.com')
+        self.client.force_authenticate(user=self.instructor)
+        self.course_id = str(self.course.id)
+        self.exam_id = create_exam(
+            course_id=self.course_id,
+            content_id='block-v1:test+test+test+type@sequential+block@exam1',
+            exam_name='Midterm Exam',
+            time_limit_mins=60,
+            is_proctored=False,
+        )
+
+    def _url(self):
+        return reverse('instructor_api_v2:course_exam_attempts', kwargs={
+            'course_id': self.course_id,
+        })
+
+    def test_list_all_attempts(self):
+        create_exam_attempt(self.exam_id, self.student.id)
+        response = self.client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['count'] == 1
+        assert data['results'][0]['exam_id'] == self.exam_id
+
+    def test_search_attempts_by_username(self):
+        create_exam_attempt(self.exam_id, self.student.id)
+        response = self.client.get(self._url(), {'search': 'student1'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['count'] == 1
+
+    def test_search_attempts_no_match(self):
+        create_exam_attempt(self.exam_id, self.student.id)
+        response = self.client.get(self._url(), {'search': 'nonexistent'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['count'] == 0

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -157,6 +157,47 @@ v2_api_urls = [
         api_v2.ScoreOverrideView.as_view(),
         name='score_override'
     ),
+    # Special Exams endpoints
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/special_exams$',
+        api_v2.SpecialExamsListView.as_view(),
+        name='special_exams_list'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/special_exams/allowances$',
+        api_v2.CourseAllowancesView.as_view(),
+        name='course_allowances'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/special_exams/attempts$',
+        api_v2.CourseExamAttemptsView.as_view(),
+        name='course_exam_attempts'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/special_exams/(?P<exam_id>\d+)$',
+        api_v2.SpecialExamDetailView.as_view(),
+        name='special_exam_detail'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/special_exams/(?P<exam_id>\d+)/reset/(?P<username>[^/]+)$',
+        api_v2.SpecialExamResetView.as_view(),
+        name='special_exam_reset'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/special_exams/(?P<exam_id>\d+)/attempts$',
+        api_v2.SpecialExamAttemptsView.as_view(),
+        name='special_exam_attempts'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/special_exams/(?P<exam_id>\d+)/allowance$',
+        api_v2.ExamAllowanceView.as_view(),
+        name='exam_allowance'
+    ),
+    re_path(
+        rf'^courses/{COURSE_ID_PATTERN}/proctoring_settings$',
+        api_v2.ProctoringSettingsView.as_view(),
+        name='proctoring_settings'
+    ),
 ]
 
 urlpatterns = [

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -28,6 +28,21 @@ from django.utils.html import strip_tags
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import cache_control
 from django_filters.rest_framework import DjangoFilterBackend
+from edx_proctoring.api import (
+    add_allowance_for_user,
+    get_all_exam_attempts,
+    get_all_exams_for_course,
+    get_allowances_for_course,
+    get_exam_by_id,
+    get_filtered_exam_attempts,
+    get_user_attempts_by_exam_id,
+    remove_allowance_for_user,
+    remove_exam_attempt,
+)
+from edx_proctoring.exceptions import (
+    ProctoredBaseException,
+    ProctoredExamNotFoundException,
+)
 from edx_rest_framework_extensions.paginators import DefaultPagination
 from edx_when import api as edx_when_api
 from opaque_keys import InvalidKeyError
@@ -114,6 +129,7 @@ from .serializers_v2 import (
     BetaTesterModifyRequestSerializerV2,
     BetaTesterModifyResponseSerializerV2,
     BlockDueDateSerializerV2,
+    BulkAllowanceRequestSerializer,
     CertificateGenerationHistorySerializer,
     CourseEnrollmentSerializerV2,
     CourseInformationSerializerV2,
@@ -121,14 +137,20 @@ from .serializers_v2 import (
     CourseTeamRevokeSerializer,
     EnrollmentModifyRequestSerializerV2,
     EnrollmentModifyResponseSerializerV2,
+    ExamAllowanceRequestSerializer,
+    ExamAllowanceSerializer,
+    ExamAttemptSerializer,
     InstructorTaskListSerializer,
     IssuedCertificateSerializer,
     LearnerSerializer,
     ORASerializer,
     ORASummarySerializer,
     ProblemSerializer,
+    ProctoringSettingsSerializer,
+    ProctoringSettingsUpdateSerializer,
     RegenerateCertificatesSerializer,
     ScoreOverrideRequestSerializer,
+    SpecialExamSerializer,
     SyncOperationResultSerializer,
     TaskStatusSerializer,
     UnitExtensionSerializer,
@@ -3251,3 +3273,537 @@ class ScoreOverrideView(DeveloperErrorViewMixin, APIView):
         return _build_async_response(
             instructor_task, course_id, usage_key, learner_scope=student.username
         )
+class SpecialExamsListView(DeveloperErrorViewMixin, APIView):
+    """
+    List all proctored/timed exams in a course.
+
+    **Example Requests**
+
+        GET /api/instructor/v2/courses/{course_id}/special_exams
+        GET /api/instructor/v2/courses/{course_id}/special_exams?exam_type=proctored
+
+    **Query Parameters**
+
+        exam_type (optional): Filter by exam type. Values: proctored, timed, practice.
+
+    **Response Values**
+
+        A JSON array of special exam objects.
+    """
+
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.EXAM_RESULTS
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+        ],
+        responses={
+            200: SpecialExamSerializer(many=True),
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks access.",
+        },
+    )
+    def get(self, request, course_id):
+        """List all proctored/timed exams in the course."""
+        # `get_all_exams_for_course()` Returns a list of dictionaries, so we have to filter manually
+        exams = get_all_exams_for_course(course_id)
+        exam_type_lower = request.query_params.get('exam_type', '').strip().lower()
+        if exam_type_lower == 'proctored':
+            exams = [e for e in exams if e.get('is_proctored') and not e.get('is_practice_exam')]
+        elif exam_type_lower == 'practice':
+            exams = [e for e in exams if e.get('is_practice_exam')]
+        elif exam_type_lower == 'timed':
+            exams = [e for e in exams if not e.get('is_proctored')]
+        serializer = SpecialExamSerializer(exams, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class SpecialExamDetailView(DeveloperErrorViewMixin, APIView):
+    """
+    Retrieve details for a specific special exam.
+
+    **Example Request**
+
+        GET /api/instructor/v2/courses/{course_id}/special_exams/{exam_id}
+    """
+
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.EXAM_RESULTS
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+            apidocs.string_parameter(
+                'exam_id',
+                apidocs.ParameterLocation.PATH,
+                description="Exam identifier.",
+            ),
+        ],
+        responses={
+            200: SpecialExamSerializer,
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks access.",
+            404: "Exam not found.",
+        },
+    )
+    def get(self, request, course_id, exam_id):
+        """Retrieve details for a specific special exam."""
+        try:
+            exam = get_exam_by_id(int(exam_id))
+        except ProctoredExamNotFoundException:
+            return Response(
+                {'error': 'Exam not found'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        if exam.get('course_id') != course_id:
+            return Response(
+                {'error': 'Exam not found in this course'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        serializer = SpecialExamSerializer(exam)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class SpecialExamResetView(DeveloperErrorViewMixin, APIView):
+    """
+    Reset a student's proctored exam attempt.
+
+    **Example Request**
+
+        POST /api/instructor/v2/courses/{course_id}/special_exams/{exam_id}/reset/{username}
+    """
+
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.EXAM_RESULTS
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+            apidocs.string_parameter(
+                'exam_id',
+                apidocs.ParameterLocation.PATH,
+                description="Exam identifier.",
+            ),
+            apidocs.string_parameter(
+                'username',
+                apidocs.ParameterLocation.PATH,
+                description="Student's username.",
+            ),
+        ],
+        responses={
+            200: "Attempt reset successfully.",
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks access.",
+            404: "Exam or user not found.",
+        },
+    )
+    def post(self, request, course_id, exam_id, username):
+        """Reset a student's proctored exam attempt."""
+        UserModel = get_user_model()
+        try:
+            student = UserModel.objects.get(username=username)
+        except UserModel.DoesNotExist:
+            return Response(
+                {'error': 'User not found'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            exam = get_exam_by_id(int(exam_id))
+        except ProctoredExamNotFoundException:
+            return Response(
+                {'error': 'Exam not found'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if exam.get('course_id') != course_id:
+            return Response(
+                {'error': 'Exam not found in this course'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # Find and remove the student's attempts for this exam
+        user_attempts = get_user_attempts_by_exam_id(student.id, int(exam_id))
+
+        if not user_attempts:
+            return Response(
+                {'error': 'No attempts found for this user on this exam'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        for attempt in user_attempts:
+            remove_exam_attempt(attempt['id'], requesting_user=request.user)
+
+        return Response(
+            {'success': True, 'message': f'Exam attempt reset for user {username}'},
+            status=status.HTTP_200_OK,
+        )
+
+
+class SpecialExamAttemptsView(DeveloperErrorViewMixin, APIView):
+    """
+    List all attempts for a specific proctored exam.
+
+    **Example Request**
+
+        GET /api/instructor/v2/courses/{course_id}/special_exams/{exam_id}/attempts
+    """
+
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.EXAM_RESULTS
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+            apidocs.string_parameter(
+                'exam_id',
+                apidocs.ParameterLocation.PATH,
+                description="Exam identifier.",
+            ),
+        ],
+        responses={
+            200: ExamAttemptSerializer(many=True),
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks access.",
+        },
+    )
+    def get(self, request, course_id, exam_id):
+        """List all attempts for a specific proctored exam."""
+        attempts = get_all_exam_attempts(course_id)
+        exam_attempts = [
+            a for a in attempts if a.get('proctored_exam', {}).get('id') == int(exam_id)
+        ]
+        serializer = ExamAttemptSerializer(exam_attempts, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class ProctoringSettingsView(DeveloperErrorViewMixin, APIView):
+    """
+    Retrieve or update proctoring configuration for a course.
+
+    **Example Requests**
+
+        GET /api/instructor/v2/courses/{course_id}/proctoring_settings
+        PATCH /api/instructor/v2/courses/{course_id}/proctoring_settings
+    """
+
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.VIEW_DASHBOARD
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+        ],
+        responses={
+            200: ProctoringSettingsSerializer,
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks access.",
+            404: "Course not found.",
+        },
+    )
+    def get(self, request, course_id):
+        """Retrieve proctoring configuration for the course."""
+        course_key = CourseKey.from_string(course_id)
+        course = get_course_by_id(course_key)
+        settings_data = {
+            'proctoring_provider': getattr(course, 'proctoring_provider', None),
+            'proctoring_escalation_email': getattr(course, 'proctoring_escalation_email', None),
+            'create_zendesk_tickets': getattr(course, 'create_zendesk_tickets', False),
+            'enable_proctored_exams': getattr(course, 'enable_proctored_exams', False),
+        }
+        serializer = ProctoringSettingsSerializer(settings_data)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+        ],
+        responses={
+            200: ProctoringSettingsSerializer,
+            400: "Invalid parameters.",
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks access.",
+            404: "Course not found.",
+        },
+    )
+    def patch(self, request, course_id):
+        """Update proctoring settings for the course."""
+        update_serializer = ProctoringSettingsUpdateSerializer(data=request.data)
+        if not update_serializer.is_valid():
+            return Response(update_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        course_key = CourseKey.from_string(course_id)
+        course = modulestore().get_course(course_key)
+        if course is None:
+            return Response(
+                {'error': 'Course not found'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        validated = update_serializer.validated_data
+        updated = False
+        for field in ('proctoring_escalation_email', 'create_zendesk_tickets', 'enable_proctored_exams'):
+            if field in validated:
+                setattr(course, field, validated[field])
+                updated = True
+
+        if updated:
+            modulestore().update_item(course, request.user.id)
+
+        settings_data = {
+            'proctoring_provider': getattr(course, 'proctoring_provider', None),
+            'proctoring_escalation_email': getattr(course, 'proctoring_escalation_email', None),
+            'create_zendesk_tickets': getattr(course, 'create_zendesk_tickets', False),
+            'enable_proctored_exams': getattr(course, 'enable_proctored_exams', False),
+        }
+        serializer = ProctoringSettingsSerializer(settings_data)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class ExamAllowanceView(DeveloperErrorViewMixin, APIView):
+    """
+    Grant, update, or remove an allowance for a student on a proctored exam.
+
+    **Example Requests**
+
+        POST /api/instructor/v2/courses/{course_id}/special_exams/{exam_id}/allowance
+        DELETE /api/instructor/v2/courses/{course_id}/special_exams/{exam_id}/allowance
+    """
+
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.EXAM_RESULTS
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+            apidocs.string_parameter(
+                'exam_id',
+                apidocs.ParameterLocation.PATH,
+                description="Exam identifier.",
+            ),
+        ],
+        responses={
+            200: "Allowance granted successfully.",
+            400: "Invalid parameters.",
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks access.",
+            404: "Exam not found.",
+        },
+    )
+    def post(self, request, course_id, exam_id):
+        """Grant an allowance for a student on a proctored exam."""
+        serializer = ExamAllowanceRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            exam = get_exam_by_id(int(exam_id))
+        except ProctoredExamNotFoundException:
+            return Response(
+                {'error': 'Exam not found'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if exam.get('course_id') != course_id:
+            return Response(
+                {'error': 'Exam not found in this course'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        validated = serializer.validated_data
+        results = []
+        for user_info in validated['user_ids']:
+            try:
+                add_allowance_for_user(
+                    int(exam_id),
+                    user_info,
+                    validated['allowance_type'],
+                    validated['value'],
+                )
+                results.append({'identifier': user_info, 'success': True})
+            except ProctoredBaseException as err:
+                results.append({'identifier': user_info, 'success': False, 'error': str(err)})
+
+        return Response(
+            {'allowance_type': validated['allowance_type'], 'results': results},
+            status=status.HTTP_200_OK,
+        )
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter(
+                'course_id',
+                apidocs.ParameterLocation.PATH,
+                description="Course key for the course.",
+            ),
+            apidocs.string_parameter(
+                'exam_id',
+                apidocs.ParameterLocation.PATH,
+                description="Exam identifier.",
+            ),
+        ],
+        responses={
+            200: "Allowance removed successfully.",
+            400: "Invalid parameters.",
+            401: "The requesting user is not authenticated.",
+            403: "The requesting user lacks access.",
+            404: "Exam not found.",
+        },
+    )
+    def delete(self, request, course_id, exam_id):
+        """Remove allowances for one or more students on a proctored exam."""
+        user_ids = request.data.get('user_ids')
+        allowance_type = request.data.get('allowance_type')
+        if not user_ids or not allowance_type:
+            return Response(
+                {'error': 'user_ids and allowance_type are required'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if isinstance(user_ids, str):
+            user_ids = [user_ids]
+
+        try:
+            exam = get_exam_by_id(int(exam_id))
+        except ProctoredExamNotFoundException:
+            return Response(
+                {'error': 'Exam not found'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if exam.get('course_id') != course_id:
+            return Response(
+                {'error': 'Exam not found in this course'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        results = []
+        for user_identifier in user_ids:
+            try:
+                numeric_user_id = int(user_identifier)
+            except (ValueError, TypeError):
+                try:
+                    user = get_user_by_username_or_email(user_identifier)
+                    numeric_user_id = user.id
+                except get_user_model().DoesNotExist:
+                    results.append({'identifier': user_identifier, 'success': False, 'error': 'User not found'})
+                    continue
+
+            try:
+                remove_allowance_for_user(int(exam_id), numeric_user_id, allowance_type)
+                results.append({'identifier': user_identifier, 'success': True})
+            except ProctoredBaseException as err:
+                results.append({'identifier': user_identifier, 'success': False, 'error': str(err)})
+
+        return Response(
+            {'allowance_type': allowance_type, 'results': results},
+            status=status.HTTP_200_OK,
+        )
+
+
+class CourseAllowancesView(DeveloperErrorViewMixin, ListAPIView):
+    """
+    List or bulk-create exam allowances for a course.
+
+    **Example Requests**
+
+        GET /api/instructor/v2/courses/{course_id}/special_exams/allowances
+        GET /api/instructor/v2/courses/{course_id}/special_exams/allowances?search=student1
+        POST /api/instructor/v2/courses/{course_id}/special_exams/allowances
+    """
+
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.EXAM_RESULTS
+    serializer_class = ExamAllowanceSerializer
+
+    def get_queryset(self):
+        course_id = self.kwargs['course_id']
+        allowances = get_allowances_for_course(course_id)
+        search = self.request.query_params.get('search', '').strip().lower()
+        if search:
+            allowances = [
+                a for a in allowances
+                if search in a.get('user', {}).get('username', '').lower()
+                or search in a.get('user', {}).get('email', '').lower()
+            ]
+        return allowances
+
+    def post(self, request, course_id):
+        """Bulk-create allowances across multiple exams and users."""
+        serializer = BulkAllowanceRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        validated = serializer.validated_data
+        results = []
+        for exam_id in validated['exam_ids']:
+            for user_info in validated['user_ids']:
+                try:
+                    add_allowance_for_user(
+                        exam_id,
+                        user_info,
+                        validated['allowance_type'],
+                        validated['value'],
+                    )
+                    results.append({'identifier': user_info, 'exam_id': exam_id, 'success': True})
+                except ProctoredBaseException as err:
+                    results.append({'identifier': user_info, 'exam_id': exam_id, 'success': False, 'error': str(err)})
+
+        return Response({
+            'allowance_type': validated['allowance_type'],
+            'value': validated['value'],
+            'results': results,
+        }, status=status.HTTP_200_OK)
+
+
+class CourseExamAttemptsView(DeveloperErrorViewMixin, ListAPIView):
+    """
+    List all exam attempts across all exams in a course with optional search and pagination.
+
+    **Example Requests**
+
+        GET /api/instructor/v2/courses/{course_id}/special_exams/attempts
+        GET /api/instructor/v2/courses/{course_id}/special_exams/attempts?search=student1
+        GET /api/instructor/v2/courses/{course_id}/special_exams/attempts?page=2&page_size=50
+    """
+
+    permission_classes = (IsAuthenticated, permissions.InstructorPermission)
+    permission_name = permissions.EXAM_RESULTS
+    serializer_class = ExamAttemptSerializer
+
+    def get_queryset(self):
+        course_id = self.kwargs['course_id']
+        search = self.request.query_params.get('search', '').strip()
+        if search:
+            # get_filtered_exam_attempts does server-side filtering by username/email
+            return get_filtered_exam_attempts(course_id, search)
+        return get_all_exam_attempts(course_id)

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -3273,6 +3273,8 @@ class ScoreOverrideView(DeveloperErrorViewMixin, APIView):
         return _build_async_response(
             instructor_task, course_id, usage_key, learner_scope=student.username
         )
+
+
 class SpecialExamsListView(DeveloperErrorViewMixin, APIView):
     """
     List all proctored/timed exams in a course.
@@ -3453,7 +3455,7 @@ class SpecialExamResetView(DeveloperErrorViewMixin, APIView):
         )
 
 
-class SpecialExamAttemptsView(DeveloperErrorViewMixin, APIView):
+class SpecialExamAttemptsView(DeveloperErrorViewMixin, ListAPIView):
     """
     List all attempts for a specific proctored exam.
 
@@ -3464,34 +3466,17 @@ class SpecialExamAttemptsView(DeveloperErrorViewMixin, APIView):
 
     permission_classes = (IsAuthenticated, permissions.InstructorPermission)
     permission_name = permissions.EXAM_RESULTS
+    serializer_class = ExamAttemptSerializer
 
-    @apidocs.schema(
-        parameters=[
-            apidocs.string_parameter(
-                'course_id',
-                apidocs.ParameterLocation.PATH,
-                description="Course key for the course.",
-            ),
-            apidocs.string_parameter(
-                'exam_id',
-                apidocs.ParameterLocation.PATH,
-                description="Exam identifier.",
-            ),
-        ],
-        responses={
-            200: ExamAttemptSerializer(many=True),
-            401: "The requesting user is not authenticated.",
-            403: "The requesting user lacks access.",
-        },
-    )
-    def get(self, request, course_id, exam_id):
-        """List all attempts for a specific proctored exam."""
+    def get_queryset(self):
+        course_id = self.kwargs['course_id']
+        exam_id = int(self.kwargs['exam_id'])
+        # TODO: replace with exam-level query from edx_proctoring once available
+        # (e.g. ProctoredExamStudentAttempt.objects.get_all_exam_attempts_by_exam_id)
         attempts = get_all_exam_attempts(course_id)
-        exam_attempts = [
-            a for a in attempts if a.get('proctored_exam', {}).get('id') == int(exam_id)
+        return [
+            a for a in attempts if a.get('proctored_exam', {}).get('id') == exam_id
         ]
-        serializer = ExamAttemptSerializer(exam_attempts, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class ProctoringSettingsView(DeveloperErrorViewMixin, APIView):
@@ -3558,12 +3543,7 @@ class ProctoringSettingsView(DeveloperErrorViewMixin, APIView):
             return Response(update_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         course_key = CourseKey.from_string(course_id)
-        course = modulestore().get_course(course_key)
-        if course is None:
-            return Response(
-                {'error': 'Course not found'},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+        course = get_course_by_id(course_key)
 
         validated = update_serializer.validated_data
         updated = False
@@ -3709,14 +3689,11 @@ class ExamAllowanceView(DeveloperErrorViewMixin, APIView):
         results = []
         for user_identifier in user_ids:
             try:
-                numeric_user_id = int(user_identifier)
-            except (ValueError, TypeError):
-                try:
-                    user = get_user_by_username_or_email(user_identifier)
-                    numeric_user_id = user.id
-                except get_user_model().DoesNotExist:
-                    results.append({'identifier': user_identifier, 'success': False, 'error': 'User not found'})
-                    continue
+                user = get_user_by_username_or_email(str(user_identifier))
+                numeric_user_id = user.id
+            except get_user_model().DoesNotExist:
+                results.append({'identifier': user_identifier, 'success': False, 'error': 'User not found'})
+                continue
 
             try:
                 remove_allowance_for_user(int(exam_id), numeric_user_id, allowance_type)

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -1010,6 +1010,8 @@ class ScoreOverrideRequestSerializer(serializers.Serializer):
         if "score" not in data and "new_score" in data:
             data = {**data, "score": data["new_score"]}
         return super().to_internal_value(data)
+
+
 class SpecialExamSerializer(serializers.Serializer):
     """Serializer for proctored/timed exam data from edx_proctoring."""
     id = serializers.IntegerField()

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -1010,3 +1010,92 @@ class ScoreOverrideRequestSerializer(serializers.Serializer):
         if "score" not in data and "new_score" in data:
             data = {**data, "score": data["new_score"]}
         return super().to_internal_value(data)
+class SpecialExamSerializer(serializers.Serializer):
+    """Serializer for proctored/timed exam data from edx_proctoring."""
+    id = serializers.IntegerField()
+    course_id = serializers.CharField()
+    content_id = serializers.CharField()
+    exam_name = serializers.CharField()
+    time_limit_mins = serializers.IntegerField()
+    due_date = serializers.DateTimeField(allow_null=True, required=False)
+    exam_type = serializers.CharField(required=False, default='')
+    is_proctored = serializers.BooleanField()
+    is_practice_exam = serializers.BooleanField()
+    is_active = serializers.BooleanField()
+    hide_after_due = serializers.BooleanField()
+    backend = serializers.CharField(allow_null=True, required=False)
+
+
+class ExamAttemptUserSerializer(serializers.Serializer):
+    """Serializer for user info within an exam attempt."""
+    id = serializers.IntegerField()
+    username = serializers.CharField()
+    email = serializers.CharField()
+
+
+class ExamAttemptSerializer(serializers.Serializer):
+    """Serializer for proctored exam attempt data."""
+    id = serializers.IntegerField()
+    user = ExamAttemptUserSerializer()
+    exam_id = serializers.IntegerField(source='proctored_exam.id')
+    status = serializers.CharField()
+    start_time = serializers.DateTimeField(source='started_at', allow_null=True, required=False)
+    end_time = serializers.DateTimeField(source='completed_at', allow_null=True, required=False)
+    allowed_time_limit_mins = serializers.IntegerField(allow_null=True, required=False)
+
+
+class ProctoringSettingsSerializer(serializers.Serializer):
+    """Serializer for course proctoring configuration."""
+    proctoring_provider = serializers.CharField(allow_null=True, required=False)
+    proctoring_escalation_email = serializers.CharField(allow_null=True, required=False)
+    create_zendesk_tickets = serializers.BooleanField()
+    enable_proctored_exams = serializers.BooleanField()
+
+
+class ProctoringSettingsUpdateSerializer(serializers.Serializer):
+    """Serializer for validating proctoring settings update requests."""
+    proctoring_escalation_email = serializers.CharField(required=False, allow_blank=True)
+    create_zendesk_tickets = serializers.BooleanField(required=False)
+    enable_proctored_exams = serializers.BooleanField(required=False)
+
+
+class ExamAllowanceRequestSerializer(serializers.Serializer):
+    """Serializer for validating exam allowance grant requests."""
+    user_ids = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="List of usernames or emails of the students",
+    )
+    allowance_type = serializers.CharField(help_text="Type of allowance (e.g. 'additional_time_granted')")
+    value = serializers.CharField(help_text="Allowance value")
+
+
+class BulkAllowanceRequestSerializer(serializers.Serializer):
+    """Serializer for validating bulk allowance requests across multiple exams."""
+    exam_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        help_text="List of exam IDs",
+    )
+    user_ids = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="List of usernames or emails of the students",
+    )
+    allowance_type = serializers.CharField(help_text="Type of allowance (e.g. 'additional_time_granted')")
+    value = serializers.CharField(help_text="Allowance value")
+
+
+class AllowanceUserSerializer(serializers.Serializer):
+    """Serializer for user info within an allowance (uses 'id' directly)."""
+    id = serializers.IntegerField()
+    username = serializers.CharField()
+    email = serializers.CharField()
+
+
+class ExamAllowanceSerializer(serializers.Serializer):
+    """Serializer for exam allowance data from edx_proctoring."""
+    id = serializers.IntegerField()
+    created = serializers.DateTimeField()
+    modified = serializers.DateTimeField()
+    user = AllowanceUserSerializer()
+    key = serializers.CharField()
+    value = serializers.CharField()
+    proctored_exam = SpecialExamSerializer()


### PR DESCRIPTION
## Description
Adds Instructor API v2 endpoints for managing proctored and timed ("special") exams, as part of the ongoing Instructor Dashboard MFE migration.

New endpoints (all under /api/instructor/v2/courses/{course_id}/):
| Method | Path | Description |
|--------|------|-------------|
| GET | /special_exams | List all proctored/timed exams in a course |
| GET | /special_exams/{exam_id} | Retrieve details for a specific exam |
| POST | /special_exams/{exam_id}/reset/{username} | Reset a student's exam attempt |
| GET | /special_exams/{exam_id}/attempts | List all attempts for an exam |
| GET | /special_exams/attempts | List all attempts across all exams (paginated, searchable) |
| GET | /special_exams/allowances | List all allowances across the course (paginated, searchable) |
| POST | /special_exams/{exam_id}/allowance | Grant a time extension or accommodation |
| GET | /proctoring_settings | Retrieve course proctoring configuration |
| PATCH | /proctoring_settings | Update course proctoring settings |

Impacted user roles: Course Staff, Instructors (users with EXAM_RESULTS or VIEW_DASHBOARD permissions).

## Supporting information
- Closes: https://github.com/openedx/openedx-platform/issues/37470

## Other information
- **No database migrations** — all data is sourced from edx_proctoring APIs and modulestore course fields.