### PR TITLE
fix: adjust gradebook URL to correct value

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -123,7 +123,7 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
         COURSE_AUTHORING_MICROFRONTEND_URL='http://localhost:2001/authoring',
         ADMIN_CONSOLE_MICROFRONTEND_URL='http://localhost:2025/admin-console',
         # intentionally include trailing slash to test URL joining logic
-        WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook/', 
+        WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook/',
     )
     def test_get_course_metadata_as_instructor(self):
         """

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -122,7 +122,7 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
     @override_settings(
         COURSE_AUTHORING_MICROFRONTEND_URL='http://localhost:2001/authoring',
         ADMIN_CONSOLE_MICROFRONTEND_URL='http://localhost:2025/admin-console',
-        WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook',
+        WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook/',  # intentionally missing trailing slash to test URL joining logic
     )
     def test_get_course_metadata_as_instructor(self):
         """

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -122,7 +122,7 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
     @override_settings(
         COURSE_AUTHORING_MICROFRONTEND_URL='http://localhost:2001/authoring',
         ADMIN_CONSOLE_MICROFRONTEND_URL='http://localhost:2025/admin-console',
-        WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook/',  # intentionally missing trailing slash to test URL joining logic
+        WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook/',  # intentionally include trailing slash to test URL joining logic
     )
     def test_get_course_metadata_as_instructor(self):
         """

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -121,6 +121,7 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
 
     @override_settings(COURSE_AUTHORING_MICROFRONTEND_URL='http://localhost:2001/authoring')
     @override_settings(ADMIN_CONSOLE_MICROFRONTEND_URL='http://localhost:2025/admin-console')
+    @override_settings(WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook')
     def test_get_course_metadata_as_instructor(self):
         """
         Test that an instructor can retrieve comprehensive course metadata.
@@ -176,9 +177,11 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
         assert 'analytics_dashboard_message' in data
         assert 'studio_grading_url' in data
         assert 'admin_console_url' in data
+        assert 'gradebook_url' in data
 
         assert data['studio_grading_url'] == f'http://localhost:2001/authoring/course/{self.course.id}/settings/grading'
         assert data['admin_console_url'] == 'http://localhost:2025/admin-console/authz'
