### PR TITLE
remove legacy video editor code

### DIFF
--- a/cms/djangoapps/contentstore/toggles.py
+++ b/cms/djangoapps/contentstore/toggles.py
@@ -86,25 +86,6 @@ def exam_setting_view_enabled(course_key):
     return not LEGACY_STUDIO_EXAM_SETTINGS.is_enabled(course_key)
 
 
-# .. toggle_name: legacy_studio.video_editor
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Temporarily fall back to the old Video component (a.k.a. video block) editor.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2025-03-14
-# .. toggle_target_removal_date: 2025-09-14
-# .. toggle_tickets: https://github.com/openedx/edx-platform/issues/36275
-# .. toggle_warning: In Ulmo, this toggle will be removed. Only the new (React-based) experience will be available.
-LEGACY_STUDIO_VIDEO_EDITOR = CourseWaffleFlag('legacy_studio.video_editor', __name__)
-
-
-def use_new_video_editor(course_key):
-    """
-    Returns a boolean = true if new video editor is enabled
-    """
-    return not LEGACY_STUDIO_VIDEO_EDITOR.is_enabled(course_key)
-
-
 # .. toggle_name: legacy_studio.pdf_editor
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
@@ -129,7 +110,7 @@ def use_new_pdf_editor():
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2023-04-03
 # .. toggle_target_removal_date: 2023-6-01
-# .. toggle_warning: You need to activate the `new_core_editors.use_new_video_editor` flag to use this new flow.
+# .. toggle_warning: This controls the new core video xblock editor flow.
 ENABLE_VIDEO_GALLERY_FLOW_FLAG = WaffleFlag('new_core_editors.use_video_gallery_flow', __name__)
 
 

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -538,12 +538,11 @@ function($, _, Backbone, gettext, BasePage,
             if (!options || options.view !== 'visibility_view') {
                 const primaryHeader = $(event.target).closest('.xblock-header-primary, .nav-actions');
 
-                var useNewVideoEditor = primaryHeader.attr('use-new-editor-video'),
-                    blockType = primaryHeader.attr('data-block-type'),
+                var blockType = primaryHeader.attr('data-block-type'),
                     useNewPdfEditor = primaryHeader.attr('use-new-editor-pdf');
 
                 if((blockType === 'html')
-                        || (useNewVideoEditor === 'True' && blockType === 'video')
+                        || (blockType === 'video')
                         || (blockType === 'problem')
                         || (useNewPdfEditor === 'True' && blockType === 'pdf')
                 ) {
@@ -1204,8 +1203,7 @@ function($, _, Backbone, gettext, BasePage,
         },
 
         onNewXBlock: function(xblockElement, scrollOffset, is_duplicate, data) {
-            var useNewVideoEditor = this.$('.xblock-header-primary').attr('use-new-editor-video'),
-                useVideoGalleryFlow = this.$('.xblock-header-primary').attr("use-video-gallery-flow");
+            var useVideoGalleryFlow = this.$('.xblock-header-primary').attr("use-video-gallery-flow");
 
             // find the block type in the locator if availible
             if(data.hasOwnProperty('locator')) {
@@ -1214,7 +1212,7 @@ function($, _, Backbone, gettext, BasePage,
             }
             // open mfe editors for new blocks only and not for content imported from libraries
             if(!data.hasOwnProperty('upstreamRef') && (blockType.includes('html')
-                    || (useNewVideoEditor === 'True' && blockType.includes('video'))
+                    || (blockType.includes('video'))
                     || (blockType.includes('problem')))
             ){
                 if (this.options.isIframeEmbed && (this.isSplitTestContentPage || this.isVerticalContentPage)) {

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -13,7 +13,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 
 from cms.djangoapps.contentstore.helpers import xblock_studio_url, xblock_type_display_name
-from cms.djangoapps.contentstore.toggles import use_new_pdf_editor, use_new_video_editor, use_video_gallery_flow
+from cms.djangoapps.contentstore.toggles import use_new_pdf_editor, use_video_gallery_flow
 from cms.djangoapps.contentstore.utils import get_editor_page_base_url
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
@@ -111,7 +111,6 @@ from openedx.core.djangolib.markup import HTML, Text
 <%block name="content">
 
 <%
-use_new_editor_video = use_new_video_editor(xblock_locator.course_key)
 use_new_editor_pdf = use_new_pdf_editor()
 use_new_video_gallery_flow = use_video_gallery_flow()
 %>
@@ -167,7 +166,6 @@ use_new_video_gallery_flow = use_video_gallery_flow()
         </div>
 
         <nav class="nav-actions" aria-label="${_('Page Actions')}"
-        use-new-editor-video = ${use_new_editor_video}
         use-new-editor-pdf = ${use_new_editor_pdf}
         use-video-gallery-flow = ${use_new_video_gallery_flow}
         authoring_MFE_base_url = ${get_editor_page_base_url(xblock_locator.course_key)}

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -8,12 +8,11 @@ from lms.lib.utils import is_unit
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
-from cms.djangoapps.contentstore.toggles import use_new_pdf_editor, use_new_video_editor, use_video_gallery_flow
+from cms.djangoapps.contentstore.toggles import use_new_pdf_editor, use_video_gallery_flow
 from cms.lib.xblock.upstream_sync import UpstreamLink
 from openedx.core.djangoapps.content_tagging.toggles import is_tagging_feature_disabled
 %>
 <%
-use_new_editor_video = use_new_video_editor(xblock.context_key)
 use_new_editor_pdf = use_new_pdf_editor()
 use_new_video_gallery_flow = use_video_gallery_flow()
 use_tagging = not is_tagging_feature_disabled()
@@ -83,7 +82,6 @@ can_unlink = upstream_info.upstream_ref and not upstream_info.top_level_parent_k
         is-collapsed
     % endif
     "
-    use-new-editor-video = ${use_new_editor_video}
     use-new-editor-pdf = ${use_new_editor_pdf}
     use-video-gallery-flow = ${use_new_video_gallery_flow}
     authoring_MFE_base_url = ${get_editor_page_base_url(xblock.location.course_key)}


### PR DESCRIPTION
Ticket: https://github.com/openedx/openedx-platform/issues/35257

- Remove legacy video editor toggle flag and its usage.
- Keep the new video editor in usage
- No html, js is found which needs to be removed as part of this PR

### Adding for the information:

We will delete these [html pages](https://github.com/openedx/openedx-platform/blob/farhan/remove-legacy-video-editor/xmodule/video_block/video_block.py#L135-L150) while removing the Built-In Video Block code.
They exist in the [extracted video block](https://github.com/openedx/xblocks-contrib/blob/main/xblocks_contrib/video/video.py#L137-L149) as well.
