### PR TITLE
fix: freeze time to avoid jwt expiration

### DIFF
--- a/openedx/core/lib/tests/test_jwt.py
+++ b/openedx/core/lib/tests/test_jwt.py
@@ -1,9 +1,12 @@
 """
 Tests for token handling
 """
+import datetime
 import unittest
 from time import time
 
+import pytest
+from freezegun import freeze_time
 from jwt.exceptions import ExpiredSignatureError, InvalidSignatureError, MissingRequiredClaimError
 
 from openedx.core.djangolib.testing.utils import skip_unless_lms
@@ -13,6 +16,7 @@ test_user_id = 121
 invalid_test_user_id = 120
 test_timeout = 1000
 test_now = int(time())
+time_snapshot = datetime.datetime.fromtimestamp(test_now, tz=datetime.UTC)
 test_claims = {"foo": "bar", "baz": "quux", "meaning": 42}
 expected_full_token = {
     "lms_user_id": test_user_id,
@@ -24,6 +28,7 @@ expected_full_token = {
 
 
 @skip_unless_lms
+@freeze_time(time_snapshot)
 class TestSign(unittest.TestCase):
     """
     Tests for JWT creation and signing.
@@ -33,7 +38,7 @@ class TestSign(unittest.TestCase):
         token = create_jwt(test_user_id, test_timeout, {}, test_now)
 
         decoded = unpack_and_verify(token)
-        self.assertEqual(expected_full_token, decoded)  # noqa: PT009
+        assert decoded == expected_full_token
 
     def test_create_jwt_with_claims(self):
         token = create_jwt(test_user_id, test_timeout, test_claims, test_now)
@@ -42,20 +47,18 @@ class TestSign(unittest.TestCase):
         expected_token_with_claims.update(test_claims)
 
         decoded = unpack_and_verify(token)
-        self.assertEqual(expected_token_with_claims, decoded)  # noqa: PT009
+        assert decoded == expected_token_with_claims
 
     def test_malformed_token(self):
         token = create_jwt(test_user_id, test_timeout, test_claims, test_now)
         token = token + "a"
 
-        expected_token_with_claims = expected_full_token.copy()
-        expected_token_with_claims.update(test_claims)
-
-        with self.assertRaises(InvalidSignatureError):  # noqa: PT027
+        with pytest.raises(InvalidSignatureError):
             unpack_and_verify(token)
 
 
 @skip_unless_lms
+@freeze_time(time_snapshot)
 class TestUnpack(unittest.TestCase):
     """
     Tests for JWT unpacking.
@@ -65,7 +68,7 @@ class TestUnpack(unittest.TestCase):
         token = create_jwt(test_user_id, test_timeout, {}, test_now)
         decoded = unpack_jwt(token, test_user_id, test_now)
 
-        self.assertEqual(expected_full_token, decoded)  # noqa: PT009
+        assert decoded == expected_full_token
 
     def test_unpack_jwt_with_claims(self):
         token = create_jwt(test_user_id, test_timeout, test_claims, test_now)
@@ -75,28 +78,25 @@ class TestUnpack(unittest.TestCase):
 
         decoded = unpack_jwt(token, test_user_id, test_now)
 
-        self.assertEqual(expected_token_with_claims, decoded)  # noqa: PT009
+        assert decoded == expected_token_with_claims
 
     def test_malformed_token(self):
         token = create_jwt(test_user_id, test_timeout, test_claims, test_now)
         token = token + "a"
 
-        expected_token_with_claims = expected_full_token.copy()
-        expected_token_with_claims.update(test_claims)
-
-        with self.assertRaises(InvalidSignatureError):  # noqa: PT027
+        with pytest.raises(InvalidSignatureError):
             unpack_jwt(token, test_user_id, test_now)
 
     def test_unpack_token_with_invalid_user(self):
         token = create_jwt(invalid_test_user_id, test_timeout, {}, test_now)
 
-        with self.assertRaises(InvalidSignatureError):  # noqa: PT027
+        with pytest.raises(InvalidSignatureError):
             unpack_jwt(token, test_user_id, test_now)
 
     def test_unpack_expired_token(self):
         token = create_jwt(test_user_id, test_timeout, {}, test_now)
 
-        with self.assertRaises(ExpiredSignatureError):  # noqa: PT027
+        with pytest.raises(ExpiredSignatureError):
             unpack_jwt(token, test_user_id, test_now + test_timeout + 1)
 
     def test_missing_expired_lms_user_id(self):
@@ -104,7 +104,7 @@ class TestUnpack(unittest.TestCase):
         del payload['lms_user_id']
         token = _encode_and_sign(payload)
 
-        with self.assertRaises(MissingRequiredClaimError):  # noqa: PT027
+        with pytest.raises(MissingRequiredClaimError):
             unpack_jwt(token, test_user_id, test_now)
 
     def test_missing_expired_key(self):
@@ -112,5 +112,5 @@ class TestUnpack(unittest.TestCase):
         del payload['exp']
         token = _encode_and_sign(payload)
 
-        with self.assertRaises(MissingRequiredClaimError):  # noqa: PT027
+        with pytest.raises(MissingRequiredClaimError):
             unpack_jwt(token, test_user_id, test_now)


### PR DESCRIPTION
## Description

Fixes flaky `ExpiredSignatureError` failures in `openedx/core/lib/tests/test_jwt.py` by freezing time during test execution.

### Root cause

`test_now = int(time())` is evaluated once at module import time. Tokens are created with
`exp = test_now + 1000`. When `unpack_and_verify` calls `jwt.decode`, PyJWT checks `exp` against
the real wall clock via `time.time()`. If the test runs more than 1000 seconds after the module
was imported (due to test ordering or slow CI), the token is already expired.

### Fix

Wrap both test classes with `@freeze_time` at the `test_now` timestamp so that `time.time()`
returns a consistent value during test execution. This ensures PyJWT's internal `exp` check
sees the same clock that was used to create the token.

Also converts assertions to pytest style (`assert ==`, `pytest.raises`) and removes the
corresponding `# noqa` suppressions.

Also removes unused variables (`expected_token_with_claims`) in a couple of methods.

No production code changes.

## Supporting information

- https://github.com/openedx/openedx-platform/issues/38450
- [Failing CI log](https://github.com/openedx/openedx-platform/actions/runs/24842511180/job/72720258185)

## Testing instructions

1. Run the test file:
   ```
   pytest openedx/core/lib/tests/test_jwt.py --ds=lms.envs.test --no-migrations -x -v
   ```
2. All 10 tests should pass.

## Deadline

None

## Other information

- No dependencies on other changes.
- `freezegun` is already in test requirements (`requirements/edx/testing.in`).
- Used Kiro (AI assistant) to help develop this change. Kiro wrote the base implementation, ran tests/linting. I reviewed the approach, made some edits (comments, naming), directed the assertion style conversion to pytest, chose the decorator ordering, and verified the fix didn't drop any meaningful test coverage.
