### PR TITLE
feat: Simplify import/export page redirects to always use MFE for courses

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
@@ -111,15 +111,13 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
         """
         Method to get the use_new_import_page switch
         """
-        course_key = self.get_course_key()
-        return toggles.use_new_import_page(course_key)
+        return True
 
     def get_use_new_export_page(self, obj):
         """
         Method to get the use_new_export_page switch
         """
-        course_key = self.get_course_key()
-        return toggles.use_new_export_page(course_key)
+        return True
 
     def get_use_new_files_uploads_page(self, obj):
         """

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1487,11 +1487,11 @@ class ContentStoreTest(ContentStoreTestCase):
         self.assertContains(resp, 'Chapter 2')
 
         # go to various pages
-        with override_waffle_flag(toggles.LEGACY_STUDIO_IMPORT, True):
-            test_get_html('import_handler')
-        with override_waffle_flag(toggles.LEGACY_STUDIO_EXPORT, True):
-            test_get_html('export_handler')
         with override_settings(COURSE_AUTHORING_MICROFRONTEND_URL='https://mfe.example'):
+            resp = self.client.get_html(get_url('import_handler', course_key, 'course_key_string'))
+            self.assertEqual(resp.status_code, 302)  # noqa: PT009
+            resp = self.client.get_html(get_url('export_handler', course_key, 'course_key_string'))
+            self.assertEqual(resp.status_code, 302)  # noqa: PT009
             resp = self.client.get_html(get_url('course_team_handler', course_key, 'course_key_string'))
             self.assertEqual(resp.status_code, 302)  # noqa: PT009
         with override_settings(COURSE_AUTHORING_MICROFRONTEND_URL='https://mfe.example'):

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -29,8 +29,7 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from pytz import UTC
 from xblock.fields import Date
 
-from cms.djangoapps.contentstore import toggles
-from cms.djangoapps.contentstore.utils import get_advanced_settings_url, reverse_course_url, reverse_usage_url
+from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
 from cms.djangoapps.models.settings.course_grading import (
     GRADING_POLICY_CHANGED_EVENT_TYPE,
     CourseGradingModel,
@@ -160,45 +159,17 @@ class CourseAdvanceSettingViewTest(CourseTestCase, MilestonesTestCaseMixin):
                 self.assertEqual('discussion_topics' in data, fields_visible)  # noqa: PT009
 
     @ddt.data(False, True)
-    @override_waffle_flag(toggles.LEGACY_STUDIO_IMPORT, True)
-    @override_waffle_flag(toggles.LEGACY_STUDIO_EXPORT, True)
     def test_disable_advanced_settings_feature(self, disable_advanced_settings):
         """
-        If this feature is enabled, only Django Staff/Superuser should be able to access the "Advanced Settings" page.
-        For non-staff users the "Advanced Settings" tab link should not be visible.
+        When DISABLE_ADVANCED_SETTINGS is enabled, non-staff users should receive
+        a 403 on the advanced settings URL; staff users should always be redirected.
         """
         with override_settings(FEATURES={
             'DISABLE_ADVANCED_SETTINGS': disable_advanced_settings,
         }, COURSE_AUTHORING_MICROFRONTEND_URL='https://mfe.example'):
-            advanced_settings_link_html = (
-                f'<a href="{get_advanced_settings_url(self.course.id)}">Advanced Settings</a>'
-            ).encode()
-            for handler in (
-                'import_handler',
-                'export_handler',
-            ):
-                # Test that non-staff users don't see the "Advanced Settings" tab link.
-                response = self.non_staff_client.get_html(
-                    get_url(self.course.id, handler)
-                )
-                self.assertEqual(response.status_code, 200)  # noqa: PT009
-                if disable_advanced_settings:
-                    self.assertNotIn(advanced_settings_link_html, response.content)  # noqa: PT009
-                else:
-                    self.assertIn(advanced_settings_link_html, response.content)  # noqa: PT009
-
-                # Test that staff users see the "Advanced Settings" tab link.
-                response = self.client.get_html(
-                    get_url(self.course.id, handler)
-                )
-                self.assertEqual(response.status_code, 200)  # noqa: PT009
-                self.assertIn(advanced_settings_link_html, response.content)  # noqa: PT009
-
-            # Test that non-staff users can't access the "Advanced Settings" page.
             response = self.non_staff_client.get_html(self.course_setting_url)
             self.assertEqual(response.status_code, 403 if disable_advanced_settings else 302)  # noqa: PT009
 
-            # Test that staff users are redirected to the MFE advanced settings page.
             response = self.client.get_html(self.course_setting_url)
             self.assertEqual(response.status_code, 302)  # noqa: PT009
 

--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -2,9 +2,7 @@
 This test file will test registration, login, activation, and session activity timeouts
 
 TODO: Rewrite several of these assertions so that they check the output of the REST or Python
-APIs rather than parsing HTML from the deprecated legacy frontend pages. In particular, any
-test case using override_waffle_flag(toggles.LEGACY_STUDIO_*, True) will need to be fixed.
-Part of https://github.com/openedx/edx-platform/issues/36275.
+APIs rather than parsing HTML from the deprecated legacy frontend pages.
 """
 
 
