### PR TITLE
Update discussion bulk user post count/delete from MongoDB to forum MySQL API

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tasks.py
+++ b/lms/djangoapps/discussion/rest_api/tasks.py
@@ -7,6 +7,7 @@ from celery import shared_task
 from django.contrib.auth import get_user_model
 from edx_django_utils.monitoring import set_code_owner_attribute
 from eventtracking import tracker
+from forum import api as forum_api
 from opaque_keys.edx.locator import CourseKey
 
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
@@ -99,8 +100,12 @@ def delete_course_post_for_user(user_id, username, course_ids, event_data=None):
     """
     event_data = event_data or {}
     log.info(f"<<Bulk Delete>> Deleting all posts for {username} in course {course_ids}")
-    threads_deleted = Thread.delete_user_threads(user_id, course_ids)
-    comments_deleted = Comment.delete_user_comments(user_id, course_ids)
+    threads_deleted = 0
+    comments_deleted = 0
+    for course_id in course_ids:
+        result = forum_api.delete_user_posts(user_id=str(user_id), course_id=course_id)
+        threads_deleted += result.get("thread_count", 0)
+        comments_deleted += result.get("comment_count", 0)
     log.info(f"<<Bulk Delete>> Deleted {threads_deleted} posts and {comments_deleted} comments for {username} "
              f"in course {course_ids}")
     event_data.update({

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -35,8 +35,7 @@ from openedx.core.djangoapps.discussions.config.waffle import ENABLE_NEW_STRUCTU
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from openedx.core.djangoapps.discussions.serializers import DiscussionSettingsSerializer
 from openedx.core.djangoapps.django_comment_common import comment_client
-from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
-from openedx.core.djangoapps.django_comment_common.comment_client.thread import Thread
+from forum import api as forum_api
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings, Role
 from openedx.core.djangoapps.user_api.accounts.permissions import CanReplaceUsername, CanRetireUser
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
@@ -1571,7 +1570,6 @@ class BulkDeleteUserPosts(DeveloperErrorViewMixin, APIView):
     def post(self, request, course_id):
         """
         Implements the delete user posts endpoint.
