### PR TITLE
fix: Allow `--experimental` on `reindex_studio` as a no-op

### DIFF
--- a/openedx/core/djangoapps/content/search/management/commands/reindex_studio.py
+++ b/openedx/core/djangoapps/content/search/management/commands/reindex_studio.py
@@ -43,6 +43,12 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         # Removed flags — provide clear error messages for operators with old automation.
+         parser.add_argument(
+            "--experimental",
+            action="store_true",
+            default=False,
+            help="(Removed) reindex_studio is no longer experimental.",
+        )
         parser.add_argument(
             "--reset",
             action="store_true",
@@ -84,6 +90,11 @@ class Command(BaseCommand):
             log.warning(
                 "The --incremental flag has been removed. "
                 "Incremental population is now the default behavior of this command."
+            )
+        if options["experimental"]:
+            log.warning(
+                "The --experimental flag has been removed. "
+                "reindex_studio is now a stable command, so the flag is no longer necessary."
             )
 
         result = rebuild_index_incremental.delay()

--- a/openedx/core/djangoapps/content/search/management/commands/reindex_studio.py
+++ b/openedx/core/djangoapps/content/search/management/commands/reindex_studio.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         # Removed flags — provide clear error messages for operators with old automation.
-         parser.add_argument(
+        parser.add_argument(
             "--experimental",
             action="store_true",
             default=False,


### PR DESCRIPTION
Follows up on:

* https://github.com/openedx/openedx-platform/pull/38384

Related:

* https://github.com/overhangio/tutor/pull/1374

Putting this flag back as a backcompat no-op will smooth out the transition for developers and operators.