@@ -17,10 +15,8 @@ from django.conf import settings
 from django.core.cache import cache
 from django.test.utils import override_settings
 from django.urls import reverse
-from edx_toggles.toggles.testutils import override_waffle_flag
 from pytz import UTC
 
-from cms.djangoapps.contentstore import toggles
 from cms.djangoapps.contentstore.tests.test_course_settings import CourseTestCase
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, parse_json, registration, user
 from cms.djangoapps.contentstore.utils import get_studio_home_url
@@ -237,20 +233,19 @@ class CourseKeyVerificationTestCase(CourseTestCase):
         super().setUp()
         self.course = CourseFactory.create(org='edX', number='test_course_key', display_name='Test Course')
 
-    @data(('edX/test_course_key/Test_Course', 200), ('garbage:edX+test_course_key+Test_Course', 404))
+    @data(('edX/test_course_key/Test_Course', 302, 200), ('garbage:edX+test_course_key+Test_Course', 404, 404))
     @unpack
-    @override_waffle_flag(toggles.LEGACY_STUDIO_IMPORT, True)
-    def test_course_key_decorator(self, course_key, status_code):
+    def test_course_key_decorator(self, course_key, import_status_code, import_status_handler_code):
         """
         Tests for the ensure_valid_course_key decorator.
         """
         url = f'/import/{course_key}'
         resp = self.client.get_html(url)
-        self.assertEqual(resp.status_code, status_code)  # noqa: PT009
+        self.assertEqual(resp.status_code, import_status_code)  # noqa: PT009
 
         url = '/import_status/{course_key}/{filename}'.format(
             course_key=course_key,
             filename='xyz.tar.gz'
         )
         resp = self.client.get_html(url)
-        self.assertEqual(resp.status_code, status_code)  # noqa: PT009
+        self.assertEqual(resp.status_code, import_status_handler_code)  # noqa: PT009

--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -161,43 +161,6 @@ def use_react_markdown_editor(course_key):
 
 
 
-# .. toggle_name: legacy_studio.import
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Temporarily fall back to the old Course Import page.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2025-03-14
-# .. toggle_target_removal_date: 2025-09-14
-# .. toggle_tickets: https://github.com/openedx/edx-platform/issues/36275
-# .. toggle_warning: In Ulmo, this toggle will be removed. Only the new (React-based) experience will be available.
-LEGACY_STUDIO_IMPORT = CourseWaffleFlag('legacy_studio.import', __name__)
-
-
-def use_new_import_page(course_key):
-    """
-    Returns a boolean if new studio import mfe is enabled
-    """
-    return not LEGACY_STUDIO_IMPORT.is_enabled(course_key)
-
-
-# .. toggle_name: legacy_studio.export
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Temporarily fall back to the old Course Export page.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2025-03-14
-# .. toggle_target_removal_date: 2025-09-14
-# .. toggle_tickets: https://github.com/openedx/edx-platform/issues/36275
-# .. toggle_warning: In Ulmo, this toggle will be removed. Only the new (React-based) experience will be available.
-LEGACY_STUDIO_EXPORT = CourseWaffleFlag('legacy_studio.export', __name__)
-
-
-def use_new_export_page(course_key):
-    """
-    Returns a boolean if new studio export mfe is enabled
-    """
-    return not LEGACY_STUDIO_EXPORT.is_enabled(course_key)
-
 
 # .. toggle_name: contentstore.new_studio_mfe.use_new_video_uploads_page
 # .. toggle_implementation: CourseWaffleFlag

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -41,8 +41,6 @@ from cms.djangoapps.contentstore.toggles import (
     libraries_v1_enabled,
     libraries_v2_enabled,
     split_library_view_on_dashboard,
-    use_new_export_page,
-    use_new_import_page,
     use_new_unit_page,
 )
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
@@ -346,30 +344,24 @@ def get_updates_url(course_locator) -> str:
     return updates_url
 
 
