### PR TITLE
fix: instructor tab url

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -76,6 +76,17 @@ class InstructorDashboardTab(CourseTab):
     is_dynamic = True    # The "Instructor" tab is instead dynamically added when it is enabled
     priority = 300
 
+    def __init__(self, tab_dict):
+        # Customize link function to support both legacy dashboard and new MFE tab response based on feature flag
+        def link_func(course, reverse_func):
+            if not legacy_instructor_dashboard():
+                return get_instructor_dashboard_url(course.id)
+            else:
+                return reverse_func(self.view_name, args=[str(course.id)])
+
+        tab_dict['link_func'] = link_func
+        super().__init__(tab_dict)
+
     @classmethod
     def is_enabled(cls, course, user=None):
         """
@@ -832,4 +843,4 @@ def get_instructor_dashboard_url(course_key: CourseKey) -> str:
     Gets instructor microfrontend URL for the current course locator.
     """
     mfe_base_url = settings.INSTRUCTOR_MICROFRONTEND_URL
-    return f'{mfe_base_url}/{course_key}/course_info'
+    return f'{mfe_base_url}/{course_key}'


### PR DESCRIPTION
## Description
Added the new url to tabs dict if MFE is enabled, return old url when MFE is disabled, this causes the correct matching on current tab for course nav bar

## Supporting information
Closes #38449 

## Before:
<img width="1154" height="221" alt="Screenshot 2026-04-24 at 10 41 51 a m" src="https://github.com/user-attachments/assets/0b2f5ed8-c60e-4a29-99fe-099daf5e7803" />

<img width="1507" height="375" alt="Image" src="https://github.com/user-attachments/assets/eba3bd44-f304-4984-b23c-4b47729526e0" />

## After:
<img width="1106" height="220" alt="Screenshot 2026-04-24 at 10 40 48 a m" src="https://github.com/user-attachments/assets/b156bc8f-16ea-42c7-a094-9180289a24f1" />

<img width="1524" height="494" alt="Screenshot 2026-04-24 at 10 37 23 a m" src="https://github.com/user-attachments/assets/d1a85232-b5ef-4629-98d5-2ccc2f1e1ed5" />
