### PR TITLE
fix: prevent .modal-fullscreen cascading flex boxes

### DIFF
--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -429,8 +429,14 @@
           }
 
           div.editor-with-buttons {
+            display: flex;
+            flex-direction: column;
             flex-grow: 1;
             margin-bottom: 0;
+
+            ul.settings-list {
+              flex-grow: 1;
+            }
           }
         }
       }

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -406,42 +406,36 @@
     display: flex;
     flex-direction: column;
 
-
-    // Set the components to flex so that they can grow
-    div,
-    form {
+    div.edit-xblock-modal {
       display: flex;
       flex-direction: column;
       flex-grow: 1;
 
-      // Set the header to not grow
-      header,
-      &.modal-header {
-        flex-grow: 0;
-      }
+      div.modal-content {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        padding: 0;
 
-    }
+        div.xblock-editor {
+          display: flex;
+          flex-direction: column;
+          flex-grow: 1;
 
-    ul {
-      flex-grow: 1;
+          div.xblock-studio_view {
+            display: flex;
+            flex-direction: column;
+            flex-grow: 1;
+          }
 
-      // Reset the divs inside the ul to preserve previous styling
-      div,
-      form {
-        display: unset;
-        flex-direction: unset;
-        flex-grow: unset;
-      }
-    }
-
-    &.modal-editor {
-      .modal-content {
-        padding: 0px;
+          div.editor-with-buttons {
+            flex-grow: 1;
+            margin-bottom: 0;
+          }
+        }
       }
     }
   }
-
-
 
   // specific modal overrides
   // ------------------------


### PR DESCRIPTION
## Description

This PR changes the `.modal-fullscreen` style to prevent it from cascading the flexbox style to its child nodes, which were causing layout issues on some xblocks.

- Which edX user roles will this change impact? 
"Developer"

## Supporting information

- More info at https://gitlab.com/opencraft/dev/exemplar-blocks/-/merge_requests/7#note_3229990394

## Testing instructions

- Checkout this PR
- Run `tutor dev exec cms npm run build-dev` to make sure you have all assets updated
- Edit some XBlocks at the unit outline, click on the Fullscreen button and check the layout. Some example XBlocks:
  - Poll
  - Drag and Drop
  - LTI Consumer
  - Word Cloud
  - Google Calendar
  - Two-column Block
  - Cover
  - Key points

## Deadline

Verawood

___
Private ref: [FAL-4347](https://tasks.opencraft.com/browse/FAL-4347)
