### PR TITLE
chore: Update lti-consumer-xblock

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -734,7 +734,7 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-lti-consumer-xblock==11.1.0
+lti-consumer-xblock==11.2.0
     # via -r requirements/edx/kernel.in
 lxml[html-clean]==5.3.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1203,7 +1203,7 @@ libsass==0.10.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/assets.txt
-lti-consumer-xblock==11.1.0
+lti-consumer-xblock==11.2.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -893,7 +893,7 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-lti-consumer-xblock==11.1.0
+lti-consumer-xblock==11.2.0
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -925,7 +925,7 @@ lazy==1.6
     #   lti-consumer-xblock
     #   ora2
     #   xblock
-lti-consumer-xblock==11.1.0
+lti-consumer-xblock==11.2.0
     # via -r requirements/edx/base.txt
 lxml[html-clean]==5.3.2
     # via


### PR DESCRIPTION
This update includes the new editor design.  This is a backport of this
new editor to the verawood release branch.