-def get_import_url(course_locator) -> str:
+def get_import_url(course_locator) -> str | None:
     """
     Gets course authoring microfrontend URL for import page view.
     """
-    import_url = None
-    if use_new_import_page(course_locator):
-        mfe_base_url = get_course_authoring_url(course_locator)
-        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/import'
-        if mfe_base_url:
-            import_url = course_mfe_url
-    return import_url
+    mfe_base_url = get_course_authoring_url(course_locator)
+    if mfe_base_url:
+        return f'{mfe_base_url}/course/{course_locator}/import'
+    return None
 
 
-def get_export_url(course_locator) -> str:
+def get_export_url(course_locator) -> str | None:
     """
     Gets course authoring microfrontend URL for export page view.
     """
-    export_url = None
-    if use_new_export_page(course_locator):
-        mfe_base_url = get_course_authoring_url(course_locator)
-        course_mfe_url = f'{mfe_base_url}/course/{course_locator}/export'
-        if mfe_base_url:
-            export_url = course_mfe_url
-    return export_url
+    mfe_base_url = get_course_authoring_url(course_locator)
+    if mfe_base_url:
+        return f'{mfe_base_url}/course/{course_locator}/export'
+    return None
 
 
 def get_optimizer_url(course_locator) -> str:

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -43,7 +43,6 @@ from xmodule.modulestore.django import modulestore  # pylint: disable=wrong-impo
 
 from ..storage import course_import_export_storage
 from ..tasks import CourseExportTask, CourseImportTask, export_olx, import_olx
