### PR TITLE
build: Upgrade to openedx-core v1.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -61,11 +61,10 @@ libsass==0.10.0
 numpy<2.0.0
 
 # Date: 2023-09-18
-# Library is still in active development. Minor versions (0.x, 0.x+1) may have
-# breaking changes which openedx-core devs want to roll out manually. New patch versions
-# are OK to accept automatically.
+# Library is still in active development. Major versions require review
+# from openedx-maintainers. Minor and patch versions can roll out automatically.
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-core<0.48
+openedx-core<2
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -840,7 +840,7 @@ openedx-calc==5.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   xblocks-contrib
-openedx-core==0.47.0
+openedx-core==1.0.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1383,7 +1383,7 @@ openedx-calc==5.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   xblocks-contrib
-openedx-core==0.47.0
+openedx-core==1.0.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1018,7 +1018,7 @@ openedx-calc==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-openedx-core==0.47.0
+openedx-core==1.0.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1058,7 +1058,7 @@ openedx-calc==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-openedx-core==0.47.0
+openedx-core==1.0.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
### Description

Includes: https://github.com/openedx/openedx-core/compare/v0.47.0...v1.0.1

## Merge info

Needs to merge ASAP, before Verawood.

Depends on:

* https://github.com/openedx/openedx-core/pull/559

Update: Before merging, one of these needs to land + we need to tag v1.0.1:

* https://github.com/openedx/openedx-core/pull/575
* https://github.com/openedx/openedx-core/pull/576
* https://github.com/openedx/openedx-core/pull/577

### Supporting info

Closes: https://github.com/openedx/openedx-core/issues/434

### Testing

Did not manually test myself.

### AI Use

None