+        assert data['gradebook_url'] == f'http://localhost:1994/gradebook/{self.course.id}'
 
     @override_settings(ADMIN_CONSOLE_MICROFRONTEND_URL='http://localhost:2025/admin-console')
     def test_admin_console_url_requires_instructor_access(self):

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -122,7 +122,8 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
     @override_settings(
         COURSE_AUTHORING_MICROFRONTEND_URL='http://localhost:2001/authoring',
         ADMIN_CONSOLE_MICROFRONTEND_URL='http://localhost:2025/admin-console',
-        WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook/',  # intentionally include trailing slash to test URL joining logic
+        # intentionally include trailing slash to test URL joining logic
+        WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook/', 
     )
     def test_get_course_metadata_as_instructor(self):
         """

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -119,11 +119,13 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
             course_id = str(self.course_key)
         return reverse('instructor_api_v2:course_metadata', kwargs={'course_id': course_id})
 
-    @override_settings(COURSE_AUTHORING_MICROFRONTEND_URL='http://localhost:2001/authoring')
-    @override_settings(ADMIN_CONSOLE_MICROFRONTEND_URL='http://localhost:2025/admin-console')
-    @override_settings(WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook')
+    @override_settings(
+        COURSE_AUTHORING_MICROFRONTEND_URL='http://localhost:2001/authoring',
+        ADMIN_CONSOLE_MICROFRONTEND_URL='http://localhost:2025/admin-console',
+        WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook',
+    )
     @patch('lms.djangoapps.instructor.views.serializers_v2.is_writable_gradebook_enabled', return_value=True)
-    def test_get_course_metadata_as_instructor(self, mock_is_writable_gradebook_enabled):
+    def test_get_course_metadata_as_instructor(self, _mock_is_writable_gradebook_enabled):
         """
         Test that an instructor can retrieve comprehensive course metadata.
         """

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -124,13 +124,16 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
         ADMIN_CONSOLE_MICROFRONTEND_URL='http://localhost:2025/admin-console',
         WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook',
     )
-    @patch('lms.djangoapps.instructor.views.serializers_v2.is_writable_gradebook_enabled', return_value=True)
-    def test_get_course_metadata_as_instructor(self, _mock_is_writable_gradebook_enabled):
+    def test_get_course_metadata_as_instructor(self):
         """
         Test that an instructor can retrieve comprehensive course metadata.
         """
-        self.client.force_authenticate(user=self.instructor)
-        response = self.client.get(self._get_url())
+        with patch(
+            'lms.djangoapps.instructor.views.serializers_v2.is_writable_gradebook_enabled',
+            return_value=True,
+        ):
+            self.client.force_authenticate(user=self.instructor)
+            response = self.client.get(self._get_url())
 
         assert response.status_code == status.HTTP_200_OK
         data = response.data

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -122,7 +122,8 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase):
     @override_settings(COURSE_AUTHORING_MICROFRONTEND_URL='http://localhost:2001/authoring')
     @override_settings(ADMIN_CONSOLE_MICROFRONTEND_URL='http://localhost:2025/admin-console')
     @override_settings(WRITABLE_GRADEBOOK_URL='http://localhost:1994/gradebook')
-    def test_get_course_metadata_as_instructor(self):
+    @patch('lms.djangoapps.instructor.views.serializers_v2.is_writable_gradebook_enabled', return_value=True)
+    def test_get_course_metadata_as_instructor(self, mock_is_writable_gradebook_enabled):
         """
         Test that an instructor can retrieve comprehensive course metadata.
         """

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -465,7 +465,7 @@ class CourseInformationSerializerV2(serializers.Serializer):
         )
         if not is_writable_gradebook_enabled(course_key) or not mfe_base_url:
             return None
-        return f'{settings.WRITABLE_GRADEBOOK_URL}/{course_key}'
+        return f'{mfe_base_url}/{course_key}'
 
     def get_studio_grading_url(self, data):
         """Get Studio MFE grading settings URL for the course."""

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -459,9 +459,13 @@ class CourseInformationSerializerV2(serializers.Serializer):
     def get_gradebook_url(self, data):
         """Get MFE gradebook URL for the course."""
         course_key = data['course'].id
-        if is_writable_gradebook_enabled(course_key) and settings.WRITABLE_GRADEBOOK_URL:
-            return f'{settings.WRITABLE_GRADEBOOK_URL}/gradebook/{course_key}'
-        return None
+        mfe_base_url = configuration_helpers.get_value(
+            'WRITABLE_GRADEBOOK_URL',
+            getattr(settings, 'WRITABLE_GRADEBOOK_URL', None)
+        )
+        if not is_writable_gradebook_enabled(course_key) or not mfe_base_url:
+            return None
+        return f'{settings.WRITABLE_GRADEBOOK_URL}/{course_key}'
 
     def get_studio_grading_url(self, data):
         """Get Studio MFE grading settings URL for the course."""

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -465,7 +465,7 @@ class CourseInformationSerializerV2(serializers.Serializer):
         )
         if not is_writable_gradebook_enabled(course_key) or not mfe_base_url:
             return None
-        return f'{mfe_base_url}/{course_key}'
+        return f'{mfe_base_url.rstrip("/")}/{course_key}'
 
     def get_studio_grading_url(self, data):
         """Get Studio MFE grading settings URL for the course."""
@@ -476,7 +476,7 @@ class CourseInformationSerializerV2(serializers.Serializer):
         )
         if not mfe_base_url:
             return None
-        return f'{mfe_base_url}/course/{course_key}/settings/grading'
+        return f'{mfe_base_url.rstrip("/")}/course/{course_key}/settings/grading'
 
     def get_admin_console_url(self, data):
         """Get admin console URL (requires instructor access and MFE configuration, null if not accessible)."""
@@ -490,7 +490,7 @@ class CourseInformationSerializerV2(serializers.Serializer):
         has_permissions = request.user.is_staff or has_instructor_access
         if not mfe_base_url or not has_permissions:
             return None
-        return f'{mfe_base_url}/authz'
+        return f'{mfe_base_url.rstrip("/")}/authz'
 
     def get_disable_buttons(self, data):
         """Check if buttons should be disabled for large courses."""

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -278,7 +278,7 @@ ENTERPRISE_ADMIN_PORTAL_NETLOC = 'localhost:1991'
 ENTERPRISE_ADMIN_PORTAL_BASE_URL = 'http://' + ENTERPRISE_ADMIN_PORTAL_NETLOC
 
 ########################## GRADEBOOK APP ##############################
-WRITABLE_GRADEBOOK_URL = 'http://localhost:1994'
+WRITABLE_GRADEBOOK_URL = 'http://localhost:1994/gradebook'
 
 ########################## ORA STAFF GRADING APP ##############################
 ORA_GRADING_MICROFRONTEND_URL = 'http://localhost:1993'


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->
### Description

The `get_gradebook_url` method in `CourseInformationSerializerV2` was building the gradebook URL incorrectly in two ways:

1. It was appending a hardcoded `/gradebook/` path segment, but the `WRITABLE_GRADEBOOK_URL` setting is already expected to include that path. The correct URL should be `{WRITABLE_GRADEBOOK_URL}/{course_key}`.

2. It was reading `WRITABLE_GRADEBOOK_URL` directly from `settings` instead of going through `configuration_helpers.get_value`, which meant site-level configuration overrides were being ignored.

### Testing instructions

1. Set `WRITABLE_GRADEBOOK_URL` to the full gradebook MFE base URL including the path (e.g. `http://localhost:1994/gradebook`).
2. Enable the writable gradebook waffle flag for a course.
3. Call the `CourseMetadataView` API endpoint for that course.
4. Verify the `gradebook_url` in the response is `http://localhost:1994/gradebook/<course_key>`.

## Deadline

Verawood
