### PR TITLE
fix: Overwrite allowances in special exams instead of creating a new …

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
@@ -12,6 +12,7 @@ from edx_proctoring.api import (
     add_allowance_for_user,
     create_exam,
     create_exam_attempt,
+    get_allowances_for_course,
 )
 from edx_proctoring.models import ProctoredExamStudentAttempt
 from rest_framework import status
@@ -428,6 +429,33 @@ class ExamAllowanceViewTest(ModuleStoreTestCase):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['results'][0]['success'] is True
 
+    def test_grant_allowance_replaces_different_key(self):
+        """Granting an allowance with a different key replaces the existing one (one per user+exam)."""
+        self.client.post(
+            self._url(),
+            data={
+                'user_ids': [self.student.username],
+                'allowance_type': 'additional_time_granted',
+                'value': '30',
+            },
+            format='json',
+        )
+        response = self.client.post(
+            self._url(),
+            data={
+                'user_ids': [self.student.username],
+                'allowance_type': 'review_policy_exception',
+                'value': 'special review',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['results'][0]['success'] is True
+        allowances = get_allowances_for_course(self.course_id)
+        user_allowances = [a for a in allowances if a['user']['username'] == self.student.username]
+        assert len(user_allowances) == 1
+        assert user_allowances[0]['key'] == 'review_policy_exception'
+
     def test_delete_allowance(self):
         add_allowance_for_user(self.exam_id, self.student.username, 'additional_time_granted', '30')
         response = self.client.delete(
@@ -547,6 +575,26 @@ class CourseAllowancesViewTest(ModuleStoreTestCase):
         assert data['value'] == '30'
         assert len(data['results']) == 4
         assert all(r['success'] is True for r in data['results'])
+
+    def test_bulk_create_allowances_replaces_different_key(self):
+        """Bulk-creating an allowance with a different key replaces the existing one."""
+        add_allowance_for_user(self.exam_id, self.student.username, 'additional_time_granted', '30')
+        response = self.client.post(
+            self._url(),
+            data={
+                'exam_ids': [self.exam_id],
+                'user_ids': [self.student.username],
+                'allowance_type': 'review_policy_exception',
+                'value': 'special review',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['results'][0]['success'] is True
+        allowances = get_allowances_for_course(self.course_id)
+        user_allowances = [a for a in allowances if a['user']['username'] == self.student.username]
+        assert len(user_allowances) == 1
+        assert user_allowances[0]['key'] == 'review_policy_exception'
 
     def test_bulk_create_allowances_missing_fields(self):
         response = self.client.post(

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -4243,11 +4243,12 @@ def add_or_replace_allowance_for_user(exam_id, username_or_email, key, value):
     """
     user_id = get_user_by_username_or_email(username_or_email).id
 
-    for allowance in ProctoredExamStudentAllowance.get_allowances_for_user(exam_id, user_id):
-        if allowance.key != key:
-            remove_allowance_for_user(exam_id, user_id, allowance.key)
+    with transaction.atomic():
+        for allowance in ProctoredExamStudentAllowance.get_allowances_for_user(exam_id, user_id):
+            if allowance.key != key:
+                remove_allowance_for_user(exam_id, user_id, allowance.key)
 
-    add_allowance_for_user(exam_id, username_or_email, key, value)
+        add_allowance_for_user(exam_id, username_or_email, key, value)
 
 
 class ExamAllowanceView(DeveloperErrorViewMixin, APIView):
@@ -4315,7 +4316,7 @@ class ExamAllowanceView(DeveloperErrorViewMixin, APIView):
                     validated['value'],
                 )
                 results.append({'identifier': username_or_email, 'success': True})
-            except (ProctoredBaseException, User.DoesNotExist) as err:
+            except (ProctoredBaseException, User.DoesNotExist, User.MultipleObjectsReturned) as err:
                 results.append({'identifier': username_or_email, 'success': False, 'error': str(err)})
 
         return Response(
@@ -4497,8 +4498,15 @@ class CourseAllowancesView(DeveloperErrorViewMixin, ListAPIView):
                         validated['value'],
                     )
                     results.append({'identifier': username_or_email, 'exam_id': exam_id, 'success': True})
-                except (ProctoredBaseException, User.DoesNotExist) as err:
-                    results.append({'identifier': username_or_email, 'exam_id': exam_id, 'success': False, 'error': str(err)})
+                except (ProctoredBaseException, User.DoesNotExist, User.MultipleObjectsReturned) as err:
+                    results.append(
+                        {
+                            'identifier': username_or_email,
+                            'exam_id': exam_id,
+                            'success': False,
+                            'error': str(err)
+                        }
+                    )
 
         return Response({
             'allowance_type': validated['allowance_type'],

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -43,6 +43,7 @@ from edx_proctoring.exceptions import (
     ProctoredBaseException,
     ProctoredExamNotFoundException,
 )
+from edx_proctoring.models import ProctoredExamStudentAllowance
 from edx_rest_framework_extensions.paginators import DefaultPagination
 from edx_when import api as edx_when_api
 from opaque_keys import InvalidKeyError
@@ -4233,6 +4234,22 @@ class ProctoringSettingsView(DeveloperErrorViewMixin, APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
+def add_or_replace_allowance_for_user(exam_id, username_or_email, key, value):
+    """
+    Add an allowance for a user on an exam, removing any existing allowance with a different key.
+
+    Enforces one allowance per user per exam regardless of allowance type. If the user already
+    has an allowance for this exam with a different key, it is removed before the new one is created.
+    """
+    user_id = get_user_by_username_or_email(username_or_email).id
+
+    for allowance in ProctoredExamStudentAllowance.get_allowances_for_user(exam_id, user_id):
+        if allowance.key != key:
+            remove_allowance_for_user(exam_id, user_id, allowance.key)
+
+    add_allowance_for_user(exam_id, username_or_email, key, value)
+
+
 class ExamAllowanceView(DeveloperErrorViewMixin, APIView):
     """
     Grant, update, or remove an allowance for a student on a proctored exam.
@@ -4289,17 +4306,17 @@ class ExamAllowanceView(DeveloperErrorViewMixin, APIView):
 
         validated = serializer.validated_data
         results = []
-        for user_info in validated['user_ids']:
+        for username_or_email in validated['user_ids']:
             try:
-                add_allowance_for_user(
+                add_or_replace_allowance_for_user(
                     int(exam_id),
-                    user_info,
+                    username_or_email,
                     validated['allowance_type'],
                     validated['value'],
                 )
-                results.append({'identifier': user_info, 'success': True})
-            except ProctoredBaseException as err:
-                results.append({'identifier': user_info, 'success': False, 'error': str(err)})
+                results.append({'identifier': username_or_email, 'success': True})
+            except (ProctoredBaseException, User.DoesNotExist) as err:
+                results.append({'identifier': username_or_email, 'success': False, 'error': str(err)})
 
         return Response(
             {'allowance_type': validated['allowance_type'], 'results': results},
@@ -4471,17 +4488,17 @@ class CourseAllowancesView(DeveloperErrorViewMixin, ListAPIView):
         validated = serializer.validated_data
         results = []
         for exam_id in validated['exam_ids']:
-            for user_info in validated['user_ids']:
+            for username_or_email in validated['user_ids']:
                 try:
-                    add_allowance_for_user(
+                    add_or_replace_allowance_for_user(
                         exam_id,
-                        user_info,
+                        username_or_email,
                         validated['allowance_type'],
                         validated['value'],
                     )
-                    results.append({'identifier': user_info, 'exam_id': exam_id, 'success': True})
-                except ProctoredBaseException as err:
-                    results.append({'identifier': user_info, 'exam_id': exam_id, 'success': False, 'error': str(err)})
+                    results.append({'identifier': username_or_email, 'exam_id': exam_id, 'success': True})
+                except (ProctoredBaseException, User.DoesNotExist) as err:
+                    results.append({'identifier': username_or_email, 'exam_id': exam_id, 'success': False, 'error': str(err)})
 
         return Response({
             'allowance_type': validated['allowance_type'],


### PR DESCRIPTION
Addresses item 1 of this issue: https://github.com/openedx/frontend-app-instructor-dashboard/issues/194

The `edx-proctoring` model has a unique constraint on (`user`, `proctored_exam`, `key`) where `key` is the allowance type. The current implementation of the v2 endpoints respects that unique constraint. However, the v1 Instructor Dashboard only allows a learner to have a single allowance at a time regardless of the type. To match that behavior, this PR does an upsert that only allows a single allowance per learner overwriting a previous allowance if it exists even if its of a different `key` (type).