### PR TITLE
fix: Use specific sort order for Instructor Dashboard roles.

### DIFF
--- a/lms/djangoapps/instructor/access.py
+++ b/lms/djangoapps/instructor/access.py
@@ -53,6 +53,11 @@ FORUM_ROLES = (
     FORUM_ROLE_COMMUNITY_TA,
 )
 
+INSTRUCTOR_DASHBOARD_ROLE_SORT_ORDER = (
+    'staff', 'limited_staff', 'instructor', 'beta', 'data_researcher',
+    *FORUM_ROLES, 'ccx_coach',
+)
+
 ROLE_DISPLAY_NAMES = {
     'instructor': _('Admin'),
     'staff': _('Staff'),

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -2885,6 +2885,29 @@ class CourseTeamRolesViewTest(SharedModuleStoreTestCase):
         ccx_entry = next(r for r in response.data['results'] if r['role'] == 'ccx_coach')
         assert ccx_entry['display_name'] == 'CCX Coach'
 
+    @override_settings(FEATURES={**settings.FEATURES, 'CUSTOM_COURSES_EDX': True})
+    def test_roles_sort_order(self):
+        """Roles are returned in the expected display order, with ccx_coach last."""
+        ccx_course = CourseFactory.create(
+            org='edX',
+            number='SortX',
+            run='2024',
+            display_name='Sort Order Test Course',
+            enable_ccx=True,
+        )
+        url = reverse('instructor_api_v2:course_team_roles', kwargs={'course_id': str(ccx_course.id)})
+        instructor = InstructorFactory.create(course_key=ccx_course.id)
+        self.client.force_authenticate(user=instructor)
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        returned_roles = [r['role'] for r in response.data['results']]
+        assert returned_roles == [
+            'staff', 'limited_staff', 'instructor', 'beta', 'data_researcher',
+            'Administrator', 'Moderator', 'Group Moderator', 'Community TA',
+            'ccx_coach',
+        ]
+
     def test_list_roles_unauthenticated(self):
         """Unauthenticated request returns 401."""
         response = self.client.get(self.url)

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -3081,11 +3081,11 @@ class CourseTeamRolesView(DeveloperErrorViewMixin, APIView):
         {
             "course_id": "course-v1:edX+DemoX+Demo_Course",
             "results": [
-                {"role": "beta", "display_name": "Beta Tester"},
-                {"role": "data_researcher", "display_name": "Data Researcher"},
-                {"role": "instructor", "display_name": "Admin"},
+                {"role": "staff", "display_name": "Staff"},
                 {"role": "limited_staff", "display_name": "Limited Staff"},
-                {"role": "staff", "display_name": "Staff"}
+                {"role": "instructor", "display_name": "Admin"},
+                {"role": "beta", "display_name": "Beta Tester"},
+                {"role": "data_researcher", "display_name": "Data Researcher"}
             ]
         }
 

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -88,6 +88,7 @@ from lms.djangoapps.courseware.tabs import get_course_tab_list
 from lms.djangoapps.instructor import enrollment, permissions
 from lms.djangoapps.instructor.access import (
     FORUM_ROLES,
+    INSTRUCTOR_DASHBOARD_ROLE_SORT_ORDER,
     ROLE_DISPLAY_NAMES,
     ROLES,
     allow_access,
@@ -3112,15 +3113,22 @@ class CourseTeamRolesView(DeveloperErrorViewMixin, APIView):
         if editable and not has_access(request.user, 'instructor', course):
             roles = set(FORUM_ROLES)
 
+        role_order = {role: i for i, role in enumerate(INSTRUCTOR_DASHBOARD_ROLE_SORT_ORDER)}
+
         results = [
             {'role': rolename, 'display_name': str(ROLE_DISPLAY_NAMES[rolename])}
-            for rolename in sorted(roles)
+            for rolename in sorted(
+                roles, key=lambda r: role_order.get(r, len(INSTRUCTOR_DASHBOARD_ROLE_SORT_ORDER))
+            )
         ]
 
-        return Response({
-            'course_id': str(course_key),
-            'results': results,
-        }, status=status.HTTP_200_OK)
+        return Response(
+            {
+                'course_id': str(course_key),
+                'results': results,
+            },
+            status=status.HTTP_200_OK
+        )
 
 
 @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True), name='dispatch')


### PR DESCRIPTION
## Description

The `CourseTeamRolesView` endpoint returns roles in alphabetical order, which doesn't match the desired display order in the Instructor Dashboard. This changes the endpoint to return roles in a specific order:

1. Staff
2. Limited Staff
3. Admin
4. Beta Tester
5. Course Data Researcher
6. Discussion Admin
7. Discussion Moderator
8. Group Community TA
9. Community TA
10. CCX Coach (when enabled)

## Supporting information

[frontend-app-instructor-dashboard#102 (comment)](https://github.com/openedx/frontend-app-instructor-dashboard/issues/102#issuecomment-4306825865)

## Testing instructions

1. Open the Instructor Dashboard and navigate to the **Course Team Management** tab
2. Verify the role filter/dropdown lists roles in the order above
3. Enable CCX for a course and verify CCX Coach appears last

## Deadline

Verawood