-from ..toggles import use_new_export_page, use_new_import_page
 from ..utils import IMPORTABLE_FILE_TYPES, get_export_url, get_import_url, reverse_course_url, reverse_library_url
 
 __all__ = [
@@ -99,7 +98,7 @@ def import_handler(request, course_key_string):
             return _write_chunk(request, courselike_key)
     elif request.method == 'GET':  # assume html
 
-        if use_new_import_page(courselike_key) and not library:
+        if not library:
             return redirect(get_import_url(courselike_key))
         status_url = reverse_course_url(
             "import_status_handler", courselike_key, kwargs={'filename': "fillerName"}
@@ -358,7 +357,7 @@ def export_handler(request, course_key_string):
         export_olx.delay(request.user.id, course_key_string, request.LANGUAGE_CODE)
         return JsonResponse({'ExportStatus': 1})
     elif 'text/html' in requested_format:
-        if use_new_export_page(course_key) and not library:
+        if not library:
             return redirect(get_export_url(course_key))
         return render_to_response('export.html', context)
     else:

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -23,7 +23,6 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import SuspiciousOperation
 from django.core.files.storage import FileSystemStorage
 from django.test.utils import override_settings
-from edx_toggles.toggles.testutils import override_waffle_flag
 from milestones.tests.utils import MilestonesTestCaseMixin
 from opaque_keys.edx.locator import LibraryLocator
 from openedx_authz.constants.roles import COURSE_DATA_RESEARCHER, COURSE_STAFF
@@ -34,7 +33,6 @@ from storages.backends.s3boto3 import S3Boto3Storage
 from user_tasks.models import UserTaskStatus
 
 from cms.djangoapps.contentstore import errors as import_error
-from cms.djangoapps.contentstore import toggles
 from cms.djangoapps.contentstore.api.tests.base import BaseCourseViewTest
 from cms.djangoapps.contentstore.storage import course_import_export_storage
 from cms.djangoapps.contentstore.tests.test_libraries import LibraryTestCase
@@ -753,15 +751,6 @@ class ExportTestCase(CourseTestCase):
         super().setUp()
         self.url = reverse_course_url('export_handler', self.course.id)
         self.status_url = reverse_course_url('export_status_handler', self.course.id)
-
-    @override_waffle_flag(toggles.LEGACY_STUDIO_EXPORT, True)
-    def test_export_html(self):
-        """
-        Get the HTML for the page.
-        """
-        resp = self.client.get_html(self.url)
-        self.assertEqual(resp.status_code, 200)  # noqa: PT009
-        self.assertContains(resp, "Export My Course Content")
 
     def test_export_json_unsupported(self):
         """

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -33,14 +33,10 @@
             assets_url = reverse('assets_handler', kwargs={'course_key_string': str(course_key)})
             textbooks_url = reverse('textbooks_list_handler', kwargs={'course_key_string': str(course_key)})
             videos_url = reverse('videos_handler', kwargs={'course_key_string': str(course_key)})
-            import_url = reverse('import_handler', kwargs={'course_key_string': str(course_key)})
             course_info_url = reverse('course_info_handler', kwargs={'course_key_string': str(course_key)})
-            export_url = reverse('export_handler', kwargs={'course_key_string': str(course_key)})
             tabs_url = reverse('tabs_handler', kwargs={'course_key_string': str(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': str(course_key)})
             pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
-            import_mfe_enabled = toggles.use_new_import_page(context_course.id)
-            export_mfe_enabled = toggles.use_new_export_page(context_course.id)
             optimizer_enabled = toggles.enable_course_optimizer(context_course.id)
             libraries_v2_enabled = toggles.libraries_v2_enabled()
 
@@ -149,26 +145,12 @@
             <div class="wrapper wrapper-nav-sub">
               <div class="nav-sub">
                 <ul>
-                  % if not import_mfe_enabled:
-                  <li class="nav-item nav-course-tools-import">
-                    <a href="${import_url}">${_("Import")}</a>
-                  </li>
-                  % endif
-                  % if import_mfe_enabled:
                   <li class="nav-item nav-course-tools-import">
                     <a href="${get_import_url(course_key)}">${_("Import")}</a>
                   </li>
-                  % endif
-                  % if not export_mfe_enabled:
-                  <li class="nav-item nav-course-tools-export">
-                    <a href="${export_url}">${_("Export")}</a>
-                  </li>
-                  % endif
-                  % if export_mfe_enabled:
                   <li class="nav-item nav-course-tools-export">
                     <a href="${get_export_url(course_key)}">${_("Export")}</a>
                   </li>
-                  % endif
                   % if toggles.EXPORT_GIT.is_enabled() and context_course.giturl:
                   <li class="nav-item nav-course-tools-export-git">
                     <a href="${reverse('export_git', kwargs=dict(course_key_string=str(course_key)))}">${_("Export to Git")}</a>


### PR DESCRIPTION
This pull request simplifies the logic for redirecting to the new import and export pages by removing the use of feature toggles. Now, the redirect happens for all courses (excluding libraries), regardless of any toggle state.

**Import/Export Page Redirection Simplification:**

* Removed the use of the `use_new_import_page` and `use_new_export_page` toggles from the import and export handlers in `import_export.py`, so that all courses (except libraries) are redirected to the new import/export pages unconditionally. [[1]](diffhunk://#diff-04b2acdc3a891b60084044b36b19700dd497759339ead9397241c0b656b38d62L102-R101) [[2]](diffhunk://#diff-04b2acdc3a891b60084044b36b19700dd497759339ead9397241c0b656b38d62L361-R360)
* Cleaned up the import statements by removing the now-unused `use_new_import_page` and `use_new_export_page` imports.

302 redirect for [Import](https://apps.pr-38423-1a7bbe.axim-sandboxes.opencraft.hosting/authoring/course/course-v1:uetx+cs-test-1+2026-q1/import)

<img width="1227" height="440" alt="image" src="https://github.com/user-attachments/assets/a1d39103-87c5-4564-a29c-a67b34dda6d4" />


302 redirect for [Export](https://apps.pr-38423-1a7bbe.axim-sandboxes.opencraft.hosting/authoring/course/course-v1:uetx+cs-test-1+2026-q1/export)

<img width="1223" height="439" alt="image" src="https://github.com/user-attachments/assets/51aae7e5-5da4-4344-bc55-b5fa34413424" />

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