-        TODO: Add support for MySQLBackend as well
         """
         username = request.GET.get("username", None)
         execute_task = request.GET.get("execute", "false").lower() == "true"
@@ -1595,8 +1593,12 @@ class BulkDeleteUserPosts(DeveloperErrorViewMixin, APIView):
             log.info(f"<<Bulk Delete>> {username} enrolled in {enrollments}")
         log.info(f"<<Bulk Delete>> Posts for {username} in {course_ids} - for {course_or_org} {course_id}")
 
-        comment_count = Comment.get_user_comment_count(user.id, course_ids)
-        thread_count = Thread.get_user_threads_count(user.id, course_ids)
+        thread_count = 0
+        comment_count = 0
+        for cid in course_ids:
+            counts = forum_api.get_user_post_counts(user_id=str(user.id), course_id=cid)
+            thread_count += counts.get("thread_count", 0)
+            comment_count += counts.get("comment_count", 0)
         log.info(f"<<Bulk Delete>> {username} in {course_ids} - Count thread {thread_count}, comment {comment_count}")
 
         if execute_task:

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -11,6 +11,7 @@ from django.shortcuts import get_object_or_404
 from drf_yasg import openapi
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
+from forum import api as forum_api
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import permissions, status
 from rest_framework.authentication import SessionAuthentication
@@ -19,8 +20,6 @@ from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSet
-
-from forum import api as forum_api
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.util.file import store_uploaded_file

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -20,6 +20,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSet
 
+from forum import api as forum_api
+
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.util.file import store_uploaded_file
 from lms.djangoapps.course_api.blocks.api import get_blocks
@@ -35,7 +37,6 @@ from openedx.core.djangoapps.discussions.config.waffle import ENABLE_NEW_STRUCTU
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, Provider
 from openedx.core.djangoapps.discussions.serializers import DiscussionSettingsSerializer
 from openedx.core.djangoapps.django_comment_common import comment_client
-from forum import api as forum_api
 from openedx.core.djangoapps.django_comment_common.models import CourseDiscussionSettings, Role
 from openedx.core.djangoapps.user_api.accounts.permissions import CanReplaceUsername, CanRetireUser
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus

--- a/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
@@ -1,10 +1,8 @@
 # pylint: disable=missing-docstring,protected-access
 import logging
-import time
 
 from bs4 import BeautifulSoup
 from forum import api as forum_api
-from forum.backends.mongodb.comments import Comment as ForumComment
 
 from openedx.core.djangoapps.django_comment_common.comment_client import models, settings
 
@@ -129,43 +127,6 @@ class Comment(models.Model):
             per_page=params.get('per_page', 10),
         )
 
-    @classmethod
-    def get_user_comment_count(cls, user_id, course_ids):
-        """
-        Returns comments and responses count of user in the given course_ids.
-        TODO: Add support for MySQL backend as well
-        """
-        query_params = {
-            "course_id": {"$in": course_ids},
-            "author_id": str(user_id),
-            "_type": "Comment"
-        }
-        return ForumComment()._collection.count_documents(query_params)  # pylint: disable=protected-access
-
-    @classmethod
-    def delete_user_comments(cls, user_id, course_ids):
-        """
-        Deletes comments and responses of user in the given course_ids.
-        TODO: Add support for MySQL backend as well
-        """
-        start_time = time.time()
-        query_params = {
-            "course_id": {"$in": course_ids},
-            "author_id": str(user_id),
-        }
-        comments_deleted = 0
-        comments = ForumComment().get_list(**query_params)
-        log.info(f"<<Bulk Delete>> Fetched comments for user {user_id} in {time.time() - start_time} seconds")
-        for comment in comments:
-            start_time = time.time()
-            comment_id = comment.get("_id")
-            course_id = comment.get("course_id")
-            if comment_id:
-                forum_api.delete_comment(comment_id, course_id=course_id)
-                comments_deleted += 1
-            log.info(f"<<Bulk Delete>> Deleted comment {comment_id} in {time.time() - start_time} seconds."
-                     f" Comment Found: {comment_id is not None}")
-        return comments_deleted
 
 
 def _url_for_thread_comments(thread_id):

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -2,11 +2,9 @@
 
 
 import logging
-import time
 
 from eventtracking import tracker
 from forum import api as forum_api
-from forum.backends.mongodb.threads import CommentThread as ForumThread
 
 from . import models, settings, utils
 
@@ -216,43 +214,6 @@ class Thread(models.Model):
         )
         self._update_from_response(response)
 
-    @classmethod
-    def get_user_threads_count(cls, user_id, course_ids):
-        """
-        Returns threads count of user in the given course_ids.
-        TODO: Add support for MySQL backend as well
-        """
-        query_params = {
-            "course_id": {"$in": course_ids},
-            "author_id": str(user_id),
-            "_type": "CommentThread"
-        }
-        return ForumThread()._collection.count_documents(query_params)  # pylint: disable=protected-access
-
-    @classmethod
-    def delete_user_threads(cls, user_id, course_ids):
-        """
-        Deletes threads of user in the given course_ids.
-        TODO: Add support for MySQL backend as well
-        """
-        start_time = time.time()
-        query_params = {
-            "course_id": {"$in": course_ids},
-            "author_id": str(user_id),
-        }
-        threads_deleted = 0
-        threads = ForumThread().get_list(**query_params)
-        log.info(f"<<Bulk Delete>> Fetched threads for user {user_id} in {time.time() - start_time} seconds")
-        for thread in threads:
-            start_time = time.time()
-            thread_id = thread.get("_id")
-            course_id = thread.get("course_id")
-            if thread_id:
-                forum_api.delete_thread(thread_id, course_id=course_id)
-                threads_deleted += 1
-            log.info(f"<<Bulk Delete>> Deleted thread {thread_id} in {time.time() - start_time} seconds."
-                     f" Thread Found: {thread_id is not None}")
-        return threads_deleted
 
 
 def _clean_forum_params(params):

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -859,7 +859,7 @@ openedx-filters==3.1.0
     #   edx-enterprise
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.4.1
+openedx-forum==0.4.2
     # via -r requirements/edx/kernel.in
 optimizely-sdk==5.4.0
     # via -r requirements/edx/bundled.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1421,7 +1421,7 @@ openedx-filters==3.1.0
     #   edx-enterprise
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.4.1
+openedx-forum==0.4.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1038,7 +1038,7 @@ openedx-filters==3.1.0
     #   edx-enterprise
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.4.1
+openedx-forum==0.4.2
     # via -r requirements/edx/base.txt
 optimizely-sdk==5.4.0
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1085,7 +1085,7 @@ openedx-filters==3.1.0
     #   edx-enterprise
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.4.1
+openedx-forum==0.4.2
     # via -r requirements/edx/base.txt
 optimizely-sdk==5.4.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
## Description
                                                                                                                                                  
The bulk delete discussion post endpoint currently relies on direct MongoDB queries to count and delete user posts. This should be replaced with the forum service API to ensure compatibility with the MySQL backend and to remove the dependency on MongoDB.  

In this PR, we updated the endpoint to be compatible with the MySQL backend and removed its dependency on MongoDB.

Rationale: https://github.com/openedx/public-engineering/issues/424
Ticket:  https://github.com/openedx/public-engineering/issues/502
                                                                                                                                                  
  ---                                                                                                                                           
  Files Changed
               
  - views.py — call forum_api.get_user_post_counts() instead of MongoDB-backed class methods
  - tasks.py — call forum_api.delete_user_posts() instead of MongoDB-backed class methods                                                         
  - thread.py / comment.py — removed MongoDB-specific count and delete methods that are no longer used                                                                   
           