### PR TITLE
fix: Drop constraints for cryptography and pact-python

### DIFF
--- a/lms/djangoapps/course_api/blocks/tests/pacts/verify_pact.py
+++ b/lms/djangoapps/course_api/blocks/tests/pacts/verify_pact.py
@@ -17,24 +17,15 @@ PACT_FILE = "api-block-contract.json"
 class ProviderVerificationServer(LiveServerTestCase):
     """ Django Test Live Server for Pact Verification """
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        cls.verifier = Verifier(
-            provider='lms',
-            provider_base_url=cls.live_server_url,
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-
     def test_verify_pact(self):
-        output, _ = self.verifier.verify_pacts(
-            os.path.join(PACT_DIR, PACT_FILE),
-            headers=['Pact-Authentication: Allow', ],
-            provider_states_setup_url=f"{self.live_server_url}{reverse('provider-state-view')}",
+        (
+            Verifier(name='lms')
+            .add_transport(url=self.live_server_url)
+            .add_source(os.path.join(PACT_DIR, PACT_FILE))
+            .add_custom_header('Pact-Authentication', 'Allow')
+            .state_handler(
+                f"{self.live_server_url}{reverse('provider-state-view')}",
+                body=True,
+            )
+            .verify()
         )
-
-        assert output == 0

--- a/lms/djangoapps/courseware/tests/pacts/verify_pact.py
+++ b/lms/djangoapps/courseware/tests/pacts/verify_pact.py
@@ -17,24 +17,15 @@ PACT_FILE = "course-xblock-handler-contract.json"
 class ProviderVerificationServer(LiveServerTestCase):
     """ Django Test Live Server for Pact Verification """
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        cls.verifier = Verifier(
-            provider='lms',
-            provider_base_url=cls.live_server_url,
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-
     def test_verify_pact(self):
-        output, _ = self.verifier.verify_pacts(
-            os.path.join(PACT_DIR, PACT_FILE),
-            headers=['Pact-Authentication: Allow', ],
-            provider_states_setup_url=f"{self.live_server_url}{reverse('courseware_xblock_handler_provider_state')}",
+        (
+            Verifier(name='lms')
+            .add_transport(url=self.live_server_url)
+            .add_source(os.path.join(PACT_DIR, PACT_FILE))
+            .add_custom_header('Pact-Authentication', 'Allow')
+            .state_handler(
+                f"{self.live_server_url}{reverse('courseware_xblock_handler_provider_state')}",
+                body=True,
+            )
+            .verify()
         )
-
-        assert output == 0

--- a/openedx/core/djangoapps/courseware_api/tests/pacts/verify_pact.py
+++ b/openedx/core/djangoapps/courseware_api/tests/pacts/verify_pact.py
@@ -20,27 +20,16 @@ PACT_FILE = "api-courseware-contract.json"
 class ProviderVerificationServer(LiveServerTestCase):
     """ Live Server for Pact Verification"""
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        cls.PACT_URL = cls.live_server_url
-
-        cls.verifier = Verifier(
-            provider='lms',
-            provider_base_url=cls.PACT_URL,
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-
     @override_waffle_flag(DISCOUNT_APPLICABILITY_FLAG, active=True)
     def test_verify_pact(self):
-        output, _ = self.verifier.verify_pacts(
-            os.path.join(PACT_DIR, PACT_FILE),
-            headers=['Pact-Authentication: Allow', ],
-            provider_states_setup_url=f"{self.PACT_URL}{reverse('courseware_api:provider-state-view')}",
+        (
+            Verifier(name='lms')
+            .add_transport(url=self.live_server_url)
+            .add_source(os.path.join(PACT_DIR, PACT_FILE))
+            .add_custom_header('Pact-Authentication', 'Allow')
+            .state_handler(
+                f"{self.live_server_url}{reverse('courseware_api:provider-state-view')}",
+                body=True,
+            )
+            .verify()
         )
-
-        assert output == 0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -125,17 +125,6 @@ xmlsec==1.3.14
 # Pin this back to the previous version until that bug is fixed.
 django-debug-toolbar<6.0.0
 
-# Date 2025-10-07
-# Cryptography 46.0.0 conflicts with system dependencies needed for snowflake-connector-python
-# snowflake-connector-python comes as a dependency of edx-enterprise so it can not be directly pinned here.
-# See issue https://github.com/openedx/edx-platform/issues/37417 for details on this.
-# This can be unpinned once snowflake-connector-python==4.0.0 is available (contains the fix).
-# pact-python==3.0.0 also removes cffi dependency and is causing the upgrade build to fail
-# This should also be removed together with cryptography constraint.
-# Issue: https://github.com/openedx/edx-platform/issues/37435
-cryptography<46.0.0
-pact-python<3.0.0
-
 # Date 2026-01-13
 # Sphinx-autoapi changed the version of astroid it needs
 # but the newer version is not compatible with the current pylint version

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -14,10 +14,8 @@ codejail-includes==2.0.0
     # via -r requirements/edx-sandbox/base.in
 contourpy==1.3.3
     # via matplotlib
-cryptography==45.0.7
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/edx-sandbox/base.in
+cryptography==47.0.0
+    # via -r requirements/edx-sandbox/base.in
 cycler==0.12.1
     # via matplotlib
 fonttools==4.62.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -150,9 +150,8 @@ codejail-includes==2.0.0
     # via -r requirements/edx/kernel.in
 crowdsourcehinter-xblock==1.0.0
     # via -r requirements/edx/bundled.in
-cryptography==45.0.7
+cryptography==47.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in
     #   django-fernet-fields-v2
     #   edx-enterprise
@@ -987,7 +986,7 @@ pynacl==1.6.2
     #   paramiko
 pynliner==0.8.0
     # via -r requirements/edx/kernel.in
-pyopenssl==25.3.0
+pyopenssl==26.1.0
     # via snowflake-connector-python
 pyparsing==3.3.2
     # via
@@ -1155,7 +1154,7 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   enterprise-integrated-channels
-snowflake-connector-python==4.3.0
+snowflake-connector-python==4.4.0
     # via enterprise-integrated-channels
 social-auth-app-django==5.4.1
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -46,10 +46,6 @@ aniso8601==10.0.1
     #   -r requirements/edx/testing.txt
     #   edx-tincan-py35
     #   tincan
-annotated-doc==0.0.4
-    # via
-    #   -r requirements/edx/testing.txt
-    #   fastapi
 annotated-types==0.7.0
     # via
     #   -r requirements/edx/doc.txt
@@ -60,7 +56,6 @@ anyio==4.13.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   httpx
-    #   starlette
 appdirs==1.4.4
     # via
     #   -r requirements/edx/doc.txt
@@ -214,6 +209,7 @@ cffi==2.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   cryptography
+    #   pact-python-ffi
     #   pynacl
 chardet==7.4.3
     # via
@@ -250,9 +246,7 @@ click==8.3.3
     #   edx-lint
     #   import-linter
     #   nltk
-    #   pact-python
     #   pip-tools
-    #   uvicorn
 click-didyoumean==0.3.1
     # via
     #   -r requirements/edx/doc.txt
@@ -295,9 +289,8 @@ crowdsourcehinter-xblock==1.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-cryptography==45.0.7
+cryptography==47.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-fernet-fields-v2
@@ -916,10 +909,6 @@ faker==40.15.0
     # via
     #   -r requirements/edx/testing.txt
     #   factory-boy
-fastapi==0.136.1
-    # via
-    #   -r requirements/edx/testing.txt
-    #   pact-python
 fastavro==1.12.2
     # via
     #   -r requirements/edx/doc.txt
@@ -967,7 +956,7 @@ gitdb==4.0.12
     # via
     #   -r requirements/edx/doc.txt
     #   gitpython
-gitpython==3.1.47
+gitpython==3.1.48
     # via -r requirements/edx/doc.txt
 glob2==0.7
     # via
@@ -1047,7 +1036,6 @@ h11==0.16.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   httpcore
-    #   uvicorn
 h2==4.3.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1458,10 +1446,12 @@ packaging==26.2
     #   sphinx
     #   tox
     #   wheel
-pact-python==1.6.0
+pact-python==3.3.1
+    # via -r requirements/edx/testing.txt
+pact-python-ffi==0.5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/edx/testing.txt
+    #   pact-python
 paramiko==4.0.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1558,7 +1548,6 @@ psutil==7.2.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   edx-django-utils
-    #   pact-python
     #   pytest-xdist
 psycopg2-binary==2.9.12
     # via
@@ -1603,7 +1592,6 @@ pydantic==2.13.3
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   camel-converter
-    #   fastapi
 pydantic-core==2.46.3
     # via
     #   -r requirements/edx/doc.txt
@@ -1692,7 +1680,7 @@ pynliner==0.8.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-pyopenssl==25.3.0
+pyopenssl==26.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -1880,7 +1868,6 @@ requests==2.33.1
     #   meilisearch
     #   openedx-forum
     #   optimizely-sdk
-    #   pact-python
     #   pylti1p3
     #   python-swiftclient
     #   requests-oauthlib
@@ -1980,7 +1967,6 @@ six==1.17.0
     #   fs-s3fs
     #   html5lib
     #   libsass
-    #   pact-python
     #   python-dateutil
 slumber==0.7.1
     # via
@@ -1997,7 +1983,7 @@ snowballstemmer==3.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   sphinx
-snowflake-connector-python==4.3.0
+snowflake-connector-python==4.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2098,10 +2084,6 @@ staff-graded-xblock==4.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-starlette==1.0.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   fastapi
 stevedore==5.7.0
     # via
     #   -r requirements/edx/doc.txt
@@ -2184,13 +2166,13 @@ typing-extensions==4.15.0
     #   django-stubs-ext
     #   djangorestframework-stubs
     #   edx-opaque-keys
-    #   fastapi
     #   grimp
     #   grpcio
     #   icalendar
     #   import-linter
     #   jwcrypto
     #   mypy
+    #   pact-python
     #   pydantic
     #   pydantic-core
     #   pydata-sphinx-theme
@@ -2198,14 +2180,12 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   referencing
     #   snowflake-connector-python
-    #   starlette
     #   typesense
     #   typing-inspection
 typing-inspection==0.4.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-    #   fastapi
     #   pydantic
 tzdata==2026.2
     # via
@@ -2242,13 +2222,8 @@ urllib3==2.6.3
     #   -r requirements/edx/testing.txt
     #   botocore
     #   elasticsearch
-    #   pact-python
     #   requests
     #   types-requests
-uvicorn==0.46.0
-    # via
-    #   -r requirements/edx/testing.txt
-    #   pact-python
 vine==5.1.0
     # via
     #   -r requirements/edx/doc.txt
@@ -2373,6 +2348,7 @@ yarl==1.23.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   aiohttp
+    #   pact-python
 zipp==3.23.1
     # via
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -210,9 +210,8 @@ codejail-includes==2.0.0
     # via -r requirements/edx/base.txt
 crowdsourcehinter-xblock==1.0.0
     # via -r requirements/edx/base.txt
-cryptography==45.0.7
+cryptography==47.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   django-fernet-fields-v2
     #   edx-enterprise
@@ -717,7 +716,7 @@ geoip2==5.2.0
     # via -r requirements/edx/base.txt
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.47
+gitpython==3.1.48
     # via -r requirements/edx/doc.in
 glob2==0.7
     # via -r requirements/edx/base.txt
@@ -1206,7 +1205,7 @@ pynacl==1.6.2
     #   paramiko
 pynliner==0.8.0
     # via -r requirements/edx/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.1.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -1409,7 +1408,7 @@ smmap==5.0.3
     # via gitdb
 snowballstemmer==3.0.1
     # via sphinx
-snowflake-connector-python==4.3.0
+snowflake-connector-python==4.4.0
     # via
     #   -r requirements/edx/base.txt
     #   enterprise-integrated-channels

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -43,10 +43,8 @@ click-option-group==0.5.9
     # via semgrep
 colorama==0.4.6
     # via semgrep
-cryptography==45.0.7
-    # via
-    #   -c requirements/constraints.txt
-    #   pyjwt
+cryptography==47.0.0
+    # via pyjwt
 exceptiongroup==1.2.2
     # via semgrep
 face==26.0.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -29,8 +29,6 @@ aniso8601==10.0.1
     #   -r requirements/edx/base.txt
     #   edx-tincan-py35
     #   tincan
-annotated-doc==0.0.4
-    # via fastapi
 annotated-types==0.7.0
     # via
     #   -r requirements/edx/base.txt
@@ -39,7 +37,6 @@ anyio==4.13.0
     # via
     #   -r requirements/edx/base.txt
     #   httpx
-    #   starlette
 appdirs==1.4.4
     # via
     #   -r requirements/edx/base.txt
@@ -162,6 +159,7 @@ cffi==2.0.0
     # via
     #   -r requirements/edx/base.txt
     #   cryptography
+    #   pact-python-ffi
     #   pynacl
 chardet==7.4.3
     # via
@@ -192,8 +190,6 @@ click==8.3.3
     #   edx-lint
     #   import-linter
     #   nltk
-    #   pact-python
-    #   uvicorn
 click-didyoumean==0.3.1
     # via
     #   -r requirements/edx/base.txt
@@ -225,9 +221,8 @@ coverage[toml]==7.13.5
     #   pytest-cov
 crowdsourcehinter-xblock==1.0.0
     # via -r requirements/edx/base.txt
-cryptography==45.0.7
+cryptography==47.0.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt
     #   django-fernet-fields-v2
     #   edx-enterprise
@@ -713,8 +708,6 @@ factory-boy==3.3.3
     # via -r requirements/edx/testing.in
 faker==40.15.0
     # via factory-boy
-fastapi==0.136.1
-    # via pact-python
 fastavro==1.12.2
     # via
     #   -r requirements/edx/base.txt
@@ -811,7 +804,6 @@ h11==0.16.0
     # via
     #   -r requirements/edx/base.txt
     #   httpcore
-    #   uvicorn
 h2==4.3.0
     # via
     #   -r requirements/edx/base.txt
@@ -1111,10 +1103,10 @@ packaging==26.2
     #   snowflake-connector-python
     #   tox
     #   wheel
-pact-python==1.6.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/edx/testing.in
+pact-python==3.3.1
+    # via -r requirements/edx/testing.in
+pact-python-ffi==0.5.3.0
+    # via pact-python
 paramiko==4.0.0
     # via
     #   -r requirements/edx/base.txt
@@ -1190,7 +1182,6 @@ psutil==7.2.2
     # via
     #   -r requirements/edx/base.txt
     #   edx-django-utils
-    #   pact-python
     #   pytest-xdist
 psycopg2-binary==2.9.12
     # via -r requirements/edx/base.txt
@@ -1225,7 +1216,6 @@ pydantic==2.13.3
     # via
     #   -r requirements/edx/base.txt
     #   camel-converter
-    #   fastapi
 pydantic-core==2.46.3
     # via
     #   -r requirements/edx/base.txt
@@ -1288,7 +1278,7 @@ pynacl==1.6.2
     #   paramiko
 pynliner==0.8.0
     # via -r requirements/edx/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.1.0
     # via
     #   -r requirements/edx/base.txt
     #   snowflake-connector-python
@@ -1442,7 +1432,6 @@ requests==2.33.1
     #   meilisearch
     #   openedx-forum
     #   optimizely-sdk
-    #   pact-python
     #   pylti1p3
     #   python-swiftclient
     #   requests-oauthlib
@@ -1522,7 +1511,6 @@ six==1.17.0
     #   fs
     #   fs-s3fs
     #   html5lib
-    #   pact-python
     #   python-dateutil
 slumber==0.7.1
     # via
@@ -1530,7 +1518,7 @@ slumber==0.7.1
     #   edx-bulk-grades
     #   edx-enterprise
     #   enterprise-integrated-channels
-snowflake-connector-python==4.3.0
+snowflake-connector-python==4.4.0
     # via
     #   -r requirements/edx/base.txt
     #   enterprise-integrated-channels
@@ -1563,8 +1551,6 @@ sqlparse==0.5.5
     #   django
 staff-graded-xblock==4.0.0
     # via -r requirements/edx/base.txt
-starlette==1.0.0
-    # via fastapi
 stevedore==5.7.0
     # via
     #   -r requirements/edx/base.txt
@@ -1626,25 +1612,23 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
-    #   fastapi
     #   grimp
     #   grpcio
     #   icalendar
     #   import-linter
     #   jwcrypto
+    #   pact-python
     #   pydantic
     #   pydantic-core
     #   pylti1p3
     #   pyopenssl
     #   referencing
     #   snowflake-connector-python
-    #   starlette
     #   typesense
     #   typing-inspection
 typing-inspection==0.4.2
     # via
     #   -r requirements/edx/base.txt
-    #   fastapi
     #   pydantic
 tzdata==2026.2
     # via
@@ -1674,10 +1658,7 @@ urllib3==2.6.3
     #   -r requirements/edx/base.txt
     #   botocore
     #   elasticsearch
-    #   pact-python
     #   requests
-uvicorn==0.46.0
-    # via pact-python
 vine==5.1.0
     # via
     #   -r requirements/edx/base.txt
@@ -1770,6 +1751,7 @@ yarl==1.23.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
+    #   pact-python
 zipp==3.23.1
     # via
     #   -r requirements/edx/base.txt

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -28,9 +28,8 @@ click==8.3.3
     # via
     #   -r scripts/user_retirement/requirements/base.in
     #   edx-django-utils
-cryptography==45.0.7
+cryptography==47.0.0
     # via
-    #   -c requirements/constraints.txt
     #   google-auth
     #   pyjwt
 django==5.2.13

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -41,7 +41,7 @@ click==8.3.3
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   edx-django-utils
-cryptography==45.0.7
+cryptography==47.0.0
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   google-auth


### PR DESCRIPTION
The latest version of snowflake-connector-python claims to fix the
underlying issue that caused us to pin cryptography so unpin both of
these and re-build dependencies to see if the issues are resolved.

pact-python was also unpinned in the same pass. Upgrading from 1.x to
3.x introduced a breaking API change in the `Verifier` class: the
constructor no longer accepts `provider`/`provider_base_url` kwargs
(now takes `name`), and `verify_pacts()` was replaced by a fluent
builder API (`.add_transport()`, `.add_source()`, `.state_handler()`,
`.verify()`). The three `verify_pact.py` pact test files were updated
to use the new API. Failure mode was caught by pylint (`E1123`/`E1120`)
rather than at runtime since the pact tests are not run in standard CI.