### PR TITLE
DEPR: Remove unused is_new studio course advanced setting

### DIFF
--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -476,14 +476,6 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
         ),
         scope=Scope.settings
     )
-    is_new = Boolean(
-        display_name=_("Course Is New"),
-        help=_(
-            "Enter true or false. If true, the course appears in the list of new courses, and a New! "
-            "badge temporarily appears next to the course image."
-        ),
-        scope=Scope.settings
-    )
     mobile_available = Boolean(
         display_name=_("Mobile Course Available"),
         help=_("Enter true or false. If true, the course will be available to mobile devices."),
@@ -1389,32 +1381,6 @@ class CourseBlock(
             return False
 
         return bool(config.get("always_cohort_inline_discussions", False))
-
-    @property
-    def is_newish(self):
-        """
-        Returns if the course has been flagged as new. If
-        there is no flag, return a heuristic value considering the
-        announcement and the start dates.
-        """
-        flag = self.is_new
-        if flag is None:
-            # Use a heuristic if the course has not been flagged
-            announcement, start, now = course_metadata_utils.sorting_dates(
-                self.start, self.advertised_start, self.announcement
-            )
-            if announcement and (now - announcement).days < 30:
-                # The course has been announced for less that month
-                return True
-            elif (now - start).days < 1:
-                # The course has not started yet
-                return True
-            else:
-                return False
-        elif isinstance(flag, str):
-            return flag.lower() in ['true', 'yes', 'y']
-        else:
-            return bool(flag)
 
     @property
     def sorting_score(self):

--- a/xmodule/tests/test_course_block.py
+++ b/xmodule/tests/test_course_block.py
@@ -77,7 +77,6 @@ class DummyModuleStoreRuntime(XMLImportingModuleStoreRuntime):  # pylint: disabl
 def get_dummy_course(
     start,
     announcement=None,
-    is_new=None,
     advertised_start=None,
     end=None,
     certs='end',
@@ -89,7 +88,6 @@ def get_dummy_course(
     def to_attrb(n, v):
         return '' if v is None else f'{n}="{v}"'.lower()
 
-    is_new = to_attrb('is_new', is_new)
     announcement = to_attrb('announcement', announcement)
     advertised_start = to_attrb('advertised_start', advertised_start)
     end = to_attrb('end', end)
@@ -99,7 +97,6 @@ def get_dummy_course(
                 graceperiod="1 day" url_name="test"
                 start="{start}"
                 {announcement}
-                {is_new}
                 {advertised_start}
                 {end}
                 certificates_display_behavior="{certs}">
@@ -111,7 +108,6 @@ def get_dummy_course(
         org=ORG,
         course=COURSE,
         start=start,
-        is_new=is_new,
         announcement=announcement,
         advertised_start=advertised_start,
         end=end,
@@ -175,112 +171,6 @@ class CourseSummaryHasEnded(unittest.TestCase):
         bad_end_date = parser.parse("2012-02-21 10:28:45")
         summary = xmodule.course_block.CourseSummary(test_course.id, end=bad_end_date)
         assert summary.has_ended()
-
-
-@ddt.ddt
-class IsNewCourseTestCase(unittest.TestCase):
-    """Make sure the property is_new works on courses"""
-
-    def setUp(self):
-        super().setUp()
-
-        # Needed for test_is_newish
-        datetime_patcher = patch.object(
-            xmodule.course_metadata_utils, 'datetime',
-            Mock(wraps=datetime)
-        )
-        mocked_datetime = datetime_patcher.start()
-        mocked_datetime.now.return_value = NOW
-        self.addCleanup(datetime_patcher.stop)
-
-    @patch('xmodule.course_metadata_utils.datetime.now')
-    def test_sorting_score(self, gmtime_mock):
-        gmtime_mock.return_value = NOW
-
-        day1 = '2012-01-01T12:00'
-        day2 = '2012-01-02T12:00'
-
-        dates = [
-            # Announce date takes priority over actual start
-            # and courses announced on a later date are newer
-            # than courses announced for an earlier date
-            ((day1, day2, None), (day1, day1, None), self.assertLess),
-            ((day1, day1, None), (day2, day1, None), self.assertEqual),
-
-            # Announce dates take priority over advertised starts
-            ((day1, day2, day1), (day1, day1, day1), self.assertLess),
-            ((day1, day1, day2), (day2, day1, day2), self.assertEqual),
-
-            # Later start == newer course
-            ((day2, None, None), (day1, None, None), self.assertLess),
-            ((day1, None, None), (day1, None, None), self.assertEqual),
-
-            # Non-parseable advertised starts are ignored in preference to actual starts
-            ((day2, None, "Spring"), (day1, None, "Fall"), self.assertLess),
-            ((day1, None, "Spring"), (day1, None, "Fall"), self.assertEqual),
-
-            # Partially parsable advertised starts should take priority over start dates
-            ((day2, None, "October 2013"), (day2, None, "October 2012"), self.assertLess),
-            ((day2, None, "October 2013"), (day1, None, "October 2013"), self.assertEqual),
-
-            # Parseable advertised starts take priority over start dates
-            ((day1, None, day2), (day1, None, day1), self.assertLess),
-            ((day2, None, day2), (day1, None, day2), self.assertEqual),
-        ]
-
-        for a, b, assertion in dates:
-            a_score = get_dummy_course(start=a[0], announcement=a[1], advertised_start=a[2]).sorting_score
-            b_score = get_dummy_course(start=b[0], announcement=b[1], advertised_start=b[2]).sorting_score
-            print(f"Comparing {a} to {b}")
-            assertion(a_score, b_score)
-
-    start_advertised_settings = [
-        # start, advertised, result, is_still_default, date_time_result
-        ('2012-12-02T12:00', None, 'Dec 02, 2012', False, 'Dec 02, 2012 at 12:00 UTC'),
-        ('2012-12-02T12:00', '2011-11-01T12:00', 'Nov 01, 2011', False, 'Nov 01, 2011 at 12:00 UTC'),
-        ('2012-12-02T12:00', 'Spring 2012', 'Spring 2012', False, 'Spring 2012'),
-        ('2012-12-02T12:00', 'November, 2011', 'November, 2011', False, 'November, 2011'),
-        (xmodule.course_block.CourseFields.start.default, None, 'TBD', True, 'TBD'),
-        (xmodule.course_block.CourseFields.start.default, 'January 2014', 'January 2014', False, 'January 2014'),
-    ]
-
-    def test_start_date_is_default(self):
-        for s in self.start_advertised_settings:
-            d = get_dummy_course(start=s[0], advertised_start=s[1])
-            assert d.start_date_is_still_default == s[3]
-
-    def test_display_organization(self):
-        block = get_dummy_course(start='2012-12-02T12:00', is_new=True)
-        assert block.location.org != block.display_org_with_default
-        assert block.display_org_with_default == f'{ORG}_display'
-
-    def test_display_coursenumber(self):
-        block = get_dummy_course(start='2012-12-02T12:00', is_new=True)
-        assert block.location.course != block.display_number_with_default
-        assert block.display_number_with_default == f'{COURSE}_display'
-
-    def test_is_newish(self):
-        block = get_dummy_course(start='2012-12-02T12:00', is_new=True)
-        assert block.is_newish is True
-
-        block = get_dummy_course(start='2013-02-02T12:00', is_new=False)
-        assert block.is_newish is False
-
-        block = get_dummy_course(start='2013-02-02T12:00', is_new=True)
-        assert block.is_newish is True
-
-        block = get_dummy_course(start='2013-01-15T12:00')
-        assert block.is_newish is True
-
-        block = get_dummy_course(start='2013-03-01T12:00')
-        assert block.is_newish is True
-
-        block = get_dummy_course(start='2012-10-15T12:00')
-        assert block.is_newish is False
-
-        block = get_dummy_course(start='2012-12-31T12:00')
-        assert block.is_newish is True
-
 
 class DiscussionTopicsTestCase(unittest.TestCase):
 


### PR DESCRIPTION
## Description

Removes unused `is_new` course advanced setting, as described in the associated DEPR ticket: https://github.com/openedx/openedx-platform/issues/38360

This affects course authors insofar as the "Course is new" advanced setting will no longer appear in the Studio Advanced Settings list, but given this setting no longer does anything, it's not a true breaking change.

## Supporting information

https://github.com/openedx/openedx-platform/issues/38360

The Course Is New setting is meant to update the course catalog to highlight new features, according to the description in Studio Advanced Settings:

<img width="445" height="172" alt="Image" src="https://github.com/user-attachments/assets/2b1c33b6-753f-4b89-93f4-5a84ad21b129" />

However it seems like the code paths do not exist for the legacy catalog and were most assuredly not ported to the Catalog MFE. to reimplement this feature a lot would need to be done:

* Exposing the “is_new” in platform APIs
* Creating a design for a “new” flag on course card
* Consuming the “is_new” flag in the Catalog MFE, and implementing the new design to show on the course card
* Updating edx-search to change the way that sorting works to somehow “expose” the new courses
* Consuming the changes to edx-search in the Catalog MFE

## Deadline

"None" 