### PR TITLE
fix: add can_learn mapping in library permissions

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -813,9 +813,15 @@ def get_backup_task_status(
 def _transform_legacy_lib_permission_to_authz_permission(permission: str) -> str:
     """
     Transform a legacy content library permission to an openedx-authz permission.
+
+    Notes:
+    - There is no dedicated permission or role for can_create_content_library in openedx-authz yet,
+      so we reuse the same permission to rely on user.has_perm via Bridgekeeper.
+    - There is no dedicated can_learn_from_this_content_library permission
+    in the new authz system,
+    but we are mapping it to view_library in the new system. So the user who can view library content can
+    learn from it.
     """
-    # There is no dedicated permission or role for can_create_content_library in openedx-authz yet,
-    # so we reuse the same permission to rely on user.has_perm via Bridgekeeper.
     return {
         permissions.CAN_CREATE_CONTENT_LIBRARY: permissions.CAN_CREATE_CONTENT_LIBRARY,
         permissions.CAN_DELETE_THIS_CONTENT_LIBRARY: authz_permissions.DELETE_LIBRARY.identifier,
@@ -823,6 +829,7 @@ def _transform_legacy_lib_permission_to_authz_permission(permission: str) -> str
         permissions.CAN_EDIT_THIS_CONTENT_LIBRARY_TEAM: authz_permissions.MANAGE_LIBRARY_TEAM.identifier,
         permissions.CAN_VIEW_THIS_CONTENT_LIBRARY: authz_permissions.VIEW_LIBRARY.identifier,
         permissions.CAN_VIEW_THIS_CONTENT_LIBRARY_TEAM: authz_permissions.VIEW_LIBRARY_TEAM.identifier,
+        permissions.CAN_LEARN_FROM_THIS_CONTENT_LIBRARY: authz_permissions.VIEW_LIBRARY.identifier,
     }.get(permission, permission)
 
 
@@ -860,6 +867,11 @@ def user_has_permission_across_lib_authz_systems(
     Current gaps covered here:
     - CAN_CREATE_CONTENT_LIBRARY: we call user.has_perm via Bridgekeeper to verify the user is a course creator.
     - CAN_VIEW_THIS_CONTENT_LIBRARY: we respect the allow_public_read flag via Bridgekeeper.
+    - CAN_LEARN_FROM_THIS_CONTENT_LIBRARY: this permission doesn't exist in the new authz system, but we are treating
+    it as equivalent to view_library in the new system, so we check both the legacy permission and the authz permission.
+    This means that if a user can view the library content, they can learn from it.
+    If we want to remove the old check fully, we should either update the can_learn enforcement points
+    or add that specific permission to the authz system.
 
     Replace these with authz_api.is_user_allowed once openedx-authz supports
     these conditions natively (including global (*) roles).

--- a/openedx/core/djangoapps/content_libraries/api/libraries.py
+++ b/openedx/core/djangoapps/content_libraries/api/libraries.py
@@ -816,11 +816,11 @@ def _transform_legacy_lib_permission_to_authz_permission(permission: str) -> str
 
     Notes:
     - There is no dedicated permission or role for can_create_content_library in openedx-authz yet,
-      so we reuse the same permission to rely on user.has_perm via Bridgekeeper.
+        so we reuse the same permission to rely on user.has_perm via Bridgekeeper.
     - There is no dedicated can_learn_from_this_content_library permission
-    in the new authz system,
-    but we are mapping it to view_library in the new system. So the user who can view library content can
-    learn from it.
+        in the new authz system,
+        but we are mapping it to view_library in the new system. So the user who can view
+        library content can learn from it.
     """
     return {
         permissions.CAN_CREATE_CONTENT_LIBRARY: permissions.CAN_CREATE_CONTENT_LIBRARY,

--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -1982,3 +1982,24 @@ class ContentLibrariesRestAPIAuthzIntegrationTestCase(ContentLibrariesRestApiTes
             with self.as_user(user):
                 result = self._delete_library(self.lib_id, expect_response=status.HTTP_200_OK)
                 assert result == {}
+
+    def test_learn_from_library_permissions(self):
+        """
+        Verify that users with view permissions can learn from the library.
+        Learning from a library means being able to render/interact with blocks.
+        """
+        # Create and publish a block
+        block_data = self._add_block_to_library(self.lib_id, "problem", "test_problem")
+        block_id = block_data["id"]
+        self._commit_library_changes(self.lib_id)
+
+        # Users with view permissions should be able to learn from the library
+        for user in self.library_viewers:
+            with self.as_user(user):
+                # Rendering a block view requires CAN_LEARN permission
+                self._render_block_view(block_id, "student_view", expect_response=status.HTTP_200_OK)
+
+        # Users without view permissions should NOT be able to learn from the library
+        for user in self._all_users_excluding(self.library_viewers):
+            with self.as_user(user):
+                self._render_block_view(block_id, "student_view", expect_response=status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

### The Problem
During the migration from the legacy permission system to the new authorization (authz) system, the `can_learn` permission was maintained without modifications.

The Consequences
Certain views that strictly enforce legacy `can_learn` checks are currently inaccessible to users assigned to modern roles. For example, a user with a non-admin role in the new system is blocked from previewing library items, even though they have the necessary functional access.

### The Solution
This PR bridges the gap between the two systems by introducing a permission mapping: **If a user has "View" permissions in the new authz system, they are granted `can_learn` equivalence in the legacy system.** This ensures that the transition to the new system doesn't break existing functionality for library learners and staff.

## Testing instructions

**Setup:** Use a user account assigned a **Read/View** role in the new system (ensure they do *not* have legacy Admin rights).

* **Before:** Attempting to preview a library item results in a permission error or a failure to load the content.
* **After:** The user should be able to view the library item preview successfully.

## Details

**Technical Implementation Details**
To ensure consistency across all enforcement points, the fix is applied at the core logic level:
* The various [enforcement points](https://github.com/search?q=repo%3Aopenedx%2Fopenedx-platform+CAN_LEARN_FROM_THIS_CONTENT_LIBRARY&type=code) that check for `can_learn` rely on a single entry point: `LibraryContextImpl._check_perm`.
* `LibraryContextImpl._check_perm` calls `require_permission_for_library_key`, which has been updated to interface with `user_has_permission_across_lib_authz_systems`.
* This structure ensures that any view or service using the standard `can_learn` check is now automatically compatible with both the old and new authorization systems without needing to update every individual enforcement point.

Note: CheckPerm.CAN_LEARN goes to LibraryContextImpl.can_view_block -> _check_perm -> require_permission_for_library_key -> user_has_permission_across_lib_authz_systems. So, this path also takes both authz systems into account.

## Other info

* Migration Plan (Ulmo): [Libraries Roles and Permissions Migration Plan](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/5252317270/Libraries+Roles+and+Permissions+Migration+Plan)

### Screenshots
<img width="1152" height="646" alt="image" src="https://github.com/user-attachments/assets/4ebe1612-d3fd-43e9-84e9-084a4c5ff8a2" />
Screenshot of a preview view
