### PR TITLE
feat: add is_enrolled field to learners endpoint response

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_api_v2.py
@@ -8,10 +8,11 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import InstructorFactory, UserFactory
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.instructor_task.models import InstructorTask
-from xmodule.modulestore.tests.django_utils import CourseEnrollment, ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 
 

--- a/lms/djangoapps/instructor/tests/views/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_api_v2.py
@@ -11,7 +11,7 @@ from rest_framework.test import APIClient
 from common.djangoapps.student.tests.factories import InstructorFactory, UserFactory
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.instructor_task.models import InstructorTask
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import CourseEnrollment, ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 
 
@@ -52,6 +52,20 @@ class LearnerViewTestCase(ModuleStoreTestCase):
         self.assertEqual(data['email'], 'john@example.com')  # noqa: PT009
         self.assertEqual(data['full_name'], 'John Harvard')  # noqa: PT009
         self.assertEqual(data['progress_url'], expected_progress_url)  # noqa: PT009
+        self.assertFalse(data['is_enrolled'])  # noqa: PT009
+
+    def test_get_learner_by_username_enrolled(self):
+        """Test that is_enrolled is true for users enrolled in the course"""
+        CourseEnrollment.enroll(self.student, self.course.id)
+        url = reverse('instructor_api_v2:learner_detail', kwargs={
+            'course_id': str(self.course.id),
+            'email_or_username': self.student.username
+        })
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
+        data = response.json()
+        self.assertTrue(data['is_enrolled'])  # noqa: PT009
 
     def test_get_learner_by_email(self):
         """Test retrieving learner info by email"""

--- a/lms/djangoapps/instructor/tests/views/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_api_v2.py
@@ -46,12 +46,12 @@ class LearnerViewTestCase(ModuleStoreTestCase):
             'student_id': self.student.id,
         })
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
+        assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        self.assertEqual(data['username'], 'john_harvard')  # noqa: PT009
-        self.assertEqual(data['email'], 'john@example.com')  # noqa: PT009
-        self.assertEqual(data['full_name'], 'John Harvard')  # noqa: PT009
-        self.assertEqual(data['progress_url'], expected_progress_url)  # noqa: PT009
+        assert data['username'] == 'john_harvard'
+        assert data['email'] == 'john@example.com'
+        assert data['full_name'] == 'John Harvard'
+        assert data['progress_url'] == expected_progress_url
         assert not data['is_enrolled']
 
     def test_get_learner_by_username_enrolled(self):

--- a/lms/djangoapps/instructor/tests/views/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_api_v2.py
@@ -63,9 +63,9 @@ class LearnerViewTestCase(ModuleStoreTestCase):
         })
         response = self.client.get(url)
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
+        assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        self.assertTrue(data['is_enrolled'])  # noqa: PT009
+        assert data['is_enrolled']
 
     def test_get_learner_by_email(self):
         """Test retrieving learner info by email"""

--- a/lms/djangoapps/instructor/tests/views/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_api_v2.py
@@ -8,8 +8,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from common.djangoapps.student.models import CourseEnrollment
-from common.djangoapps.student.tests.factories import InstructorFactory, UserFactory
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, InstructorFactory, UserFactory
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.instructor_task.models import InstructorTask
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -57,7 +56,11 @@ class LearnerViewTestCase(ModuleStoreTestCase):
 
     def test_get_learner_by_username_enrolled(self):
         """Test that is_enrolled is true for users enrolled in the course"""
-        CourseEnrollment.enroll(self.student, self.course.id)
+        CourseEnrollmentFactory(
+            is_active=True,
+            course_id=self.course.id,
+            user=self.student
+        )
         url = reverse('instructor_api_v2:learner_detail', kwargs={
             'course_id': str(self.course.id),
             'email_or_username': self.student.username

--- a/lms/djangoapps/instructor/tests/views/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_api_v2.py
@@ -53,7 +53,7 @@ class LearnerViewTestCase(ModuleStoreTestCase):
         self.assertEqual(data['email'], 'john@example.com')  # noqa: PT009
         self.assertEqual(data['full_name'], 'John Harvard')  # noqa: PT009
         self.assertEqual(data['progress_url'], expected_progress_url)  # noqa: PT009
-        self.assertFalse(data['is_enrolled'])  # noqa: PT009
+        assert not data['is_enrolled']
 
     def test_get_learner_by_username_enrolled(self):
         """Test that is_enrolled is true for users enrolled in the course"""

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -1684,7 +1684,8 @@ class LearnerView(DeveloperErrorViewMixin, APIView):
         "username": "john_harvard",
         "email": "john@example.com",
         "full_name": "John Harvard",
-        "progress_url": "https://example.com/courses/course-v1:edX+DemoX+Demo_Course/progress/john_harvard/"
+        "progress_url": "https://example.com/courses/course-v1:edX+DemoX+Demo_Course/progress/john_harvard/",
+        "is_enrolled": true
     }
     ```
     """

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -1754,6 +1754,7 @@ class LearnerView(DeveloperErrorViewMixin, APIView):
             'email': student.email,
             'full_name': student.profile.name,
             'progress_url': progress_url,
+            'is_enrolled': CourseEnrollment.is_enrolled(student, course_key),
         }
 
         serializer = LearnerSerializer(learner_data)

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -1684,7 +1684,7 @@ class LearnerView(DeveloperErrorViewMixin, APIView):
         "username": "john_harvard",
         "email": "john@example.com",
         "full_name": "John Harvard",
-        "progress_url": "https://example.com/courses/course-v1:edX+DemoX+Demo_Course/progress/john_harvard/",
+        "progress_url": "https://example.com/courses/course-v1:edX+DemoX+Demo_Course/progress/42/",
         "is_enrolled": true
     }
     ```

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -762,7 +762,7 @@ class LearnerSerializer(serializers.Serializer):
         help_text="URL to learner's progress page"
     )
     is_enrolled = serializers.BooleanField(
-        help_text="Whether the learner is enrolled in the course"
+        help_text="Whether the learner has an active enrollment in the course"
     )
 
 

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -761,6 +761,9 @@ class LearnerSerializer(serializers.Serializer):
         required=False,
         help_text="URL to learner's progress page"
     )
+    is_enrolled = serializers.BooleanField(
+        help_text="Whether the learner is enrolled in the course"
+    )
 
 
 class GraderSerializer(serializers.Serializer):


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds a new is_enrolled field to the learners endpoint and integrates it into the Instructor Dashboard UI.

The goal is to expose enrollment status directly in the learners data, enabling the frontend to display or act on whether a learner is currently enrolled in a course without requiring additional API calls.

**Related Issue**

https://github.com/openedx/frontend-app-instructor-dashboard/issues/164

**Changes**:

Add is_enrolled field to learners endpoint response
Update frontend data handling to include the new field
Ensure compatibility with existing learners view/components

**Notes**

This change is backward compatible (adds a new field without modifying existing ones)
No impact expected on existing functionality

## Deadline

Verawood
