### PR TITLE
fix: Allow `--reset` or `--init` on `reindex_studio` as no-ops

### DIFF
--- a/openedx/core/djangoapps/content/search/management/commands/reindex_studio.py
+++ b/openedx/core/djangoapps/content/search/management/commands/reindex_studio.py
@@ -73,14 +73,14 @@ class Command(BaseCommand):
             raise CommandError("Meilisearch is not enabled. Please set MEILISEARCH_ENABLED to True in your settings.")
 
         if options["reset"]:
-            raise CommandError(
+            log.warning(
                 "The --reset flag has been removed. "
                 "Index reset is now handled automatically by post_migrate reconciliation. "
                 "Run: ./manage.py cms migrate"
             )
 
         if options["init"]:
-            raise CommandError(
+            log.warning(
                 "The --init flag has been removed. "
                 "Index initialization is now handled automatically by post_migrate reconciliation. "
                 "Run: ./manage.py cms migrate"

--- a/openedx/core/djangoapps/content/search/tests/test_reindex_cmd.py
+++ b/openedx/core/djangoapps/content/search/tests/test_reindex_cmd.py
@@ -39,25 +39,15 @@ class TestReindexStudioCommand(TestCase):
         with pytest.raises(CommandError, match="not enabled"):
             call_command("reindex_studio")
 
-    def test_reset_flag_removed(self):
-        """Passing --reset raises a clear error."""
-        with pytest.raises(CommandError, match="--reset flag has been removed"):
-            call_command("reindex_studio", "--reset")
-
-    def test_init_flag_removed(self):
-        """Passing --init raises a clear error."""
-        with pytest.raises(CommandError, match="--init flag has been removed"):
-            call_command("reindex_studio", "--init")
-
     @patch("openedx.core.djangoapps.content.search.tasks.rebuild_index_incremental.delay")
     @patch("openedx.core.djangoapps.content.search.management.commands.reindex_studio.log")
     def test_incremental_flag_accepted_with_warning(self, mock_log, mock_delay):
-        """Passing --incremental logs a warning but still enqueues the task."""
+        """Passing old flags logs a warning but still enqueues the task."""
         mock_delay.return_value = Mock(id="fake-task-id")
 
-        call_command("reindex_studio", "--incremental")
+        call_command("reindex_studio", "--incremental", "--init", "--experimental", "--reset")
 
-        mock_log.warning.assert_called_once()
+        assert mock_log.warning.call_count == 4
         mock_delay.assert_called_once_with()
 
 


### PR DESCRIPTION
Follows up on:

* https://github.com/openedx/openedx-platform/pull/38384
* https://github.com/openedx/openedx-platform/pull/38433

Related:

* https://github.com/overhangio/tutor/pull/1374

Changing these to warnings will smooth out the transition for developers and operators.