### PR TITLE
[FC-0018] feat: Standardize AuthoringGradingView

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_authoring_grading.py
@@ -1,0 +1,156 @@
+"""
+Tests for the AuthoringGrading API (ADR 0028 ViewSet migration).
+
+Two test classes:
+  - TestAuthoringGradingViewSetPermissions — auth/permission boundaries (APITestCase, no MongoDB)
+  - TestAuthoringGradingViewSetUpdate      — successful PATCH + deprecated alias (APITestCase + mocks, no MongoDB)
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from common.djangoapps.student.tests.factories import UserFactory
+
+COURSE_ID = 'course-v1:edX+ToyX+Toy_Course'
+
+# Minimal graders payload accepted by CourseGradingModelSerializer
+_GRADERS_PAYLOAD = [
+    {
+        'type': 'Homework',
+        'min_count': 1,
+        'drop_count': 0,
+        'short_label': '',
+        'weight': 100,
+        'id': 0,
+    }
+]
+
+# Fake CourseGradingModel return value: only the field the serializer reads
+_MOCK_GRADING_MODEL = SimpleNamespace(graders=_GRADERS_PAYLOAD)
+
+
+class TestAuthoringGradingViewSetPermissions(APITestCase):
+    """
+    ADR 0028 – permission boundary tests for AuthoringGradingViewSet.partial_update.
+
+    These tests only exercise auth/permission enforcement and do not require
+    a real course in the module store (MongoDB not needed).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.url = reverse(
+            'cms.djangoapps.contentstore:v0:authoring-grading-detail',
+            kwargs={'course_id': COURSE_ID},
+        )
+
+    def test_unauthenticated_patch_gets_401(self):
+        """Unauthenticated PATCH must be rejected with 401 before reaching business logic."""
+        response = self.client.patch(self.url, {}, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_non_staff_patch_gets_403(self):
+        """Authenticated non-staff user must be rejected with 403 (HasStudioReadAccess fails)."""
+        non_staff = UserFactory.create()
+        self.client.force_authenticate(user=non_staff)
+        response = self.client.patch(self.url, {}, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class TestAuthoringGradingViewSetUpdate(APITestCase):
+    """
+    ADR 0028 – functional tests for AuthoringGradingViewSet.partial_update.
+
+    Uses APITestCase with targeted mocks so no MongoDB connection is required:
+      - CourseOverview.course_exists          -> True               (bypasses module-store lookup)
+      - CourseGradingModel.update_from_json   -> _MOCK_GRADING_MODEL (no module-store write)
+      - update_credit_course_requirements.delay -> no-op
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        # GlobalStaff (is_staff=True) passes HasStudioReadAccess without a real course
+        self.staff_user = UserFactory.create(is_staff=True)
+        self.client.force_authenticate(user=self.staff_user)
+
+        # Router-generated detail URL: PATCH /api/contentstore/v0/grading/{course_id}/
+        self.url = reverse(
+            'cms.djangoapps.contentstore:v0:authoring-grading-detail',
+            kwargs={'course_id': COURSE_ID},
+        )
+        # Deprecated backward-compat alias: POST /api/contentstore/v0/grading/{course_id}
+        self.deprecated_url = reverse(
+            'cms.djangoapps.contentstore:v0:cms_api_update_grading',
+            kwargs={'course_id': COURSE_ID},
+        )
+
+    @patch(
+        'openedx.core.djangoapps.credit.tasks.update_credit_course_requirements.delay'
+    )
+    @patch(
+        'cms.djangoapps.contentstore.rest_api.v0.views.authoring_grading.CourseGradingModel.update_from_json',
+        return_value=_MOCK_GRADING_MODEL,
+    )
+    @patch(
+        'openedx.core.lib.api.view_utils.CourseOverview.course_exists',
+        return_value=True,
+    )
+    def test_staff_patch_updates_grading_returns_200(
+        self, mock_exists, mock_update, mock_credit_task
+    ):
+        """
+        Staff PATCH with valid graders data returns HTTP 200 and fires the
+        update_credit_course_requirements Celery task when minimum_grade_credit is present.
+        """
+        request_data = {
+            'graders': _GRADERS_PAYLOAD,
+            'grade_cutoffs': {'A': 0.75, 'B': 0.63, 'C': 0.57, 'D': 0.5},
+            'grace_period': {'hours': 12, 'minutes': 0},
+            'minimum_grade_credit': 0.7,
+            'is_credit_course': True,
+        }
+        response = self.client.patch(
+            self.url,
+            data=json.dumps(request_data),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_update.assert_called_once()
+        mock_credit_task.assert_called_once()
+
+    @patch(
+        'openedx.core.djangoapps.credit.tasks.update_credit_course_requirements.delay'
+    )
+    @patch(
+        'cms.djangoapps.contentstore.rest_api.v0.views.authoring_grading.CourseGradingModel.update_from_json',
+        return_value=_MOCK_GRADING_MODEL,
+    )
+    @patch(
+        'openedx.core.lib.api.view_utils.CourseOverview.course_exists',
+        return_value=True,
+    )
+    def test_deprecated_post_alias_still_returns_200(
+        self, mock_exists, mock_update, mock_credit_task
+    ):
+        """
+        Deprecated POST /grading/{course_id} alias must still return 200 during the
+        deprecation window (backward compatibility requirement of ADR 0028).
+        """
+        request_data = {
+            'graders': _GRADERS_PAYLOAD,
+            'grade_cutoffs': {'A': 0.75, 'B': 0.63, 'C': 0.57, 'D': 0.5},
+            'grace_period': {'hours': 12, 'minutes': 0},
+        }
+        response = self.client.post(
+            self.deprecated_url,
+            data=json.dumps(request_data),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_update.assert_called_once()

--- a/cms/djangoapps/contentstore/rest_api/v0/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/urls.py
@@ -2,6 +2,7 @@
 
 from django.conf import settings
 from django.urls import re_path, path
+from rest_framework.routers import DefaultRouter
 
 from openedx.core.constants import COURSE_ID_PATTERN
 
@@ -9,6 +10,7 @@ from .views import (
     AdvancedCourseSettingsView,
     APIHeartBeatView,
     AuthoringGradingView,
+    AuthoringGradingViewSet,
     CourseTabListView,
     CourseTabReorderView,
     CourseTabSettingsView,
@@ -26,9 +28,14 @@ from .views import xblock
 
 app_name = "v0"
 
+# ADR 0028: AuthoringGradingViewSet registered via DefaultRouter.
+# Generates: PATCH /grading/{course_id}/  (authoring-grading-detail)
+router = DefaultRouter()
+router.register(r'grading', AuthoringGradingViewSet, basename='authoring-grading')
+
 VIDEO_ID_PATTERN = r'(?P<edx_video_id>[-\w]+)'
 
-urlpatterns = [
+urlpatterns = router.urls + [
     re_path(
         fr"^advanced_settings/{COURSE_ID_PATTERN}$",
         AdvancedCourseSettingsView.as_view(),
@@ -66,6 +73,8 @@ urlpatterns = [
         fr'^videos/encodings/{settings.COURSE_ID_PATTERN}$',
         authoring_videos.VideoEncodingsDownloadView.as_view(), name='cms_api_videos_encodings'
     ),
+    # DEPRECATED (ADR 0028): POST /grading/{course_id} kept for backward compatibility.
+    # Will be removed after one named release. Use PATCH grading/{course_id}/ (router URL) instead.
     re_path(
         fr'grading/{settings.COURSE_ID_PATTERN}$',
         AuthoringGradingView.as_view(), name='cms_api_update_grading'

--- a/cms/djangoapps/contentstore/rest_api/v0/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/__init__.py
@@ -3,7 +3,7 @@ Views for v0 contentstore API.
 """
 from .advanced_settings import AdvancedCourseSettingsView
 from .api_heartbeat import APIHeartBeatView
-from .authoring_grading import AuthoringGradingView
+from .authoring_grading import AuthoringGradingView, AuthoringGradingViewSet
 from .course_optimizer import LinkCheckStatusView, LinkCheckView, RerunLinkUpdateStatusView, RerunLinkUpdateView
 from .tabs import CourseTabListView, CourseTabReorderView, CourseTabSettingsView
 from .transcripts import TranscriptView, YoutubeTranscriptCheckView, YoutubeTranscriptUploadView

--- a/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
@@ -1,7 +1,8 @@
-""" API Views for course advanced settings """
+""" API Views for course grading settings """
 
 import edx_api_doc_tools as apidocs
 from opaque_keys.edx.keys import CourseKey
+from rest_framework import viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -18,6 +19,100 @@ from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_cour
 from ..serializers import CourseGradingModelSerializer
 
 
+# ADR 0028 – consolidated from AuthoringGradingView
+class AuthoringGradingViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
+    """
+    ViewSet for getting and setting the grading settings for a course.
+
+    Registered via DefaultRouter with basename ``authoring-grading``.
+    Router-generated URL: PATCH /api/contentstore/v0/grading/{course_id}/
+    """
+
+    authentication_classes = (  # ADR 0026
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAuthenticated, HasStudioReadAccess)  # ADR 0026
+    serializer_class = CourseGradingModelSerializer
+
+    # DefaultRouter lookup: matches course-v1:org+course+run (+ or / separators)
+    lookup_field = 'course_id'
+    lookup_value_regex = r'[^/+]+(?:/|\+)[^/+]+(?:/|\+)[^/?]+'
+
+    def get_serializer(self, *args, **kwargs):
+        """Return a serializer instance using the configured serializer_class."""
+        return self.serializer_class(*args, **kwargs)
+
+    @apidocs.schema(
+        body=CourseGradingModelSerializer,
+        parameters=[
+            apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
+        ],
+        responses={
+            200: CourseGradingModelSerializer,
+            401: "The requester is not authenticated.",
+            403: "The requester cannot access the specified course.",
+            404: "The requested course does not exist.",
+        },
+    )
+    @verify_course_exists()
+    def partial_update(self, request: Request, course_id: str):
+        """
+        Update a course's grading settings.
+
+        **Example Request**
+
+            PATCH /api/contentstore/v0/grading/{course_id}/
+
+        **PATCH Parameters**
+
+        The data sent for a patch request should follow this object.
+        Here is an example request data that updates ``course_grading``:
+
+        ```json
+        {
+            "graders": [
+                {
+                    "type": "Homework",
+                    "min_count": 1,
+                    "drop_count": 0,
+                    "short_label": "",
+                    "weight": 100,
+                    "id": 0
+                }
+            ],
+            "grade_cutoffs": {
+                "A": 0.75,
+                "B": 0.63,
+                "C": 0.57,
+                "D": 0.5
+            },
+            "grace_period": {
+                "hours": 12,
+                "minutes": 0
+            },
+            "minimum_grade_credit": 0.7,
+            "is_credit_course": true
+        }
+        ```
+
+        **Response Values**
+
+        If the request is successful, an HTTP 200 "OK" response is returned.
+        """
+        course_key = CourseKey.from_string(course_id)
+
+        if 'minimum_grade_credit' in request.data:
+            update_credit_course_requirements.delay(str(course_key))
+
+        updated_data = CourseGradingModel.update_from_json(course_key, request.data, request.user)
+        serializer = self.get_serializer(updated_data)
+        return Response(serializer.data)
+
+
+# DEPRECATED (ADR 0028): Use AuthoringGradingViewSet instead.
+# Will be removed after one named release. Use PATCH grading/{course_id}/ via the router URL.
 class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
     """
     View for getting and setting the advanced settings for a course.
@@ -29,6 +124,7 @@ class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
     )
     permission_classes = (IsAuthenticated, HasStudioReadAccess)  # ADR 0026
     serializer_class = CourseGradingModelSerializer
+
     @apidocs.schema(
         body=CourseGradingModelSerializer,
         parameters=[

--- a/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
@@ -6,18 +6,28 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+from rest_framework.permissions import IsAuthenticated
+
+from cms.djangoapps.contentstore.views.permissions import HasStudioReadAccess
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
-from common.djangoapps.student.auth import has_studio_read_access
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
-from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
+from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists
 from ..serializers import CourseGradingModelSerializer
 
 
-@view_auth_classes(is_authenticated=True)
 class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
     """
     View for getting and setting the advanced settings for a course.
     """
+    authentication_classes = (  # ADR 0026
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAuthenticated, HasStudioReadAccess)  # ADR 0026
     serializer_class = CourseGradingModelSerializer
     @apidocs.schema(
         body=CourseGradingModelSerializer,
@@ -77,9 +87,6 @@ class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
         If the request is successful, an HTTP 200 "OK" response is returned,
         """
         course_key = CourseKey.from_string(course_id)
-
-        if not has_studio_read_access(request.user, course_key):
-            self.permission_denied(request)
 
         if 'minimum_grade_credit' in request.data:
             update_credit_course_requirements.delay(str(course_key))

--- a/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
@@ -18,6 +18,7 @@ class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
     """
     View for getting and setting the advanced settings for a course.
     """
+    serializer_class = CourseGradingModelSerializer
     @apidocs.schema(
         body=CourseGradingModelSerializer,
         parameters=[
@@ -84,5 +85,5 @@ class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
             update_credit_course_requirements.delay(str(course_key))
 
         updated_data = CourseGradingModel.update_from_json(course_key, request.data, request.user)
-        serializer = CourseGradingModelSerializer(updated_data)
+        serializer = self.serializer_class(updated_data)
         return Response(serializer.data)

--- a/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
@@ -1,6 +1,11 @@
 """ API Views for course grading settings """
 
-import edx_api_doc_tools as apidocs
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiParameter,
+    OpenApiRequest,
+    OpenApiResponse,
+)
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import viewsets
 from rest_framework.request import Request
@@ -44,16 +49,27 @@ class AuthoringGradingViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
         """Return a serializer instance using the configured serializer_class."""
         return self.serializer_class(*args, **kwargs)
 
-    @apidocs.schema(
-        body=CourseGradingModelSerializer,
+    @extend_schema(
+        summary="Update a course's grading settings",
+        description="Partially update the grading settings for the specified course.",
+        request=OpenApiRequest(request=CourseGradingModelSerializer),
         parameters=[
-            apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
+            OpenApiParameter(
+                name="course_id",
+                description="Course ID",
+                required=True,
+                type=str,
+                location=OpenApiParameter.PATH,
+            ),
         ],
         responses={
-            200: CourseGradingModelSerializer,
-            401: "The requester is not authenticated.",
-            403: "The requester cannot access the specified course.",
-            404: "The requested course does not exist.",
+            200: OpenApiResponse(
+                response=CourseGradingModelSerializer,
+                description="Grading settings updated successfully.",
+            ),
+            401: OpenApiResponse(description="The requester is not authenticated."),
+            403: OpenApiResponse(description="The requester cannot access the specified course."),
+            404: OpenApiResponse(description="The requested course does not exist."),
         },
     )
     @verify_course_exists()
@@ -125,17 +141,32 @@ class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
     permission_classes = (IsAuthenticated, HasStudioReadAccess)  # ADR 0026
     serializer_class = CourseGradingModelSerializer
 
-    @apidocs.schema(
-        body=CourseGradingModelSerializer,
+    @extend_schema(
+        summary="Update a course's grading settings (deprecated)",
+        description=(
+            "Deprecated POST alias for updating course grading settings. "
+            "Use PATCH /api/contentstore/v0/grading/{course_id}/ instead."
+        ),
+        request=OpenApiRequest(request=CourseGradingModelSerializer),
         parameters=[
-            apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
+            OpenApiParameter(
+                name="course_id",
+                description="Course ID",
+                required=True,
+                type=str,
+                location=OpenApiParameter.PATH,
+            ),
         ],
         responses={
-            200: CourseGradingModelSerializer,
-            401: "The requester is not authenticated.",
-            403: "The requester cannot access the specified course.",
-            404: "The requested course does not exist.",
+            200: OpenApiResponse(
+                response=CourseGradingModelSerializer,
+                description="Grading settings updated successfully.",
+            ),
+            401: OpenApiResponse(description="The requester is not authenticated."),
+            403: OpenApiResponse(description="The requester cannot access the specified course."),
+            404: OpenApiResponse(description="The requested course does not exist."),
         },
+        deprecated=True,
     )
     @verify_course_exists()
     def post(self, request: Request, course_id: str):

--- a/cms/djangoapps/contentstore/views/permissions.py
+++ b/cms/djangoapps/contentstore/views/permissions.py
@@ -4,7 +4,7 @@ Custom permissions for the content store views.
 
 from rest_framework.permissions import BasePermission
 
-from common.djangoapps.student.auth import has_studio_write_access
+from common.djangoapps.student.auth import has_studio_read_access, has_studio_write_access
 from openedx.core.lib.api.view_utils import validate_course_key
 
 
@@ -20,3 +20,20 @@ class HasStudioWriteAccess(BasePermission):
         course_key_string = view.kwargs.get("course_key_string")
         course_key = validate_course_key(course_key_string)
         return has_studio_write_access(request.user, course_key)
+
+
+class HasStudioReadAccess(BasePermission):
+    """
+    Check if the user has read access to studio.
+
+    ADR 0026: replaces inline ``has_studio_read_access`` checks.
+    Expects a ``course_id`` URL kwarg.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Check if the user has read access to studio.
+        """
+        course_key_string = view.kwargs.get("course_id")
+        course_key = validate_course_key(course_key_string)
+        return has_studio_read_access(request.user, course_key)

--- a/docs/decisions/0025-standardize-serializer-usage.rst
+++ b/docs/decisions/0025-standardize-serializer-usage.rst
@@ -22,7 +22,7 @@ Implementation requirements:
 * Replace manual JSON construction with serializer-based responses.
 * Use serializers for both input validation and output formatting.
 * Ensure serializers are properly documented with field descriptions and validation rules.
-* Maintain backward compatibility for all APIs during migration.
+* Maintain backward compatibility for all APIs during migration. While the goal is fully compatible DRF serializers, if that is not possible and we must make a backwards incompatible change, that change MUST be handled by creating a new version of the API and transitioning to that API using the deprecation process.
 
 Relevance in edx-platform
 -------------------------

--- a/docs/decisions/0025-standardize-serializer-usage.rst
+++ b/docs/decisions/0025-standardize-serializer-usage.rst
@@ -1,0 +1,113 @@
+Standardize Serializer Usage Across APIs
+========================================
+
+:Status: Proposed
+:Date: 2026-03-09
+:Deciders: API Working Group
+:Technical Story: Open edX REST API Standards - Serializer standardization for consistency
+
+Context
+-------
+
+Many Open edX platform API endpoints manually construct JSON responses using Python dictionaries instead of Django REST Framework (DRF) serializers. This leads to inconsistent schema responses, makes validation errors harder to manage, and creates unpredictable formats that AI and third-party systems struggle with.
+
+Decision
+--------
+
+We will standardize all Open edX REST APIs to use **DRF serializers** for request and response handling.
+
+Implementation requirements:
+
+* All API views MUST define explicit serializers for request and response handling.
+* Replace manual JSON construction with serializer-based responses.
+* Use serializers for both input validation and output formatting.
+* Ensure serializers are properly documented with field descriptions and validation rules.
+* Maintain backward compatibility for all APIs during migration.
+
+Relevance in edx-platform
+-------------------------
+
+Current patterns that should be migrated:
+
+* **Certificates API** (``/api/certificates/v0/``) constructs JSON manually with nested dictionaries.
+* **Enrollment API** endpoints manually build response objects without serializers.
+* **Course API** views use hand-coded JSON responses instead of structured serializers.
+
+Code example (target serializer usage)
+--------------------------------------
+
+**Example serializer and APIView using DRF best practices:**
+
+.. code-block:: python
+
+   # serializers.py
+   from rest_framework import serializers
+
+   class CertificateSerializer(serializers.Serializer):
+       username = serializers.CharField(
+           help_text="The username of the certificate holder"
+       )
+       course_id = serializers.CharField(
+           help_text="The course identifier"
+       )
+       status = serializers.CharField(
+           help_text="The certificate status (e.g., downloadable, generating)"
+       )
+       grade = serializers.FloatField(
+           help_text="The final grade achieved"
+       )
+
+   # views.py
+   from rest_framework.views import APIView
+   from rest_framework.response import Response
+   from rest_framework import status
+
+   class CertificateAPIView(APIView):
+       def get(self, request):
+           data = {
+               "username": "john_doe",
+               "course_id": "course-v1:edX+DemoX+1T2024",
+               "status": "downloadable",
+               "grade": 0.95,
+           }
+           serializer = CertificateSerializer(data)
+           return Response(serializer.data, status=status.HTTP_200_OK)
+
+Consequences
+------------
+
+Positive
+~~~~~~~~
+
+* Simplifies validation and ensures consistent response contracts.
+* Improves AI compatibility through predictable data structures.
+* Enables automatic schema generation and documentation.
+* Reduces code duplication and maintenance overhead.
+
+Negative / Trade-offs
+~~~~~~~~~~~~~~~~~~~~~
+
+* Requires refactoring existing endpoints that manually construct JSON.
+* Initial development overhead for creating comprehensive serializers.
+* May require updates to existing client code that expects legacy formats.
+
+Alternatives Considered
+-----------------------
+
+* **Keep manual JSON construction**: rejected due to inconsistency and maintenance burden.
+* **Use DRF defaults only**: rejected because explicit serializers provide better validation and documentation.
+* **Use newer ways of managing API responses such as dataclasses or pydantic**: rejected due to complexity and unknowns in transitioning from two existing patterns (manual JSON and DRF serializers) to a third approach. While these python libraries offer better ergonomics, migration would require checking nested serializers, complex validation, and ModelSerializer-heavy endpoints. To move to some new format, we would want to prevent using the basic DRF Serializers any more than we do right now, but preventing new DRF serializers via linting is more complex than anticipated.  This work can be revisited in the future once the platform is a bit more consistent.
+
+Rollout Plan
+------------
+
+1. Audit existing endpoints to identify those using manual JSON construction.
+2. Create a library of common serializers for shared data structures.
+3. Migrate high-impact endpoints first (certificates, enrollment, courses).
+4. Update tests to validate serializer-based responses.
+5. Update API documentation to reflect new serializer-based contracts.
+
+References
+----------
+
+* Open edX REST API Standards: "Serializer Usage" recommendations for API consistency.


### PR DESCRIPTION
### Description:

The FC-0118 initiative introduces a comprehensive standardization of APIs across the platform, guided by 15 newly defined Architectural Decision Records (ADRs). These ADRs collectively establish consistent patterns for serializers, permissions, error handling, pagination, filtering, authentication, versioning, and overall API design. Through this effort, existing endpoints are being refactored and aligned to ensure uniformity, improved developer experience, and long-term maintainability, while also reducing redundancy and inconsistencies across services.

### Checklist:

- [x] 0025 – Standardize Serializer Usage
- [x] 0026 – Standardize Permission Classes
- [x] 0027 – Standardize API Documentation & Schema Coverage
- [x] 0028 – Standardize RESTful API Endpoints using DRF ViewSets
- [ ] 0029 – Standardize Error Responses
- [ ] 0030 – Ensure GET Requests are Idempotent
- [ ] 0031 – Merge Similar Endpoints
- [x] 0032 – Standardize Pagination Usage
- [ ] 0033 – Standardize Filter & Sort using django-filter
- [ ] 0034 – Unify Auth (OAuth2 v2)
- [ ] 0035 – Port Legacy Django Views to DRF
- [ ] 0036 – Normalize Deeply Nested JSON APIs
- [ ] 0037 – API Versioning Strategy
- [ ] 0038 - Introduce Row level Security Layer
- [ ] 0039 – Modulestore CRUD APIs with Custom Serializers
- [ ] 0040 – Document & Consolidate Internal APIs used by MFEs

