### PR TITLE
feat: General cleanup of legacy Studio page waffle flags and related code

### DIFF
--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -159,9 +159,6 @@ def use_react_markdown_editor(course_key):
     return ENABLE_REACT_MARKDOWN_EDITOR.is_enabled(course_key)
 
 
-
-
-
 # .. toggle_name: contentstore.new_studio_mfe.use_new_video_uploads_page
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
@@ -214,9 +211,6 @@ def use_new_unit_page(course_key):
     Returns a boolean if new studio course outline mfe is enabled
     """
     return not LEGACY_STUDIO_UNIT_EDITOR.is_enabled(course_key)
-
-
-
 
 
 # .. toggle_name: contentstore.mock_video_uploads

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -297,9 +297,8 @@ def get_schedule_details_url(course_locator) -> str:
     Gets course authoring microfrontend URL for schedule and details pages view.
     """
     mfe_base_url = get_course_authoring_url(course_locator)
-    if mfe_base_url:
-        return f'{mfe_base_url}/course/{course_locator}/settings/details'
-    return None
+    course_mfe_url = f'{mfe_base_url}/course/{course_locator}/settings/details'
+    return course_mfe_url if mfe_base_url else None
 
 
 def get_advanced_settings_url(course_locator) -> str | None:
@@ -307,9 +306,8 @@ def get_advanced_settings_url(course_locator) -> str | None:
     Gets course authoring microfrontend URL for advanced settings page view.
     """
     mfe_base_url = get_course_authoring_url(course_locator)
-    if mfe_base_url:
-        return f'{mfe_base_url}/course/{course_locator}/settings/advanced'
-    return None
+    course_mfe_url = f'{mfe_base_url}/course/{course_locator}/settings/advanced'
+    return course_mfe_url if mfe_base_url else None
 
 
 def get_grading_url(course_locator) -> str:
@@ -317,9 +315,8 @@ def get_grading_url(course_locator) -> str:
     Gets course authoring microfrontend URL for grading page view.
     """
     mfe_base_url = get_course_authoring_url(course_locator)
-    if mfe_base_url:
-        return f'{mfe_base_url}/course/{course_locator}/settings/grading'
-    return None
+    course_mfe_url = f'{mfe_base_url}/course/{course_locator}/settings/grading'
+    return course_mfe_url if mfe_base_url else None
 
 
 def get_course_team_url(course_locator) -> str:
@@ -327,9 +324,8 @@ def get_course_team_url(course_locator) -> str:
     Gets course authoring microfrontend URL for course team page view.
     """
     mfe_base_url = get_course_authoring_url(course_locator)
-    if mfe_base_url:
-        return f'{mfe_base_url}/course/{course_locator}/course_team'
-    return None
+    course_mfe_url = f'{mfe_base_url}/course/{course_locator}/course_team'
+    return course_mfe_url if mfe_base_url else None
 
 
 def get_updates_url(course_locator) -> str:
@@ -349,9 +345,8 @@ def get_import_url(course_locator) -> str | None:
     Gets course authoring microfrontend URL for import page view.
     """
     mfe_base_url = get_course_authoring_url(course_locator)
-    if mfe_base_url:
-        return f'{mfe_base_url}/course/{course_locator}/import'
-    return None
+    course_mfe_url = f'{mfe_base_url}/course/{course_locator}/import'
+    return course_mfe_url if mfe_base_url else None
 
 
 def get_export_url(course_locator) -> str | None:
@@ -359,9 +354,8 @@ def get_export_url(course_locator) -> str | None:
     Gets course authoring microfrontend URL for export page view.
     """
     mfe_base_url = get_course_authoring_url(course_locator)
-    if mfe_base_url:
-        return f'{mfe_base_url}/course/{course_locator}/export'
-    return None
+    course_mfe_url = f'{mfe_base_url}/course/{course_locator}/export'
+    return course_mfe_url if mfe_base_url else None
 
 
 def get_optimizer_url(course_locator) -> str:
@@ -445,9 +439,8 @@ def get_certificates_url(course_locator) -> str:
     Gets course authoring microfrontend URL for certificates page view.
     """
     mfe_base_url = get_course_authoring_url(course_locator)
-    if mfe_base_url:
-        return f'{mfe_base_url}/course/{course_locator}/certificates'
-    return None
+    course_mfe_url = f'{mfe_base_url}/course/{course_locator}/certificates'
+    return course_mfe_url if mfe_base_url else None
 
 
 def get_textbooks_url(course_locator) -> str:
@@ -467,7 +460,8 @@ def get_group_configurations_url(course_locator) -> str:
     Gets course authoring microfrontend URL for group configurations page view.
     """
     mfe_base_url = get_course_authoring_url(course_locator)
-    return f'{mfe_base_url}/course/{course_locator}/group_configurations' if mfe_base_url else None
+    course_mfe_url = f'{mfe_base_url}/course/{course_locator}/group_configurations'
+    return course_mfe_url if mfe_base_url else None
 
 
 def get_custom_pages_url(course_locator) -> str:


### PR DESCRIPTION
This pull request primarily refactors utility functions in `cms/djangoapps/contentstore/utils.py` to simplify and standardize how URLs for various course authoring microfrontend pages are constructed and returned. Additionally, it includes some minor cleanup in the toggles file by removing unnecessary blank lines.

Refactoring and simplification of URL utility functions:

* Standardized the pattern for generating and returning URLs in several functions (such as `get_schedule_details_url`, `get_advanced_settings_url`, `get_grading_url`, `get_course_team_url`, `get_import_url`, `get_export_url`, `get_certificates_url`, and `get_group_configurations_url`) by assigning the constructed URL to a variable and returning it if the base URL exists, otherwise returning `None`. This improves readability and consistency across these functions. [[1]](diffhunk://#diff-4c3d3ca903f6c372776d85ee0afd1d56fcd920cb2e7d2f207aca45afe9377af5L300-R328) [[2]](diffhunk://#diff-4c3d3ca903f6c372776d85ee0afd1d56fcd920cb2e7d2f207aca45afe9377af5L352-R358) [[3]](diffhunk://#diff-4c3d3ca903f6c372776d85ee0afd1d56fcd920cb2e7d2f207aca45afe9377af5L448-R443) [[4]](diffhunk://#diff-4c3d3ca903f6c372776d85ee0afd1d56fcd920cb2e7d2f207aca45afe9377af5L470-R464)

Code cleanup:

* Removed extra blank lines in `cms/djangoapps/contentstore/toggles.py` to tidy up the code. [[1]](diffhunk://#diff-cb9e0d2c6205de9a97da287d859992e78b2c0028433d4a9e160bc412ae5dbb8dL162-L164) [[2]](diffhunk://#diff-cb9e0d2c6205de9a97da287d859992e78b2c0028433d4a9e160bc412ae5dbb8dL219-L221)