### PR TITLE
feat: Add sync_library_updates url in help tokens [FC-0123]

### DIFF
--- a/cms/envs/help_tokens.ini
+++ b/cms/envs/help_tokens.ini
@@ -27,6 +27,7 @@ video = course_author:references/course_development/guide_to_video.html
 certificates = course_author:concepts/open_edx_platform/about_certificates.html
 content_highlights = course_author:how-tos/course_development/manage_course_highlight_emails.html
 social_sharing = course_author:how-tos/course_development/social_sharing.html
+sync_library_updates = course_author:how-tos/course_development/sync_a_library_update_to_your_course.html
 
 # below are the language directory names for the different locales
 [locales]


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description


- Adds a new URL `sync_library_updates` to the `help_tokens`
- Which edX user roles will this change impact? "Course Author".


## Supporting information

- Github issue: https://github.com/openedx/frontend-app-authoring/issues/2605
- Used in: https://github.com/openedx/frontend-app-authoring/pull/3022
- Internal ticket: https://tasks.opencraft.com/browse/FAL-4331

## Testing instructions

Follow the testing instructions in: https://github.com/openedx/frontend-app-authoring/pull/3022

## Deadline

Verawood's cut

## Other information

N/A
