### PR TITLE
test: pin `HELP_TOKENS_VERSION` in instructor-dashboard `SUPPORT_URL` tests

### DIFF
--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -297,6 +297,7 @@ class MFEConfigTestCase(APITestCase):
         # Value in original MFE_CONFIG not overridden by catalog config should be preserved
         self.assertEqual(data["PRESERVED_SETTING"], "preserved")  # noqa: PT009
 
+    @override_settings(HELP_TOKENS_VERSION="latest")
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
     def test_legacy_overrides_instructor_dashboard(self, configuration_helpers_mock):
         """Legacy help-tokens SUPPORT_URL is included for instructor-dashboard when no explicit override is set."""
@@ -769,6 +770,7 @@ class FrontendSiteConfigTestCase(APITestCase):
         brand_new = apps_by_id["org.openedx.frontend.app.brand.new"]["config"]
         self.assertEqual(brand_new["BRAND_NEW_KEY"], "value")  # noqa: PT009
 
+    @override_settings(HELP_TOKENS_VERSION="latest")
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
     def test_legacy_overrides_instructor_dashboard_support_url(self, configuration_helpers_mock):
         """Instructor dashboard gets SUPPORT_URL from help-tokens when no explicit override is set."""


### PR DESCRIPTION
## Summary

The instructor-dashboard `SUPPORT_URL` tests added in #38446 assert the full help-tokens URL, which includes the doc version. `HELP_TOKENS_VERSION` derives from `doc_version()`

https://github.com/openedx/openedx-platform/blob/bb6709429ae0a48849a7def0eb08236022c7dc49/openedx/envs/common.py#L2529

which returns `"latest"` on master but `"open-release-<name>.master"` on release branches — so the tests fail on release branches (e.g., #38487 against `verawood.master`).

This pins `HELP_TOKENS_VERSION` to `"latest"` in the affected tests so the URL is deterministic regardless of which branch the tests run on. The rest of the help-tokens integration (singleton, INI file, `HELP_TOKENS_BOOKS` lookup) is still exercised end-to-end.

## Test plan

- [ ] Existing tests pass (`lms/djangoapps/mfe_config_api/tests/test_views.py`)
- [ ] Tests pass when cherry-picked to a release branch where `doc_version()` returns a non-`latest` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)