### PR TITLE
fix(contentstore): guard downstream_customized copy on paste [FC-0123]

### DIFF
--- a/cms/djangoapps/contentstore/helpers.py
+++ b/cms/djangoapps/contentstore/helpers.py
@@ -9,6 +9,7 @@ Platform-wide Python APIs should be added to an appropriate api.py file instead.
 
 from __future__ import annotations
 
+import json
 import logging
 import pathlib
 import re
@@ -511,9 +512,13 @@ def _fetch_and_set_upstream_link(
             downstream_customized = getattr(temp_xblock, "downstream_customized", [])
             # XmlMixin blocks expose raw XML attrs on `xml_attributes`; other blocks (e.g. DnD)
             # may not have this attribute, but still have parsed downstream_customized field.
-            if hasattr(temp_xblock, 'xml_attributes'):
-                raw_downstream_customized = temp_xblock.xml_attributes.get("downstream_customized", [])
-                downstream_customized = raw_downstream_customized
+            xml_attributes = getattr(temp_xblock, "xml_attributes", None)
+            if isinstance(xml_attributes, dict):
+                raw_downstream_customized = xml_attributes.get("downstream_customized")
+                if isinstance(raw_downstream_customized, str):
+                    downstream_customized = json.loads(raw_downstream_customized)
+                elif isinstance(raw_downstream_customized, list):
+                    downstream_customized = raw_downstream_customized
             if hasattr(temp_xblock, "downstream_customized"):
                 temp_xblock.downstream_customized = downstream_customized
 

--- a/cms/djangoapps/contentstore/helpers.py
+++ b/cms/djangoapps/contentstore/helpers.py
@@ -9,7 +9,6 @@ Platform-wide Python APIs should be added to an appropriate api.py file instead.
 
 from __future__ import annotations
 
-import json
 import logging
 import pathlib
 import re
@@ -509,8 +508,14 @@ def _fetch_and_set_upstream_link(
             # temp_xblock.display_name == temp_xblock.upstream_display_name
             # temp_xblock.data == temp_xblock.upstream_data   # for html blocks
             # Even then we want to set `downstream_customized` value to avoid overriding user customisations on sync
-            downstream_customized = temp_xblock.xml_attributes.get("downstream_customized", '[]')
-            temp_xblock.downstream_customized = json.loads(downstream_customized)
+            downstream_customized = getattr(temp_xblock, "downstream_customized", [])
+            # XmlMixin blocks expose raw XML attrs on `xml_attributes`; other blocks (e.g. DnD)
+            # may not have this attribute, but still have parsed downstream_customized field.
+            if hasattr(temp_xblock, 'xml_attributes'):
+                raw_downstream_customized = temp_xblock.xml_attributes.get("downstream_customized", [])
+                downstream_customized = raw_downstream_customized
+            if hasattr(temp_xblock, "downstream_customized"):
+                temp_xblock.downstream_customized = downstream_customized
 
 
 def _import_xml_node_to_parent(


### PR DESCRIPTION
## Description

Fix clipboard paste crash in upstream-link setup when pasted block does not expose `xml_attributes`.

Before change, paste flow always read `temp_xblock.xml_attributes["downstream_customized"]`. Blocks like `DragAndDropBlockWithMixins` do not have `xml_attributes`, so Studio raised `AttributeError` and paste failed.

Change now:
- Read `downstream_customized` from parsed block field first (`getattr(temp_xblock, "downstream_customized", [])`).
- Read `xml_attributes` only when block exposes it.
- Set `downstream_customized` only when block has field.

Impact:
- **Course Author**: paste of blocks like drag-and-drop no longer crashes.

## Supporting information

- `Private-ref`: https://tasks.opencraft.com/browse/FAL-4331
- Discovered while working on: https://github.com/openedx/frontend-app-authoring/issues/1749

## Testing instructions

1. In any library, create drag-and-drop-v2 block
2. Copy block.
3. Paste block into a course unit.
4. Verify paste succeeds (no 500 in CMS logs).
5. Verify pasted block opens and renders in unit.

## Deadline

ASAP