### PR TITLE
fix: correct fallback handling for email opt-in report

### DIFF
--- a/openedx/core/djangoapps/user_api/management/commands/email_opt_in_list.py
+++ b/openedx/core/djangoapps/user_api/management/commands/email_opt_in_list.py
@@ -243,7 +243,7 @@ class Command(BaseCommand):
             if pref_set_datetime:
                 pref_set_datetime = timezone.make_aware(pref_set_datetime, dt_timezone.utc)  # noqa: UP017
             else:
-                pref_set_datetime = self.DEFAULT_DATETIME_STR
+                pref_set_datetime = ""
 
             if not full_name:
                 full_name = ""
@@ -257,7 +257,7 @@ class Command(BaseCommand):
                 # of ECOM-1995.
                 "full_name": full_name,
                 "course_id": course_id,
-                "is_opted_in_for_email": is_opted_in if is_opted_in else "True",
+                "is_opted_in_for_email": is_opted_in if is_opted_in else "",
                 "preference_set_datetime": pref_set_datetime,
             })
             row_count += 1

--- a/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
@@ -70,7 +70,7 @@ class EmailOptInListTest(ModuleStoreTestCase):
         output = self._run_command(self.TEST_ORG)
 
         # By default, if no preference is set by the user is enrolled, opt in
-        self._assert_output(output, (self.user, self.courses[0].id, True))
+        self._assert_output(output, (self.user, self.courses[0].id, ""))
 
     def test_enrolled_pref_opted_in(self):
         self._create_courses_and_enrollments((self.TEST_ORG, True))
@@ -107,7 +107,7 @@ class EmailOptInListTest(ModuleStoreTestCase):
         output = self._run_command(self.TEST_ORG)
         self._assert_output(
             output,
-            (self.user, self.courses[0].id, True),
+            (self.user, self.courses[0].id, ""),
             expect_pref_datetime=False
         )
 
@@ -355,7 +355,7 @@ class EmailOptInListTest(ModuleStoreTestCase):
 
         """
         pref = UserOrgTag.objects.filter(user=user).order_by("-modified")
-        return pref[0].modified.isoformat(' ') if len(pref) > 0 else self.DEFAULT_DATETIME_STR
+        return pref[0].modified.isoformat(' ') if len(pref) > 0 else ""
 
     def _run_command(self, org, other_names=None, only_courses=None, query_interval=None, chunk_size=None):
         """Execute the management command to generate the email opt-in list.
@@ -439,7 +439,7 @@ class EmailOptInListTest(ModuleStoreTestCase):
             assert {'user_id': str(user.id), 'username': user.username, 'email': user.email,
                     'full_name': (user.profile.name if hasattr(user, 'profile') else ''),
                     'course_id': str(course_id),
-                    'is_opted_in_for_email': str(opt_in_pref),
+                    'is_opted_in_for_email': str(opt_in_pref) if isinstance(opt_in_pref, bool) else opt_in_pref,
                     'preference_set_datetime':
                         (self._latest_pref_set_datetime(self.user) if kwargs.get('expect_pref_datetime', True) else
-                         self.DEFAULT_DATETIME_STR)} in output[1:]
+                         "")} in output[1:]


### PR DESCRIPTION
## Summary

Fixes incorrect fallback behavior in the Email Opt-In report where users without an email preference record were assigned misleading default values.

## Problem

The report currently assigns:
- `is_opted_in_for_email = "True"` (hardcoded)
- `preference_set_datetime = "2014-12-01 00:00:00"` (hardcoded default)

when no corresponding record exists in `user_api_userorgtag`.

## Solution

- Removed the hardcoded fallback date
- Avoid defaulting `is_opted_in_for_email` to `"True"`
- Instead:
  - Leave `preference_set_datetime` empty when no value exists
  - Leave `is_opted_in_for_email` empty when no preference is set
  
  Amal please take a look on it.