### PR TITLE
[FC-0018] feat: Standardize XblockView/XblockCreateView

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_xblock_viewset.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_xblock_viewset.py
@@ -1,0 +1,161 @@
+"""
+Tests for the XblockViewSet (ADR 0028 ViewSet migration).
+
+Three test classes — all use APITestCase (no MongoDB required):
+  - TestXblockViewSetDetailPermissions  — auth/permission gates on the detail URL
+  - TestXblockViewSetCreatePermissions  — auth/permission gates on the create (list) URL
+  - TestXblockViewSetActions            — functional routing tests (handle_xblock is mocked)
+"""
+import json
+from unittest.mock import patch
+
+from django.http import JsonResponse
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from common.djangoapps.student.tests.factories import UserFactory
+
+# A valid v2 block key; course key encoded as dede+aba+weagi
+TEST_LOCATOR = "block-v1:dede+aba+weagi+type@problem+block@ba6327f840da49289fb27a9243913478"
+MOCK_HANDLE_XBLOCK = "cms.djangoapps.contentstore.rest_api.v0.views.xblock.handle_xblock"
+_MOCK_RESPONSE = JsonResponse({"locator": TEST_LOCATOR, "courseKey": "course-v1:dede+aba+weagi"})
+
+
+class TestXblockViewSetDetailPermissions(APITestCase):
+    """
+    ADR 0028 – permission boundary tests for XblockViewSet detail actions.
+
+    course_id is derived from TEST_LOCATOR in XblockViewSet.initial(); no MongoDB needed.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.url = reverse(
+            'cms.djangoapps.contentstore:v0:xblock-detail',
+            kwargs={'usage_key_string': TEST_LOCATOR},
+        )
+
+    def test_unauthenticated_get_gets_401(self):
+        """Unauthenticated GET must be rejected before reaching handle_xblock."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_unauthenticated_delete_gets_401(self):
+        """Unauthenticated DELETE must be rejected before reaching handle_xblock."""
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_non_course_author_get_gets_403(self):
+        """Authenticated user without course-author access must get 403."""
+        non_author = UserFactory.create()
+        self.client.force_authenticate(user=non_author)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_non_course_author_delete_gets_403(self):
+        """Authenticated user without course-author access must get 403 on DELETE."""
+        non_author = UserFactory.create()
+        self.client.force_authenticate(user=non_author)
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class TestXblockViewSetCreatePermissions(APITestCase):
+    """
+    ADR 0028 – permission boundary tests for XblockViewSet create action.
+
+    course_id is derived from parent_locator in XblockViewSet.initial(); no MongoDB needed.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.url = reverse('cms.djangoapps.contentstore:v0:xblock-list')
+        # A valid parent_locator so initial() can derive course_id for permission check
+        self.create_payload = json.dumps({
+            'parent_locator': TEST_LOCATOR,
+            'category': 'html',
+        })
+
+    def test_unauthenticated_post_gets_401(self):
+        """Unauthenticated POST must be rejected with 401."""
+        response = self.client.post(self.url, self.create_payload, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_non_course_author_post_gets_403(self):
+        """Authenticated user without course-author access must get 403."""
+        non_author = UserFactory.create()
+        self.client.force_authenticate(user=non_author)
+        response = self.client.post(self.url, self.create_payload, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class TestXblockViewSetActions(APITestCase):
+    """
+    ADR 0028 – functional routing tests for XblockViewSet actions.
+
+    handle_xblock is mocked so no module store or xblock infrastructure is needed.
+    GlobalStaff (is_staff=True) satisfies HasCourseAuthorAccess without a real course.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.staff_user = UserFactory.create(is_staff=True)
+        self.client.force_authenticate(user=self.staff_user)
+        self.detail_url = reverse(
+            'cms.djangoapps.contentstore:v0:xblock-detail',
+            kwargs={'usage_key_string': TEST_LOCATOR},
+        )
+        self.list_url = reverse('cms.djangoapps.contentstore:v0:xblock-list')
+
+    @patch(MOCK_HANDLE_XBLOCK, return_value=_MOCK_RESPONSE)
+    def test_retrieve_calls_handle_xblock(self, mock_handle):
+        """GET detail URL calls handle_xblock with the usage_key_string."""
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_handle.assert_called_once()
+        self.assertEqual(mock_handle.call_args[0][1], TEST_LOCATOR)
+
+    @patch(MOCK_HANDLE_XBLOCK, return_value=_MOCK_RESPONSE)
+    def test_update_calls_handle_xblock(self, mock_handle):
+        """PUT detail URL calls handle_xblock with the usage_key_string."""
+        payload = {'category': 'html', 'data': '<p>Updated</p>', 'id': TEST_LOCATOR}
+        response = self.client.put(
+            self.detail_url, json.dumps(payload), content_type='application/json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_handle.assert_called_once()
+        self.assertEqual(mock_handle.call_args[0][1], TEST_LOCATOR)
+
+    @patch(MOCK_HANDLE_XBLOCK, return_value=_MOCK_RESPONSE)
+    def test_partial_update_calls_handle_xblock(self, mock_handle):
+        """PATCH detail URL calls handle_xblock with the usage_key_string."""
+        payload = {'category': 'html', 'data': '<p>Patched</p>', 'id': TEST_LOCATOR}
+        response = self.client.patch(
+            self.detail_url, json.dumps(payload), content_type='application/json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_handle.assert_called_once()
+        self.assertEqual(mock_handle.call_args[0][1], TEST_LOCATOR)
+
+    @patch(MOCK_HANDLE_XBLOCK, return_value=_MOCK_RESPONSE)
+    def test_destroy_calls_handle_xblock(self, mock_handle):
+        """DELETE detail URL calls handle_xblock with the usage_key_string."""
+        response = self.client.delete(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_handle.assert_called_once()
+        self.assertEqual(mock_handle.call_args[0][1], TEST_LOCATOR)
+
+    @patch(MOCK_HANDLE_XBLOCK, return_value=_MOCK_RESPONSE)
+    def test_create_calls_handle_xblock(self, mock_handle):
+        """POST list URL calls handle_xblock with usage_key_string=None."""
+        payload = {'parent_locator': TEST_LOCATOR, 'category': 'html'}
+        response = self.client.post(
+            self.list_url, json.dumps(payload), content_type='application/json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_handle.assert_called_once()
+        self.assertEqual(mock_handle.call_args[0][1], None)

--- a/cms/djangoapps/contentstore/rest_api/v0/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/urls.py
@@ -2,6 +2,7 @@
 
 from django.conf import settings
 from django.urls import re_path, path
+from rest_framework.routers import DefaultRouter
 
 from openedx.core.constants import COURSE_ID_PATTERN
 
@@ -26,9 +27,19 @@ from .views import xblock
 
 app_name = "v0"
 
+# ADR 0028: XblockViewSet registered via DefaultRouter.
+# Generates:
+#   POST   xblock/                          → xblock-list   (create)
+#   GET    xblock/{usage_key_string}/       → xblock-detail (retrieve)
+#   PUT    xblock/{usage_key_string}/       → xblock-detail (update)
+#   PATCH  xblock/{usage_key_string}/       → xblock-detail (partial_update)
+#   DELETE xblock/{usage_key_string}/       → xblock-detail (destroy)
+router = DefaultRouter()
+router.register(r'xblock', xblock.XblockViewSet, basename='xblock')
+
 VIDEO_ID_PATTERN = r'(?P<edx_video_id>[-\w]+)'
 
-urlpatterns = [
+urlpatterns = router.urls + [
     re_path(
         fr"^advanced_settings/{COURSE_ID_PATTERN}$",
         AdvancedCourseSettingsView.as_view(),
@@ -90,6 +101,8 @@ urlpatterns = [
         fr'^video_transcripts/{settings.COURSE_ID_PATTERN}$',
         TranscriptView.as_view(), name='cms_api_video_transcripts'
     ),
+    # DEPRECATED (ADR 0028): xblock URLs with course_id kept for backward compatibility.
+    # Will be removed after one named release. Use xblock/ router URLs instead.
     re_path(
         fr'^xblock/{settings.COURSE_ID_PATTERN}$',
         xblock.XblockCreateView.as_view(), name='cms_api_create_xblock'

--- a/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
@@ -1,7 +1,9 @@
 """
 Public rest API endpoints for the CMS API.
 """
+import json
 import logging
+from rest_framework import viewsets
 from rest_framework.generics import RetrieveUpdateDestroyAPIView, CreateAPIView
 from django.views.decorators.csrf import csrf_exempt
 
@@ -11,6 +13,8 @@ from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiv
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from rest_framework.permissions import IsAuthenticated
 from common.djangoapps.util.json_request import expect_json_in_class_view
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import UsageKey
 
 from cms.djangoapps.contentstore.views.permissions import HasCourseAuthorAccess
 from cms.djangoapps.contentstore.xblock_storage_handlers import view_handlers
@@ -23,6 +27,115 @@ log = logging.getLogger(__name__)
 handle_xblock = view_handlers.handle_xblock
 
 
+# ADR 0028 – consolidated from XblockView and XblockCreateView
+class XblockViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
+    """
+    ViewSet for xblock CRUD operations.
+
+    Registered via DefaultRouter with basename ``xblock``.
+    Router-generated URLs:
+      POST   /api/contentstore/v0/xblock/                          → create
+      GET    /api/contentstore/v0/xblock/{usage_key_string}/       → retrieve
+      PUT    /api/contentstore/v0/xblock/{usage_key_string}/       → update
+      PATCH  /api/contentstore/v0/xblock/{usage_key_string}/       → partial_update
+      DELETE /api/contentstore/v0/xblock/{usage_key_string}/       → destroy
+
+    course_id is not included in the router URL. It is derived in initial() from:
+      - usage_key_string (detail routes): the course key is embedded in the block key
+      - parent_locator in request.data (create route)
+    This ensures HasCourseAuthorAccess can still perform its course-level authorization.
+
+    ADR 0025 compliance notes:
+    - ``serializer_class`` is declared and used for input validation via
+      ``@validate_request_with_serializer`` on mutating methods.
+    - Response formatting is delegated to ``handle_xblock()`` which produces
+      its own JSON shape; wrapping its output in ``XblockSerializer`` requires
+      a deeper refactor and is tracked as a follow-up task.
+    """
+
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAuthenticated, HasCourseAuthorAccess)  # ADR 0026
+    serializer_class = XblockSerializer
+
+    # Matches both i4x:// legacy keys and block-v1: v2 keys
+    lookup_field = 'usage_key_string'
+    lookup_value_regex = r'(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|(?:[^/]+)'
+
+    def get_serializer(self, *args, **kwargs):
+        """Return a serializer instance using the configured serializer_class."""
+        return self.serializer_class(*args, **kwargs)
+
+    def initial(self, request, *args, **kwargs):
+        """
+        Inject ``course_id`` into self.kwargs before permission checks run.
+
+        HasCourseAuthorAccess expects ``view.kwargs['course_id']``. Router-generated
+        URLs omit course_id, so we derive it here:
+          - Detail routes: extracted from ``usage_key_string`` (the course key is
+            always encoded in the block key, e.g. block-v1:org+course+run+type@...).
+          - Create route: extracted from ``parent_locator`` in the request body.
+        """
+        if 'course_id' not in self.kwargs:
+            usage_key_string = self.kwargs.get('usage_key_string')
+            if usage_key_string:
+                try:
+                    self.kwargs['course_id'] = str(
+                        UsageKey.from_string(usage_key_string).course_key
+                    )
+                except InvalidKeyError:
+                    pass
+            else:
+                # Create path: derive from parent_locator in the request body.
+                # Access request._request.body (Django's raw bytes) rather than
+                # request.data so that Django caches the body content before DRF
+                # reads the stream.  If we used request.data here, the underlying
+                # WSGI stream would be consumed and @expect_json_in_class_view
+                # would later raise RawPostDataException when it tried to read
+                # request.body.
+                try:
+                    raw = request._request.body
+                    data = json.loads(raw) if raw else {}
+                    parent_locator = data.get('parent_locator')
+                    if parent_locator:
+                        self.kwargs['course_id'] = str(
+                            UsageKey.from_string(parent_locator).course_key
+                        )
+                except (InvalidKeyError, AttributeError, ValueError):
+                    pass
+        super().initial(request, *args, **kwargs)
+
+    # pylint: disable=arguments-differ
+    @expect_json_in_class_view
+    def retrieve(self, request, usage_key_string=None, **kwargs):
+        return handle_xblock(request, usage_key_string)
+
+    @csrf_exempt
+    @expect_json_in_class_view
+    @validate_request_with_serializer
+    def create(self, request, **kwargs):
+        return handle_xblock(request, None)
+
+    @expect_json_in_class_view
+    @validate_request_with_serializer
+    def update(self, request, usage_key_string=None, **kwargs):
+        return handle_xblock(request, usage_key_string)
+
+    @expect_json_in_class_view
+    @validate_request_with_serializer
+    def partial_update(self, request, usage_key_string=None, **kwargs):
+        return handle_xblock(request, usage_key_string)
+
+    @expect_json_in_class_view
+    def destroy(self, request, usage_key_string=None, **kwargs):
+        return handle_xblock(request, usage_key_string)
+
+
+# DEPRECATED (ADR 0028): Use XblockViewSet instead.
+# Will be removed after one named release. Use GET/PUT/PATCH/DELETE xblock/{usage_key_string}/ instead.
 class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
     """
     Public rest API endpoints for the CMS API.
@@ -65,6 +178,8 @@ class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
         return handle_xblock(request, usage_key_string)
 
 
+# DEPRECATED (ADR 0028): Use XblockViewSet instead.
+# Will be removed after one named release. Use POST xblock/ instead.
 class XblockCreateView(DeveloperErrorViewMixin, CreateAPIView):
     """
     Public rest API endpoints for the CMS API.

--- a/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
@@ -3,6 +3,14 @@ Public rest API endpoints for the CMS API.
 """
 import json
 import logging
+
+from drf_spectacular.utils import (
+    extend_schema,
+    extend_schema_view,
+    OpenApiParameter,
+    OpenApiRequest,
+    OpenApiResponse,
+)
 from rest_framework import viewsets
 from rest_framework.generics import RetrieveUpdateDestroyAPIView, CreateAPIView
 from django.views.decorators.csrf import csrf_exempt
@@ -25,6 +33,31 @@ from .utils import validate_request_with_serializer
 
 log = logging.getLogger(__name__)
 handle_xblock = view_handlers.handle_xblock
+
+
+_COURSE_ID_PARAMETER = OpenApiParameter(
+    name="course_id",
+    description="Course ID",
+    required=True,
+    type=str,
+    location=OpenApiParameter.PATH,
+)
+_USAGE_KEY_PARAMETER = OpenApiParameter(
+    name="usage_key_string",
+    description=(
+        "XBlock identifier, e.g. "
+        "'block-v1:<course id>+type@<type>+block@<block id>'."
+    ),
+    required=True,
+    type=str,
+    location=OpenApiParameter.PATH,
+)
+_COMMON_ERROR_RESPONSES = {
+    400: OpenApiResponse(description="Bad request - invalid data."),
+    401: OpenApiResponse(description="The requester is not authenticated."),
+    403: OpenApiResponse(description="The requester cannot access the specified course."),
+    404: OpenApiResponse(description="The requested course or xblock does not exist."),
+}
 
 
 # ADR 0028 – consolidated from XblockView and XblockCreateView
@@ -109,26 +142,88 @@ class XblockViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
         super().initial(request, *args, **kwargs)
 
     # pylint: disable=arguments-differ
+    @extend_schema(
+        summary="Retrieve an xblock",
+        description="Retrieve an xblock by its usage key.",
+        parameters=[_USAGE_KEY_PARAMETER],
+        responses={
+            200: OpenApiResponse(
+                response=XblockSerializer,
+                description="XBlock retrieved successfully.",
+            ),
+            **_COMMON_ERROR_RESPONSES,
+        },
+    )
     @expect_json_in_class_view
     def retrieve(self, request, usage_key_string=None, **kwargs):
         return handle_xblock(request, usage_key_string)
 
+    @extend_schema(
+        summary="Create a new xblock",
+        description=(
+            "Create a new xblock. The parent xblock is identified via "
+            "``parent_locator`` in the request body."
+        ),
+        request=OpenApiRequest(request=XblockSerializer),
+        responses={
+            200: OpenApiResponse(
+                response=XblockSerializer,
+                description="XBlock created successfully.",
+            ),
+            **_COMMON_ERROR_RESPONSES,
+        },
+    )
     @csrf_exempt
     @expect_json_in_class_view
     @validate_request_with_serializer
     def create(self, request, **kwargs):
         return handle_xblock(request, None)
 
+    @extend_schema(
+        summary="Update an xblock",
+        description="Replace an xblock's data.",
+        request=OpenApiRequest(request=XblockSerializer),
+        parameters=[_USAGE_KEY_PARAMETER],
+        responses={
+            200: OpenApiResponse(
+                response=XblockSerializer,
+                description="XBlock updated successfully.",
+            ),
+            **_COMMON_ERROR_RESPONSES,
+        },
+    )
     @expect_json_in_class_view
     @validate_request_with_serializer
     def update(self, request, usage_key_string=None, **kwargs):
         return handle_xblock(request, usage_key_string)
 
+    @extend_schema(
+        summary="Partially update an xblock",
+        description="Patch an xblock's data.",
+        request=OpenApiRequest(request=XblockSerializer),
+        parameters=[_USAGE_KEY_PARAMETER],
+        responses={
+            200: OpenApiResponse(
+                response=XblockSerializer,
+                description="XBlock updated successfully.",
+            ),
+            **_COMMON_ERROR_RESPONSES,
+        },
+    )
     @expect_json_in_class_view
     @validate_request_with_serializer
     def partial_update(self, request, usage_key_string=None, **kwargs):
         return handle_xblock(request, usage_key_string)
 
+    @extend_schema(
+        summary="Delete an xblock",
+        description="Delete an xblock by its usage key.",
+        parameters=[_USAGE_KEY_PARAMETER],
+        responses={
+            200: OpenApiResponse(description="XBlock deleted successfully."),
+            **_COMMON_ERROR_RESPONSES,
+        },
+    )
     @expect_json_in_class_view
     def destroy(self, request, usage_key_string=None, **kwargs):
         return handle_xblock(request, usage_key_string)
@@ -136,6 +231,71 @@ class XblockViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
 
 # DEPRECATED (ADR 0028): Use XblockViewSet instead.
 # Will be removed after one named release. Use GET/PUT/PATCH/DELETE xblock/{usage_key_string}/ instead.
+@extend_schema_view(
+    get=extend_schema(
+        operation_id="v0_xblock_retrieve_deprecated",
+        summary="Retrieve an xblock (deprecated)",
+        description=(
+            "Deprecated. Use GET /api/contentstore/v0/xblock/{usage_key_string}/ instead."
+        ),
+        parameters=[_COURSE_ID_PARAMETER, _USAGE_KEY_PARAMETER],
+        responses={
+            200: OpenApiResponse(
+                response=XblockSerializer,
+                description="XBlock retrieved successfully.",
+            ),
+            **_COMMON_ERROR_RESPONSES,
+        },
+        deprecated=True,
+    ),
+    put=extend_schema(
+        operation_id="v0_xblock_update_deprecated",
+        summary="Update an xblock (deprecated)",
+        description=(
+            "Deprecated. Use PUT /api/contentstore/v0/xblock/{usage_key_string}/ instead."
+        ),
+        request=OpenApiRequest(request=XblockSerializer),
+        parameters=[_COURSE_ID_PARAMETER, _USAGE_KEY_PARAMETER],
+        responses={
+            200: OpenApiResponse(
+                response=XblockSerializer,
+                description="XBlock updated successfully.",
+            ),
+            **_COMMON_ERROR_RESPONSES,
+        },
+        deprecated=True,
+    ),
+    patch=extend_schema(
+        operation_id="v0_xblock_partial_update_deprecated",
+        summary="Partially update an xblock (deprecated)",
+        description=(
+            "Deprecated. Use PATCH /api/contentstore/v0/xblock/{usage_key_string}/ instead."
+        ),
+        request=OpenApiRequest(request=XblockSerializer),
+        parameters=[_COURSE_ID_PARAMETER, _USAGE_KEY_PARAMETER],
+        responses={
+            200: OpenApiResponse(
+                response=XblockSerializer,
+                description="XBlock updated successfully.",
+            ),
+            **_COMMON_ERROR_RESPONSES,
+        },
+        deprecated=True,
+    ),
+    delete=extend_schema(
+        operation_id="v0_xblock_destroy_deprecated",
+        summary="Delete an xblock (deprecated)",
+        description=(
+            "Deprecated. Use DELETE /api/contentstore/v0/xblock/{usage_key_string}/ instead."
+        ),
+        parameters=[_COURSE_ID_PARAMETER, _USAGE_KEY_PARAMETER],
+        responses={
+            200: OpenApiResponse(description="XBlock deleted successfully."),
+            **_COMMON_ERROR_RESPONSES,
+        },
+        deprecated=True,
+    ),
+)
 class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
     """
     Public rest API endpoints for the CMS API.
@@ -180,6 +340,23 @@ class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
 
 # DEPRECATED (ADR 0028): Use XblockViewSet instead.
 # Will be removed after one named release. Use POST xblock/ instead.
+@extend_schema_view(
+    post=extend_schema(
+        operation_id="v0_xblock_create_deprecated",
+        summary="Create a new xblock (deprecated)",
+        description="Deprecated. Use POST /api/contentstore/v0/xblock/ instead.",
+        request=OpenApiRequest(request=XblockSerializer),
+        parameters=[_COURSE_ID_PARAMETER],
+        responses={
+            200: OpenApiResponse(
+                response=XblockSerializer,
+                description="XBlock created successfully.",
+            ),
+            **_COMMON_ERROR_RESPONSES,
+        },
+        deprecated=True,
+    ),
+)
 class XblockCreateView(DeveloperErrorViewMixin, CreateAPIView):
     """
     Public rest API endpoints for the CMS API.

--- a/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
@@ -5,10 +5,14 @@ import logging
 from rest_framework.generics import RetrieveUpdateDestroyAPIView, CreateAPIView
 from django.views.decorators.csrf import csrf_exempt
 
-from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
+from rest_framework.permissions import IsAuthenticated
 from common.djangoapps.util.json_request import expect_json_in_class_view
 
-from cms.djangoapps.contentstore.api import course_author_access_required
+from cms.djangoapps.contentstore.views.permissions import HasCourseAuthorAccess
 from cms.djangoapps.contentstore.xblock_storage_handlers import view_handlers
 
 from ..serializers import XblockSerializer
@@ -19,11 +23,10 @@ log = logging.getLogger(__name__)
 handle_xblock = view_handlers.handle_xblock
 
 
-@view_auth_classes()
 class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
     """
     Public rest API endpoints for the CMS API.
-    course_key: required argument, needed to authorize course authors.
+    course_id: required argument, needed to authorize course authors.
     usage_key_string (optional):
     xblock identifier, for example in the form of "block-v1:<course id>+type@<type>+block@<block id>"
 
@@ -34,37 +37,38 @@ class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
       its own JSON shape; wrapping its output in ``XblockSerializer`` requires
       a deeper refactor and is tracked as a follow-up task.
     """
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAuthenticated, HasCourseAuthorAccess)
     serializer_class = XblockSerializer
 
     # pylint: disable=arguments-differ
-    @course_author_access_required
     @expect_json_in_class_view
-    def retrieve(self, request, course_key, usage_key_string=None):
+    def retrieve(self, request, course_id, usage_key_string=None):
         return handle_xblock(request, usage_key_string)
 
-    @course_author_access_required
     @expect_json_in_class_view
     @validate_request_with_serializer
-    def update(self, request, course_key, usage_key_string=None):
+    def update(self, request, course_id, usage_key_string=None):
         return handle_xblock(request, usage_key_string)
 
-    @course_author_access_required
     @expect_json_in_class_view
     @validate_request_with_serializer
-    def partial_update(self, request, course_key, usage_key_string=None):
+    def partial_update(self, request, course_id, usage_key_string=None):
         return handle_xblock(request, usage_key_string)
 
-    @course_author_access_required
     @expect_json_in_class_view
-    def destroy(self, request, course_key, usage_key_string=None):
+    def destroy(self, request, course_id, usage_key_string=None):
         return handle_xblock(request, usage_key_string)
 
 
-@view_auth_classes()
 class XblockCreateView(DeveloperErrorViewMixin, CreateAPIView):
     """
     Public rest API endpoints for the CMS API.
-    course_key: required argument, needed to authorize course authors.
+    course_id: required argument, needed to authorize course authors.
     usage_key_string (optional):
     xblock identifier, for example in the form of "block-v1:<course id>+type@<type>+block@<block id>"
 
@@ -74,12 +78,17 @@ class XblockCreateView(DeveloperErrorViewMixin, CreateAPIView):
     - Response formatting is delegated to ``handle_xblock()``; full response
       serialization is tracked as a follow-up task.
     """
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAuthenticated, HasCourseAuthorAccess)  # ADR 0026
     serializer_class = XblockSerializer
 
     # pylint: disable=arguments-differ
     @csrf_exempt
-    @course_author_access_required
     @expect_json_in_class_view
     @validate_request_with_serializer
-    def create(self, request, course_key, usage_key_string=None):
+    def create(self, request, course_id, usage_key_string=None):
         return handle_xblock(request, usage_key_string)

--- a/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
@@ -26,6 +26,13 @@ class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
     course_key: required argument, needed to authorize course authors.
     usage_key_string (optional):
     xblock identifier, for example in the form of "block-v1:<course id>+type@<type>+block@<block id>"
+
+    ADR 0025 compliance notes:
+    - ``serializer_class`` is declared and used for input validation via
+      ``@validate_request_with_serializer`` on mutating methods.
+    - Response formatting is delegated to ``handle_xblock()`` which produces
+      its own JSON shape; wrapping its output in ``XblockSerializer`` requires
+      a deeper refactor and is tracked as a follow-up task.
     """
     serializer_class = XblockSerializer
 
@@ -60,6 +67,12 @@ class XblockCreateView(DeveloperErrorViewMixin, CreateAPIView):
     course_key: required argument, needed to authorize course authors.
     usage_key_string (optional):
     xblock identifier, for example in the form of "block-v1:<course id>+type@<type>+block@<block id>"
+
+    ADR 0025 compliance notes:
+    - ``serializer_class`` is declared and used for input validation via
+      ``@validate_request_with_serializer``.
+    - Response formatting is delegated to ``handle_xblock()``; full response
+      serialization is tracked as a follow-up task.
     """
     serializer_class = XblockSerializer
 

--- a/cms/djangoapps/contentstore/views/permissions.py
+++ b/cms/djangoapps/contentstore/views/permissions.py
@@ -4,7 +4,7 @@ Custom permissions for the content store views.
 
 from rest_framework.permissions import BasePermission
 
-from common.djangoapps.student.auth import has_studio_write_access
+from common.djangoapps.student.auth import has_course_author_access, has_studio_write_access
 from openedx.core.lib.api.view_utils import validate_course_key
 
 
@@ -20,3 +20,20 @@ class HasStudioWriteAccess(BasePermission):
         course_key_string = view.kwargs.get("course_key_string")
         course_key = validate_course_key(course_key_string)
         return has_studio_write_access(request.user, course_key)
+
+
+class HasCourseAuthorAccess(BasePermission):
+    """
+    Check if the user has course author access.
+
+    ADR 0026: replaces the ``@course_author_access_required`` method decorator.
+    Expects a ``course_id`` URL kwarg.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Check if the user has course author access.
+        """
+        course_key_string = view.kwargs.get("course_id")
+        course_key = validate_course_key(course_key_string)
+        return has_course_author_access(request.user, course_key)

--- a/docs/decisions/0025-standardize-serializer-usage.rst
+++ b/docs/decisions/0025-standardize-serializer-usage.rst
@@ -22,7 +22,7 @@ Implementation requirements:
 * Replace manual JSON construction with serializer-based responses.
 * Use serializers for both input validation and output formatting.
 * Ensure serializers are properly documented with field descriptions and validation rules.
-* Maintain backward compatibility for all APIs during migration.
+* Maintain backward compatibility for all APIs during migration. While the goal is fully compatible DRF serializers, if that is not possible and we must make a backwards incompatible change, that change MUST be handled by creating a new version of the API and transitioning to that API using the deprecation process.
 
 Relevance in edx-platform
 -------------------------

--- a/docs/decisions/0025-standardize-serializer-usage.rst
+++ b/docs/decisions/0025-standardize-serializer-usage.rst
@@ -1,0 +1,113 @@
+Standardize Serializer Usage Across APIs
+========================================
+
+:Status: Proposed
+:Date: 2026-03-09
+:Deciders: API Working Group
+:Technical Story: Open edX REST API Standards - Serializer standardization for consistency
+
+Context
+-------
+
+Many Open edX platform API endpoints manually construct JSON responses using Python dictionaries instead of Django REST Framework (DRF) serializers. This leads to inconsistent schema responses, makes validation errors harder to manage, and creates unpredictable formats that AI and third-party systems struggle with.
+
+Decision
+--------
+
+We will standardize all Open edX REST APIs to use **DRF serializers** for request and response handling.
+
+Implementation requirements:
+
+* All API views MUST define explicit serializers for request and response handling.
+* Replace manual JSON construction with serializer-based responses.
+* Use serializers for both input validation and output formatting.
+* Ensure serializers are properly documented with field descriptions and validation rules.
+* Maintain backward compatibility for all APIs during migration.
+
+Relevance in edx-platform
+-------------------------
+
+Current patterns that should be migrated:
+
+* **Certificates API** (``/api/certificates/v0/``) constructs JSON manually with nested dictionaries.
+* **Enrollment API** endpoints manually build response objects without serializers.
+* **Course API** views use hand-coded JSON responses instead of structured serializers.
+
+Code example (target serializer usage)
+--------------------------------------
+
+**Example serializer and APIView using DRF best practices:**
+
+.. code-block:: python
+
+   # serializers.py
+   from rest_framework import serializers
+
+   class CertificateSerializer(serializers.Serializer):
+       username = serializers.CharField(
+           help_text="The username of the certificate holder"
+       )
+       course_id = serializers.CharField(
+           help_text="The course identifier"
+       )
+       status = serializers.CharField(
+           help_text="The certificate status (e.g., downloadable, generating)"
+       )
+       grade = serializers.FloatField(
+           help_text="The final grade achieved"
+       )
+
+   # views.py
+   from rest_framework.views import APIView
+   from rest_framework.response import Response
+   from rest_framework import status
+
+   class CertificateAPIView(APIView):
+       def get(self, request):
+           data = {
+               "username": "john_doe",
+               "course_id": "course-v1:edX+DemoX+1T2024",
+               "status": "downloadable",
+               "grade": 0.95,
+           }
+           serializer = CertificateSerializer(data)
+           return Response(serializer.data, status=status.HTTP_200_OK)
+
+Consequences
+------------
+
+Positive
+~~~~~~~~
+
+* Simplifies validation and ensures consistent response contracts.
+* Improves AI compatibility through predictable data structures.
+* Enables automatic schema generation and documentation.
+* Reduces code duplication and maintenance overhead.
+
+Negative / Trade-offs
+~~~~~~~~~~~~~~~~~~~~~
+
+* Requires refactoring existing endpoints that manually construct JSON.
+* Initial development overhead for creating comprehensive serializers.
+* May require updates to existing client code that expects legacy formats.
+
+Alternatives Considered
+-----------------------
+
+* **Keep manual JSON construction**: rejected due to inconsistency and maintenance burden.
+* **Use DRF defaults only**: rejected because explicit serializers provide better validation and documentation.
+* **Use newer ways of managing API responses such as dataclasses or pydantic**: rejected due to complexity and unknowns in transitioning from two existing patterns (manual JSON and DRF serializers) to a third approach. While these python libraries offer better ergonomics, migration would require checking nested serializers, complex validation, and ModelSerializer-heavy endpoints. To move to some new format, we would want to prevent using the basic DRF Serializers any more than we do right now, but preventing new DRF serializers via linting is more complex than anticipated.  This work can be revisited in the future once the platform is a bit more consistent.
+
+Rollout Plan
+------------
+
+1. Audit existing endpoints to identify those using manual JSON construction.
+2. Create a library of common serializers for shared data structures.
+3. Migrate high-impact endpoints first (certificates, enrollment, courses).
+4. Update tests to validate serializer-based responses.
+5. Update API documentation to reflect new serializer-based contracts.
+
+References
+----------
+
+* Open edX REST API Standards: "Serializer Usage" recommendations for API consistency.


### PR DESCRIPTION
### Description:

The FC-0118 initiative introduces a comprehensive standardization of APIs across the platform, guided by 15 newly defined Architectural Decision Records (ADRs). These ADRs collectively establish consistent patterns for serializers, permissions, error handling, pagination, filtering, authentication, versioning, and overall API design. Through this effort, existing endpoints are being refactored and aligned to ensure uniformity, improved developer experience, and long-term maintainability, while also reducing redundancy and inconsistencies across services.

### Checklist:

- [x] 0025 – Standardize Serializer Usage
- [x] 0026 – Standardize Permission Classes
- [ ] 0027 – Standardize API Documentation & Schema Coverage
- [x] 0028 – Standardize RESTful API Endpoints using DRF ViewSets
- [ ] 0029 – Standardize Error Responses
- [ ] 0030 – Ensure GET Requests are Idempotent
- [ ] 0031 – Merge Similar Endpoints
- [x] 0032 – Standardize Pagination Usage
- [ ] 0033 – Standardize Filter & Sort using django-filter
- [ ] 0034 – Unify Auth (OAuth2 v2)
- [ ] 0035 – Port Legacy Django Views to DRF
- [ ] 0036 – Normalize Deeply Nested JSON APIs
- [ ] 0037 – API Versioning Strategy
- [ ] 0038 - Introduce Row level Security Layer
- [ ] 0039 – Modulestore CRUD APIs with Custom Serializers
- [ ] 0040 – Document & Consolidate Internal APIs used by MFEs