### PR TITLE
[FC-0018] feat: Standardize CourseDetailsView

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -2,6 +2,7 @@
 
 from django.conf import settings
 from django.urls import path, re_path
+from rest_framework.routers import DefaultRouter
 
 from openedx.core.constants import COURSE_ID_PATTERN
 
@@ -10,6 +11,7 @@ from .views import (
     ContainerHandlerView,
     CourseCertificatesView,
     CourseDetailsView,
+    CourseDetailsViewSet,
     CourseGradingView,
     CourseGroupConfigurationsView,
     CourseIndexView,
@@ -34,7 +36,11 @@ app_name = 'v1'
 
 VIDEO_ID_PATTERN = r'(?P<edx_video_id>[-\w]+)'
 
-urlpatterns = [
+# ADR 0028: ViewSets registered via DefaultRouter.
+router = DefaultRouter()
+router.register(r'course_details', CourseDetailsViewSet, basename='course_details')
+
+urlpatterns = router.urls + [
     path(
         'home',
         HomePageView.as_view(),
@@ -83,6 +89,8 @@ urlpatterns = [
         CourseIndexView.as_view(),
         name="course_index"
     ),
+    # DEPRECATED (ADR 0028): Use CourseDetailsViewSet instead (GET/PUT course_details/{course_id}/).
+    # Kept as a backward-compatible alias. Remove after one named release.
     re_path(
         fr'^course_details/{COURSE_ID_PATTERN}$',
         CourseDetailsView.as_view(),

--- a/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/__init__.py
@@ -2,7 +2,7 @@
 Views for v1 contentstore API.
 """
 from .certificates import CourseCertificatesView
-from .course_details import CourseDetailsView
+from .course_details import CourseDetailsView, CourseDetailsViewSet
 from .course_index import ContainerChildrenView, CourseIndexView
 from .course_rerun import CourseRerunView
 from .course_team import CourseTeamView

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py
@@ -4,23 +4,27 @@ import edx_api_doc_tools as apidocs
 from django.core.exceptions import ValidationError
 from common.djangoapps.util.json_request import JsonResponseBadRequest
 from opaque_keys.edx.keys import CourseKey
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from common.djangoapps.student.auth import has_studio_read_access
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from openedx.core.djangoapps.models.course_details import CourseDetails
-from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
+from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists
 from xmodule.modulestore.django import modulestore
 
+from cms.djangoapps.contentstore.views.permissions import HasStudioReadAccess
 from ..serializers import CourseDetailsSerializer
 from ....utils import update_course_details
 
 
-@view_auth_classes(is_authenticated=True)
 class CourseDetailsView(DeveloperErrorViewMixin, APIView):
     """
     View for getting and setting the course details.
     """
+    authentication_classes = (JwtAuthentication, SessionAuthenticationAllowInactiveUser)
+    permission_classes = (IsAuthenticated, HasStudioReadAccess)
     serializer_class = CourseDetailsSerializer
     @apidocs.schema(
         parameters=[
@@ -99,9 +103,6 @@ class CourseDetailsView(DeveloperErrorViewMixin, APIView):
         ```
         """
         course_key = CourseKey.from_string(course_id)
-        if not has_studio_read_access(request.user, course_key):
-            self.permission_denied(request)
-
         course_details = CourseDetails.fetch(course_key)
         serializer = self.serializer_class(course_details)
         return Response(serializer.data)
@@ -142,9 +143,6 @@ class CourseDetailsView(DeveloperErrorViewMixin, APIView):
         along with all the course's details similar to a ``GET`` request.
         """
         course_key = CourseKey.from_string(course_id)
-        if not has_studio_read_access(request.user, course_key):
-            self.permission_denied(request)
-
         course_block = modulestore().get_course(course_key)
 
         try:

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py
@@ -7,6 +7,7 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework import viewsets
 from rest_framework.views import APIView
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
@@ -19,6 +20,108 @@ from ..serializers import CourseDetailsSerializer
 from ....utils import update_course_details
 
 
+# ADR 0028 – consolidated from CourseDetailsView
+class CourseDetailsViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
+    """
+    ViewSet for course details.  Registered via DefaultRouter (basename ``course_details``).
+
+    Router-generated URLs:
+      GET  /api/contentstore/v1/course_details/{course_id}/  → retrieve
+      PUT  /api/contentstore/v1/course_details/{course_id}/  → update
+
+    ADR 0025 compliance notes:
+    - ``serializer_class`` declared; used for both response serialization and apidocs schema.
+    - Request validation is handled by ``update_course_details()`` (service layer) and
+      the ``@verify_course_exists()`` decorator.
+    """
+
+    authentication_classes = (JwtAuthentication, SessionAuthenticationAllowInactiveUser)
+    permission_classes = (IsAuthenticated, HasStudioReadAccess)  # ADR 0026
+    serializer_class = CourseDetailsSerializer
+
+    # Matches both slash-separated (org/course/run) and plus-separated (course-v1:org+course+run) IDs
+    lookup_field = 'course_id'
+    lookup_value_regex = r'[^/+]+(?:/|\+)[^/+]+(?:/|\+)[^/?]+'
+
+    @apidocs.schema(
+        parameters=[
+            apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
+        ],
+        responses={
+            200: CourseDetailsSerializer,
+            401: "The requester is not authenticated.",
+            403: "The requester cannot access the specified course.",
+            404: "The requested course does not exist.",
+        },
+    )
+    @verify_course_exists()
+    def retrieve(self, request: Request, course_id: str):
+        """
+        Get an object containing all the course details.
+
+        **Example Request**
+
+            GET /api/contentstore/v1/course_details/{course_id}/
+
+        **Response Values**
+
+        If the request is successful, an HTTP 200 "OK" response is returned.
+
+        The HTTP 200 response contains a single dict that contains keys that
+        are the course's details.
+        """
+        course_key = CourseKey.from_string(course_id)
+        course_details = CourseDetails.fetch(course_key)
+        serializer = self.serializer_class(course_details)
+        return Response(serializer.data)
+
+    @apidocs.schema(
+        body=CourseDetailsSerializer,
+        parameters=[
+            apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
+        ],
+        responses={
+            200: CourseDetailsSerializer,
+            401: "The requester is not authenticated.",
+            403: "The requester cannot access the specified course.",
+            404: "The requested course does not exist.",
+        },
+    )
+    @verify_course_exists()
+    def update(self, request: Request, course_id: str):
+        """
+        Update a course's details.
+
+        **Example Request**
+
+            PUT /api/contentstore/v1/course_details/{course_id}/
+
+        **PUT Parameters**
+
+        The data sent for a put request should follow a similar format as
+        is returned by a ``GET`` request. Multiple details can be updated in
+        a single request, however only the ``value`` field can be updated;
+        any other fields, if included, will be ignored.
+
+        **Response Values**
+
+        If the request is successful, an HTTP 200 "OK" response is returned,
+        along with all the course's details similar to a ``GET`` request.
+        """
+        course_key = CourseKey.from_string(course_id)
+        course_block = modulestore().get_course(course_key)
+
+        try:
+            updated_data = update_course_details(request, course_key, request.data, course_block)
+        except ValidationError as err:
+            return JsonResponseBadRequest({"error": err.message})
+
+        serializer = self.serializer_class(updated_data)
+        return Response(serializer.data)
+
+
+# DEPRECATED (ADR 0028): Use CourseDetailsViewSet instead.
+# Will be removed after one named release. Use GET/PUT course_details/{course_id}/ instead.
 class CourseDetailsView(DeveloperErrorViewMixin, APIView):
     """
     View for getting and setting the course details.

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py
@@ -1,6 +1,11 @@
 """ API Views for course details """
 
-import edx_api_doc_tools as apidocs
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiParameter,
+    OpenApiRequest,
+    OpenApiResponse,
+)
 from django.core.exceptions import ValidationError
 from common.djangoapps.util.json_request import JsonResponseBadRequest
 from opaque_keys.edx.keys import CourseKey
@@ -20,6 +25,20 @@ from ..serializers import CourseDetailsSerializer
 from ....utils import update_course_details
 
 
+_COURSE_ID_PARAMETER = OpenApiParameter(
+    name="course_id",
+    description="Course ID",
+    required=True,
+    type=str,
+    location=OpenApiParameter.PATH,
+)
+_COMMON_ERROR_RESPONSES = {
+    401: OpenApiResponse(description="The requester is not authenticated."),
+    403: OpenApiResponse(description="The requester cannot access the specified course."),
+    404: OpenApiResponse(description="The requested course does not exist."),
+}
+
+
 # ADR 0028 – consolidated from CourseDetailsView
 class CourseDetailsViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
     """
@@ -30,7 +49,7 @@ class CourseDetailsViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
       PUT  /api/contentstore/v1/course_details/{course_id}/  → update
 
     ADR 0025 compliance notes:
-    - ``serializer_class`` declared; used for both response serialization and apidocs schema.
+    - ``serializer_class`` declared; used for both response serialization and OpenAPI schema.
     - Request validation is handled by ``update_course_details()`` (service layer) and
       the ``@verify_course_exists()`` decorator.
     """
@@ -43,15 +62,16 @@ class CourseDetailsViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
     lookup_field = 'course_id'
     lookup_value_regex = r'[^/+]+(?:/|\+)[^/+]+(?:/|\+)[^/?]+'
 
-    @apidocs.schema(
-        parameters=[
-            apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
-        ],
+    @extend_schema(
+        summary="Retrieve a course's details",
+        description="Get an object containing all the course details for the specified course.",
+        parameters=[_COURSE_ID_PARAMETER],
         responses={
-            200: CourseDetailsSerializer,
-            401: "The requester is not authenticated.",
-            403: "The requester cannot access the specified course.",
-            404: "The requested course does not exist.",
+            200: OpenApiResponse(
+                response=CourseDetailsSerializer,
+                description="Course details retrieved successfully.",
+            ),
+            **_COMMON_ERROR_RESPONSES,
         },
     )
     @verify_course_exists()
@@ -75,16 +95,18 @@ class CourseDetailsViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
         serializer = self.serializer_class(course_details)
         return Response(serializer.data)
 
-    @apidocs.schema(
-        body=CourseDetailsSerializer,
-        parameters=[
-            apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
-        ],
+    @extend_schema(
+        summary="Update a course's details",
+        description="Update the details for the specified course.",
+        request=OpenApiRequest(request=CourseDetailsSerializer),
+        parameters=[_COURSE_ID_PARAMETER],
         responses={
-            200: CourseDetailsSerializer,
-            401: "The requester is not authenticated.",
-            403: "The requester cannot access the specified course.",
-            404: "The requested course does not exist.",
+            200: OpenApiResponse(
+                response=CourseDetailsSerializer,
+                description="Course details updated successfully.",
+            ),
+            400: OpenApiResponse(description="Bad request - invalid data."),
+            **_COMMON_ERROR_RESPONSES,
         },
     )
     @verify_course_exists()
@@ -129,16 +151,21 @@ class CourseDetailsView(DeveloperErrorViewMixin, APIView):
     authentication_classes = (JwtAuthentication, SessionAuthenticationAllowInactiveUser)
     permission_classes = (IsAuthenticated, HasStudioReadAccess)
     serializer_class = CourseDetailsSerializer
-    @apidocs.schema(
-        parameters=[
-            apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
-        ],
+    @extend_schema(
+        operation_id="v1_course_details_retrieve_deprecated",
+        summary="Retrieve a course's details (deprecated)",
+        description=(
+            "Deprecated. Use GET /api/contentstore/v1/course_details/{course_id}/ instead."
+        ),
+        parameters=[_COURSE_ID_PARAMETER],
         responses={
-            200: CourseDetailsSerializer,
-            401: "The requester is not authenticated.",
-            403: "The requester cannot access the specified course.",
-            404: "The requested course does not exist.",
+            200: OpenApiResponse(
+                response=CourseDetailsSerializer,
+                description="Course details retrieved successfully.",
+            ),
+            **_COMMON_ERROR_RESPONSES,
         },
+        deprecated=True,
     )
     @verify_course_exists()
     def get(self, request: Request, course_id: str):
@@ -210,17 +237,23 @@ class CourseDetailsView(DeveloperErrorViewMixin, APIView):
         serializer = self.serializer_class(course_details)
         return Response(serializer.data)
 
-    @apidocs.schema(
-        body=CourseDetailsSerializer,
-        parameters=[
-            apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
-        ],
+    @extend_schema(
+        operation_id="v1_course_details_update_deprecated",
+        summary="Update a course's details (deprecated)",
+        description=(
+            "Deprecated. Use PUT /api/contentstore/v1/course_details/{course_id}/ instead."
+        ),
+        request=OpenApiRequest(request=CourseDetailsSerializer),
+        parameters=[_COURSE_ID_PARAMETER],
         responses={
-            200: CourseDetailsSerializer,
-            401: "The requester is not authenticated.",
-            403: "The requester cannot access the specified course.",
-            404: "The requested course does not exist.",
+            200: OpenApiResponse(
+                response=CourseDetailsSerializer,
+                description="Course details updated successfully.",
+            ),
+            400: OpenApiResponse(description="Bad request - invalid data."),
+            **_COMMON_ERROR_RESPONSES,
         },
+        deprecated=True,
     )
     @verify_course_exists()
     def put(self, request: Request, course_id: str):

--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_details.py
@@ -21,6 +21,7 @@ class CourseDetailsView(DeveloperErrorViewMixin, APIView):
     """
     View for getting and setting the course details.
     """
+    serializer_class = CourseDetailsSerializer
     @apidocs.schema(
         parameters=[
             apidocs.string_parameter("course_id", apidocs.ParameterLocation.PATH, description="Course ID"),
@@ -102,7 +103,7 @@ class CourseDetailsView(DeveloperErrorViewMixin, APIView):
             self.permission_denied(request)
 
         course_details = CourseDetails.fetch(course_key)
-        serializer = CourseDetailsSerializer(course_details)
+        serializer = self.serializer_class(course_details)
         return Response(serializer.data)
 
     @apidocs.schema(
@@ -151,5 +152,5 @@ class CourseDetailsView(DeveloperErrorViewMixin, APIView):
         except ValidationError as err:
             return JsonResponseBadRequest({"error": err.message})
 
-        serializer = CourseDetailsSerializer(updated_data)
+        serializer = self.serializer_class(updated_data)
         return Response(serializer.data)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_details.py
@@ -5,10 +5,13 @@ import json
 from unittest.mock import patch
 
 import ddt
+from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APIClient
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from common.djangoapps.student.tests.factories import UserFactory
 
 from ...mixins import PermissionAccessMixin
 
@@ -110,4 +113,73 @@ class CourseDetailsViewTest(CourseTestCase, PermissionAccessMixin):
             data=json.dumps(request_data),
             content_type="application/json",
         )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class CourseDetailsViewPermissionsTest(CourseTestCase):
+    """
+    ADR 0026 – permission regression tests for CourseDetailsView.
+
+    Verifies that permission_classes = (IsAuthenticated, HasStudioReadAccess) enforces
+    the same access rules previously split between @view_auth_classes(is_authenticated=True)
+    and the inline has_studio_read_access() checks in get() and put().
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse(
+            "cms.djangoapps.contentstore:v1:course_details",
+            kwargs={"course_id": self.course.id},
+        )
+
+    # --- Unauthenticated ---
+    def test_unauthenticated_get_returns_401(self):
+        """
+        Unauthenticated GET must return 401.
+
+        Before ADR 0026: enforced by @view_auth_classes(is_authenticated=True).
+        After ADR 0026: enforced by IsAuthenticated in permission_classes.
+        """
+        self.client.logout()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_unauthenticated_put_returns_401(self):
+        """
+        Unauthenticated PUT must return 401.
+
+        Before ADR 0026: enforced by @view_auth_classes(is_authenticated=True).
+        After ADR 0026: enforced by IsAuthenticated in permission_classes.
+        """
+        self.client.logout()
+        response = self.client.put(self.url, data={}, content_type="application/json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # --- Authenticated but no course access ---
+    def test_non_staff_get_returns_403(self):
+        """
+        Authenticated user without course staff role must receive 403 on GET.
+
+        Before ADR 0026: enforced by inline has_studio_read_access() check in get().
+        After ADR 0026: enforced by HasStudioReadAccess in permission_classes.
+        """
+        client, _ = self.create_non_staff_authed_user_client()
+        response = client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_non_staff_put_returns_403(self):
+        """
+        Authenticated user without course staff role must receive 403 on PUT.
+
+        Before ADR 0026: enforced by inline has_studio_read_access() check in put().
+        After ADR 0026: enforced by HasStudioReadAccess in permission_classes.
+        """
+        client, _ = self.create_non_staff_authed_user_client()
+        response = client.put(self.url, data={}, content_type="application/json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # --- Authorized ---
+    def test_course_staff_get_returns_200(self):
+        """Course staff/instructor must receive 200 on GET."""
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_details_viewset.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_details_viewset.py
@@ -1,0 +1,129 @@
+"""
+Unit tests for CourseDetailsViewSet (ADR 0028).
+
+MongoDB-free: all service-layer calls are mocked so these tests run without a
+live modulestore.  Permission-boundary tests use force_authenticate with a
+plain (non-staff) or global-staff User factory instance.
+"""
+from unittest.mock import MagicMock, patch
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from cms.djangoapps.contentstore.rest_api.v1.views.course_details import CourseDetailsViewSet
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+# ------------------------------------------------------------------
+# Mock target paths
+# ------------------------------------------------------------------
+MOCK_FETCH = 'openedx.core.djangoapps.models.course_details.CourseDetails.fetch'
+MOCK_MODULESTORE = (
+    'cms.djangoapps.contentstore.rest_api.v1.views.course_details.modulestore'
+)
+MOCK_UPDATE = (
+    'cms.djangoapps.contentstore.rest_api.v1.views.course_details.update_course_details'
+)
+
+TEST_COURSE_ID = 'course-v1:org+course+run'
+
+
+class TestCourseDetailsViewSetPermissions(APITestCase):
+    """
+    ADR 0028 – permission regression tests for CourseDetailsViewSet.
+
+    Verifies that IsAuthenticated + HasStudioReadAccess enforce the same access
+    rules as the deprecated CourseDetailsView.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse(
+            'cms.djangoapps.contentstore:v1:course_details-detail',
+            kwargs={'course_id': TEST_COURSE_ID},
+        )
+
+    # --- Unauthenticated ---
+
+    def test_unauthenticated_get_returns_401(self):
+        """Unauthenticated GET must return 401 (IsAuthenticated)."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_unauthenticated_put_returns_401(self):
+        """Unauthenticated PUT must return 401 (IsAuthenticated)."""
+        response = self.client.put(self.url, data={}, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # --- Authenticated but no studio access ---
+
+    def test_non_staff_get_returns_403(self):
+        """Authenticated user without studio access must receive 403 on GET (HasStudioReadAccess)."""
+        user = UserFactory.create(is_staff=False)
+        self.client.force_authenticate(user=user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_non_staff_put_returns_403(self):
+        """Authenticated user without studio access must receive 403 on PUT (HasStudioReadAccess)."""
+        user = UserFactory.create(is_staff=False)
+        self.client.force_authenticate(user=user)
+        response = self.client.put(self.url, data={}, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class TestCourseDetailsViewSetActions(APITestCase):
+    """
+    Action tests for CourseDetailsViewSet (retrieve and update).
+
+    Uses a global-staff user (is_staff=True) so HasStudioReadAccess passes
+    without needing a real course in the DB.  All service-layer calls are mocked.
+
+    patch.object is used instead of string-based patch() because:
+      1. CourseOverview.course_exists falls through to modulestore().has_course() when no
+         CourseOverview row exists in the test DB — patch.object reliably replaces the
+         classmethod before any code path can reach MongoDB.
+      2. serializer_class is stored as a class attribute reference at class-definition time,
+         so patching the module-level name has no effect; patch.object on the ViewSet class
+         replaces the live attribute directly.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create(is_staff=True)
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse(
+            'cms.djangoapps.contentstore:v1:course_details-detail',
+            kwargs={'course_id': TEST_COURSE_ID},
+        )
+
+    @patch.object(CourseDetailsViewSet, 'serializer_class')
+    @patch.object(CourseOverview, 'course_exists', return_value=True)
+    @patch(MOCK_FETCH)
+    def test_retrieve_calls_course_details_fetch(self, mock_fetch, mock_exists, mock_ser_cls):
+        """GET calls CourseDetails.fetch() and returns 200."""
+        mock_fetch.return_value = MagicMock()
+        mock_ser_cls.return_value.data = {'course_id': 'run'}
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_fetch.assert_called_once()
+
+    @patch.object(CourseDetailsViewSet, 'serializer_class')
+    @patch.object(CourseOverview, 'course_exists', return_value=True)
+    @patch(MOCK_UPDATE)
+    @patch(MOCK_MODULESTORE)
+    def test_update_calls_update_course_details(
+        self, mock_store, mock_update, mock_exists, mock_ser_cls
+    ):
+        """PUT calls update_course_details() and returns 200."""
+        mock_store.return_value.get_course.return_value = MagicMock()
+        mock_update.return_value = MagicMock()
+        mock_ser_cls.return_value.data = {'course_id': 'run'}
+
+        response = self.client.put(self.url, data={}, content_type='application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_update.assert_called_once()

--- a/cms/djangoapps/contentstore/views/permissions.py
+++ b/cms/djangoapps/contentstore/views/permissions.py
@@ -4,7 +4,7 @@ Custom permissions for the content store views.
 
 from rest_framework.permissions import BasePermission
 
-from common.djangoapps.student.auth import has_studio_write_access
+from common.djangoapps.student.auth import has_studio_read_access, has_studio_write_access
 from openedx.core.lib.api.view_utils import validate_course_key
 
 
@@ -20,3 +20,20 @@ class HasStudioWriteAccess(BasePermission):
         course_key_string = view.kwargs.get("course_key_string")
         course_key = validate_course_key(course_key_string)
         return has_studio_write_access(request.user, course_key)
+
+
+class HasStudioReadAccess(BasePermission):
+    """
+    Check if the user has read access to studio for the requested course.
+
+    ADR 0026: replaces inline ``if not has_studio_read_access(request.user, course_key):
+    self.permission_denied(request)`` checks previously embedded in view methods
+    (e.g. CourseDetailsView.get() and CourseDetailsView.put()).
+
+    Expects the view to receive the course identifier as a ``course_id`` URL kwarg.
+    """
+
+    def has_permission(self, request, view):
+        course_key_string = view.kwargs.get("course_id")
+        course_key = validate_course_key(course_key_string)
+        return has_studio_read_access(request.user, course_key)

--- a/docs/decisions/0025-standardize-serializer-usage.rst
+++ b/docs/decisions/0025-standardize-serializer-usage.rst
@@ -22,7 +22,7 @@ Implementation requirements:
 * Replace manual JSON construction with serializer-based responses.
 * Use serializers for both input validation and output formatting.
 * Ensure serializers are properly documented with field descriptions and validation rules.
-* Maintain backward compatibility for all APIs during migration.
+* Maintain backward compatibility for all APIs during migration. While the goal is fully compatible DRF serializers, if that is not possible and we must make a backwards incompatible change, that change MUST be handled by creating a new version of the API and transitioning to that API using the deprecation process.
 
 Relevance in edx-platform
 -------------------------

--- a/docs/decisions/0025-standardize-serializer-usage.rst
+++ b/docs/decisions/0025-standardize-serializer-usage.rst
@@ -1,0 +1,113 @@
+Standardize Serializer Usage Across APIs
+========================================
+
+:Status: Proposed
+:Date: 2026-03-09
+:Deciders: API Working Group
+:Technical Story: Open edX REST API Standards - Serializer standardization for consistency
+
+Context
+-------
+
+Many Open edX platform API endpoints manually construct JSON responses using Python dictionaries instead of Django REST Framework (DRF) serializers. This leads to inconsistent schema responses, makes validation errors harder to manage, and creates unpredictable formats that AI and third-party systems struggle with.
+
+Decision
+--------
+
+We will standardize all Open edX REST APIs to use **DRF serializers** for request and response handling.
+
+Implementation requirements:
+
+* All API views MUST define explicit serializers for request and response handling.
+* Replace manual JSON construction with serializer-based responses.
+* Use serializers for both input validation and output formatting.
+* Ensure serializers are properly documented with field descriptions and validation rules.
+* Maintain backward compatibility for all APIs during migration.
+
+Relevance in edx-platform
+-------------------------
+
+Current patterns that should be migrated:
+
+* **Certificates API** (``/api/certificates/v0/``) constructs JSON manually with nested dictionaries.
+* **Enrollment API** endpoints manually build response objects without serializers.
+* **Course API** views use hand-coded JSON responses instead of structured serializers.
+
+Code example (target serializer usage)
+--------------------------------------
+
+**Example serializer and APIView using DRF best practices:**
+
+.. code-block:: python
+
+   # serializers.py
+   from rest_framework import serializers
+
+   class CertificateSerializer(serializers.Serializer):
+       username = serializers.CharField(
+           help_text="The username of the certificate holder"
+       )
+       course_id = serializers.CharField(
+           help_text="The course identifier"
+       )
+       status = serializers.CharField(
+           help_text="The certificate status (e.g., downloadable, generating)"
+       )
+       grade = serializers.FloatField(
+           help_text="The final grade achieved"
+       )
+
+   # views.py
+   from rest_framework.views import APIView
+   from rest_framework.response import Response
+   from rest_framework import status
+
+   class CertificateAPIView(APIView):
+       def get(self, request):
+           data = {
+               "username": "john_doe",
+               "course_id": "course-v1:edX+DemoX+1T2024",
+               "status": "downloadable",
+               "grade": 0.95,
+           }
+           serializer = CertificateSerializer(data)
+           return Response(serializer.data, status=status.HTTP_200_OK)
+
+Consequences
+------------
+
+Positive
+~~~~~~~~
+
+* Simplifies validation and ensures consistent response contracts.
+* Improves AI compatibility through predictable data structures.
+* Enables automatic schema generation and documentation.
+* Reduces code duplication and maintenance overhead.
+
+Negative / Trade-offs
+~~~~~~~~~~~~~~~~~~~~~
+
+* Requires refactoring existing endpoints that manually construct JSON.
+* Initial development overhead for creating comprehensive serializers.
+* May require updates to existing client code that expects legacy formats.
+
+Alternatives Considered
+-----------------------
+
+* **Keep manual JSON construction**: rejected due to inconsistency and maintenance burden.
+* **Use DRF defaults only**: rejected because explicit serializers provide better validation and documentation.
+* **Use newer ways of managing API responses such as dataclasses or pydantic**: rejected due to complexity and unknowns in transitioning from two existing patterns (manual JSON and DRF serializers) to a third approach. While these python libraries offer better ergonomics, migration would require checking nested serializers, complex validation, and ModelSerializer-heavy endpoints. To move to some new format, we would want to prevent using the basic DRF Serializers any more than we do right now, but preventing new DRF serializers via linting is more complex than anticipated.  This work can be revisited in the future once the platform is a bit more consistent.
+
+Rollout Plan
+------------
+
+1. Audit existing endpoints to identify those using manual JSON construction.
+2. Create a library of common serializers for shared data structures.
+3. Migrate high-impact endpoints first (certificates, enrollment, courses).
+4. Update tests to validate serializer-based responses.
+5. Update API documentation to reflect new serializer-based contracts.
+
+References
+----------
+
+* Open edX REST API Standards: "Serializer Usage" recommendations for API consistency.


### PR DESCRIPTION
### Description:

The FC-0118 initiative introduces a comprehensive standardization of APIs across the platform, guided by 15 newly defined Architectural Decision Records (ADRs). These ADRs collectively establish consistent patterns for serializers, permissions, error handling, pagination, filtering, authentication, versioning, and overall API design. Through this effort, existing endpoints are being refactored and aligned to ensure uniformity, improved developer experience, and long-term maintainability, while also reducing redundancy and inconsistencies across services.

### Checklist:

- [x] 0025 – Standardize Serializer Usage
- [x] 0026 – Standardize Permission Classes
- [ ] 0027 – Standardize API Documentation & Schema Coverage
- [x] 0028 – Standardize RESTful API Endpoints using DRF ViewSets
- [ ] 0029 – Standardize Error Responses
- [ ] 0030 – Ensure GET Requests are Idempotent
- [ ] 0031 – Merge Similar Endpoints
- [x] 0032 – Standardize Pagination Usage
- [ ] 0033 – Standardize Filter & Sort using django-filter
- [ ] 0034 – Unify Auth (OAuth2 v2)
- [ ] 0035 – Port Legacy Django Views to DRF
- [ ] 0036 – Normalize Deeply Nested JSON APIs
- [ ] 0037 – API Versioning Strategy
- [ ] 0038 - Introduce Row level Security Layer
- [ ] 0039 – Modulestore CRUD APIs with Custom Serializers
- [ ] 0040 – Document & Consolidate Internal APIs used by MFEs