### PR TITLE
fix: properly update studio search index when tags are deleted

### DIFF
--- a/openedx/core/djangoapps/content/search/documents.py
+++ b/openedx/core/djangoapps/content/search/documents.py
@@ -380,15 +380,23 @@ def searchable_doc_tags(object_id: OpaqueKey) -> dict:
     # if we used get_all_object_tags() to load all the tags for the library in a single query rather than loading the
     # tags for each component separately.
     all_tags = tagging_api.get_object_tags(str(object_id)).all()
-    if not all_tags:
-        # Clear out tags in the index when unselecting all tags for the block, otherwise
-        # it would remain the last value if a cleared Fields.tags field is not included
-        return {Fields.tags: {}}
     result = {
         Fields.tags_taxonomy: [],
         Fields.tags_level0: [],
-        # ... other levels added as needed
+        Fields.tags_level1: [],
+        Fields.tags_level2: [],
+        Fields.tags_level3: [],
     }
+    if not all_tags:
+        # Clear out tags in the index when the block has no tags (anymore)
+        # Note: due to a bug in Meilisearch, just setting `{Fields.tags: {}}`
+        # does not properly clear previously-set values within the tags field,
+        # like tags.level0, so we explicitly set `{Field.tags: { level0: [], ... }}`
+        # etc. to work around that and ensure tags are removed properly.
+        # In the future, if Meili's bug is fixed, we can perhaps simplify this
+        # and go back to just setting {Fields.tags: {}}` when there are no tags.
+        return {Fields.tags: result}
+
     for obj_tag in all_tags:
         # Add the taxonomy name:
         if obj_tag.taxonomy.name not in result[Fields.tags_taxonomy]:
@@ -594,8 +602,8 @@ def searchable_doc_for_container(
     found using faceted search.
 
     If no container is found for the given container key, the returned document
-    will contain only basic information derived from the container key, and no
-    Fields.type value will be included in the returned dict.
+    will contain only basic information derived from the container key, and some
+    fields like Fields.display_name will be missing from the returned dict.
     """
     doc = {
         Fields.id: meili_id_from_opaque_key(container_key),

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -33,6 +33,13 @@ except RuntimeError:
     SearchAccess = {}
 
 STUDIO_SEARCH_ENDPOINT_URL = "/api/content_search/v2/studio/"
+EMPTY_TAGS = {
+    "taxonomy": [],
+    "level0": [],
+    "level1": [],
+    "level2": [],
+    "level3": [],
+}
 
 
 @ddt.ddt
@@ -342,29 +349,29 @@ class TestSearchApi(ModuleStoreTestCase):
 
         # Add tags field to doc, since reindex calls includes tags
         doc_sequential = copy.deepcopy(self.doc_sequential)
-        doc_sequential["tags"] = {}
+        doc_sequential["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_vertical = copy.deepcopy(self.doc_vertical)
-        doc_vertical["tags"] = {}
+        doc_vertical["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_problem1 = copy.deepcopy(self.doc_problem1)
-        doc_problem1["tags"] = {}
+        doc_problem1["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_problem1["collections"] = {'display_name': [], 'key': []}
         doc_problem1["units"] = {'display_name': [], 'key': []}
         doc_problem2 = copy.deepcopy(self.doc_problem2)
-        doc_problem2["tags"] = {}
+        doc_problem2["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_problem2["collections"] = {'display_name': [], 'key': []}
         doc_problem2["units"] = {'display_name': [], 'key': []}
         doc_collection = copy.deepcopy(self.collection_dict)
-        doc_collection["tags"] = {}
+        doc_collection["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_unit = copy.deepcopy(self.unit_dict)
-        doc_unit["tags"] = {}
+        doc_unit["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_unit["collections"] = {'display_name': [], 'key': []}
         doc_unit["subsections"] = {'display_name': ['Subsection 1'], 'key': ['lct:org1:lib:subsection:subsection-1']}
         doc_subsection = copy.deepcopy(self.subsection_dict)
-        doc_subsection["tags"] = {}
+        doc_subsection["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_subsection["collections"] = {'display_name': [], 'key': []}
         doc_subsection["sections"] = {'display_name': ['Section 1'], 'key': ['lct:org1:lib:section:section-1']}
         doc_section = copy.deepcopy(self.section_dict)
-        doc_section["tags"] = {}
+        doc_section["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_section["collections"] = {'display_name': [], 'key': []}
 
         api.rebuild_index()
@@ -384,29 +391,29 @@ class TestSearchApi(ModuleStoreTestCase):
 
         # Add tags field to doc, since reindex calls includes tags
         doc_sequential = copy.deepcopy(self.doc_sequential)
-        doc_sequential["tags"] = {}
+        doc_sequential["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_vertical = copy.deepcopy(self.doc_vertical)
-        doc_vertical["tags"] = {}
+        doc_vertical["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_problem1 = copy.deepcopy(self.doc_problem1)
-        doc_problem1["tags"] = {}
+        doc_problem1["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_problem1["collections"] = {"display_name": [], "key": []}
         doc_problem1["units"] = {'display_name': [], 'key': []}
         doc_problem2 = copy.deepcopy(self.doc_problem2)
-        doc_problem2["tags"] = {}
+        doc_problem2["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_problem2["collections"] = {"display_name": [], "key": []}
         doc_problem2["units"] = {'display_name': [], 'key': []}
         doc_collection = copy.deepcopy(self.collection_dict)
-        doc_collection["tags"] = {}
+        doc_collection["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_unit = copy.deepcopy(self.unit_dict)
-        doc_unit["tags"] = {}
+        doc_unit["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_unit["collections"] = {"display_name": [], "key": []}
         doc_unit["subsections"] = {'display_name': ['Subsection 1'], 'key': ['lct:org1:lib:subsection:subsection-1']}
         doc_subsection = copy.deepcopy(self.subsection_dict)
-        doc_subsection["tags"] = {}
+        doc_subsection["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_subsection["collections"] = {'display_name': [], 'key': []}
         doc_subsection["sections"] = {'display_name': ['Section 1'], 'key': ['lct:org1:lib:section:section-1']}
         doc_section = copy.deepcopy(self.section_dict)
-        doc_section["tags"] = {}
+        doc_section["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_section["collections"] = {'display_name': [], 'key': []}
 
         api.rebuild_index(incremental=True)
@@ -524,11 +531,11 @@ class TestSearchApi(ModuleStoreTestCase):
 
         # Add tags field to doc, since reindex calls includes tags
         doc_sequential = copy.deepcopy(self.doc_sequential)
-        doc_sequential["tags"] = {}
+        doc_sequential["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_vertical = copy.deepcopy(self.doc_vertical)
-        doc_vertical["tags"] = {}
+        doc_vertical["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_problem2 = copy.deepcopy(self.doc_problem2)
-        doc_problem2["tags"] = {}
+        doc_problem2["tags"] = copy.deepcopy(EMPTY_TAGS)
         doc_problem2["collections"] = {'display_name': [], 'key': []}
         doc_problem2["units"] = {'display_name': [], 'key': []}
 
@@ -611,14 +618,20 @@ class TestSearchApi(ModuleStoreTestCase):
             "id": self.doc_sequential["id"],
             "tags": {
                 'taxonomy': ['A'],
-                'level0': ['A > one', 'A > two']
+                'level0': ['A > one', 'A > two'],
+                'level1': [],
+                'level2': [],
+                'level3': [],
             }
         }
         doc_sequential_with_tags2 = {
             "id": self.doc_sequential["id"],
             "tags": {
                 'taxonomy': ['A', 'B'],
-                'level0': ['A > one', 'A > two', 'B > four', 'B > three']
+                'level0': ['A > one', 'A > two', 'B > four', 'B > three'],
+                'level1': [],
+                'level2': [],
+                'level3': [],
             }
         }
 
@@ -627,6 +640,41 @@ class TestSearchApi(ModuleStoreTestCase):
             [
                 call([doc_sequential_with_tags1]),
                 call([doc_sequential_with_tags2]),
+            ],
+            any_order=True,
+        )
+
+    @override_settings(MEILISEARCH_ENABLED=True)
+    def test_remove_xblock_tag_clears_index_tags(self, mock_meilisearch) -> None:
+        """
+        Test that removing tags from an XBlock clears tag facets in the index.
+        """
+        # Add a tag first so we can verify it is later cleared.
+        tagging_api.tag_object(str(self.sequential.usage_key), self.taxonomyA, ["one"])
+
+        # Remove all tags for taxonomyA from this object.
+        tagging_api.tag_object(str(self.sequential.usage_key), self.taxonomyA, [])
+
+        doc_with_tag = {
+            "id": self.doc_sequential["id"],
+            "tags": {
+                "taxonomy": ["A"],
+                "level0": ["A > one"],
+                "level1": [],
+                "level2": [],
+                "level3": [],
+            },
+        }
+        doc_without_tags = {
+            "id": self.doc_sequential["id"],
+            "tags": copy.deepcopy(EMPTY_TAGS),
+        }
+
+        assert mock_meilisearch.return_value.index.return_value.update_documents.call_count == 2
+        mock_meilisearch.return_value.index.return_value.update_documents.assert_has_calls(
+            [
+                call([doc_with_tag]),
+                call([doc_without_tags]),
             ],
             any_order=True,
         )
@@ -670,14 +718,20 @@ class TestSearchApi(ModuleStoreTestCase):
             "id": self.doc_problem1["id"],
             "tags": {
                 'taxonomy': ['A'],
-                'level0': ['A > one', 'A > two']
+                'level0': ['A > one', 'A > two'],
+                'level1': [],
+                'level2': [],
+                'level3': [],
             }
         }
         doc_problem_with_tags2 = {
             "id": self.doc_problem1["id"],
             "tags": {
                 'taxonomy': ['A', 'B'],
-                'level0': ['A > one', 'A > two', 'B > four', 'B > three']
+                'level0': ['A > one', 'A > two', 'B > four', 'B > three'],
+                'level1': [],
+                'level2': [],
+                'level3': [],
             }
         }
 
@@ -876,14 +930,20 @@ class TestSearchApi(ModuleStoreTestCase):
             "id": "lib-collectionorg1libmycol-5b647617",
             "tags": {
                 'taxonomy': ['A'],
-                'level0': ['A > one', 'A > two']
+                'level0': ['A > one', 'A > two'],
+                'level1': [],
+                'level2': [],
+                'level3': [],
             }
         }
         doc_collection_with_tags2 = {
             "id": "lib-collectionorg1libmycol-5b647617",
             "tags": {
                 'taxonomy': ['A', 'B'],
-                'level0': ['A > one', 'A > two', 'B > four', 'B > three']
+                'level0': ['A > one', 'A > two', 'B > four', 'B > three'],
+                'level1': [],
+                'level2': [],
+                'level3': [],
             }
         }
 
@@ -1148,14 +1208,20 @@ class TestSearchApi(ModuleStoreTestCase):
             "id": container_id,
             "tags": {
                 'taxonomy': ['A'],
-                'level0': ['A > one', 'A > two']
+                'level0': ['A > one', 'A > two'],
+                'level1': [],
+                'level2': [],
+                'level3': [],
             }
         }
         doc_unit_with_tags2 = {
             "id": container_id,
             "tags": {
                 'taxonomy': ['A', 'B'],
-                'level0': ['A > one', 'A > two', 'B > four', 'B > three']
+                'level0': ['A > one', 'A > two', 'B > four', 'B > three'],
+                'level1': [],
+                'level2': [],
+                'level3': [],
             }
         }
 

--- a/openedx/core/djangoapps/content/search/tests/test_documents.py
+++ b/openedx/core/djangoapps/content/search/tests/test_documents.py
@@ -229,6 +229,9 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "tags": {
                 "taxonomy": ["Difficulty"],
                 "level0": ["Difficulty > Easy"],
+                "level1": [],
+                "level2": [],
+                "level3": [],
             },
         }
 
@@ -276,6 +279,7 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
                 "level0": ["Difficulty > Normal", "Subject > Hypertext", "Subject > Linguistics"],
                 "level1": ["Subject > Hypertext > Jump Links", "Subject > Linguistics > Asian Languages"],
                 "level2": ["Subject > Linguistics > Asian Languages > Chinese"],
+                "level3": [],
             },
         }
 
@@ -285,7 +289,9 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
         """
         block_usage_key = self.toy_course_key.make_usage_key("video", "Welcome")
         block = self.store.get_item(block_usage_key)
-        doc = searchable_doc_for_course_block(block)
+        doc = {}
+        doc.update(searchable_doc_for_course_block(block))
+        doc.update(searchable_doc_tags(block.usage_key))
         assert doc == {
             "id": "block-v1edxtoy2012_falltypevideoblockwelcome-0c9fd626",
             "type": "course_block",
@@ -307,7 +313,13 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             ],
             "content": {},
             "modified": self.created_date.timestamp(),
-            # This video has no tags.
+            "tags": {
+                "taxonomy": [],
+                "level0": [],
+                "level1": [],
+                "level2": [],
+                "level3": [],
+            },
         }
 
     def test_html_library_block(self):
@@ -346,6 +358,9 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "tags": {
                 "taxonomy": ["Difficulty"],
                 "level0": ["Difficulty > Normal"],
+                "level1": [],
+                "level2": [],
+                "level3": [],
             },
             "publish_status": "never",
         }
@@ -385,6 +400,9 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "tags": {
                 "taxonomy": ["Difficulty"],
                 "level0": ["Difficulty > Normal"],
+                "level1": [],
+                "level2": [],
+                "level3": [],
             },
             'published': {'display_name': 'Text'},
             "publish_status": "published",
@@ -427,6 +445,9 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "tags": {
                 "taxonomy": ["Difficulty"],
                 "level0": ["Difficulty > Normal"],
+                "level1": [],
+                "level2": [],
+                "level3": [],
             },
             "published": {"display_name": "Text"},
             "publish_status": "published",
@@ -467,6 +488,9 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "tags": {
                 "taxonomy": ["Difficulty"],
                 "level0": ["Difficulty > Normal"],
+                "level1": [],
+                "level2": [],
+                "level3": [],
             },
             "published": {
                 "display_name": "Text 2",
@@ -506,7 +530,10 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "modified": 1680674828.0,
             'tags': {
                 'taxonomy': ['Difficulty'],
-                'level0': ['Difficulty > Normal']
+                'level0': ['Difficulty > Normal'],
+                'level1': [],
+                'level2': [],
+                'level3': [],
             },
             "published": {
                 "num_children": 0
@@ -535,7 +562,10 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "modified": 1680674828.0,
             'tags': {
                 'taxonomy': ['Difficulty'],
-                'level0': ['Difficulty > Normal']
+                'level0': ['Difficulty > Normal'],
+                'level1': [],
+                'level2': [],
+                'level3': [],
             },
             "published": {
                 "num_children": 1
@@ -579,7 +609,10 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "last_published": None,
             "tags": {
                 "taxonomy": ["Difficulty"],
-                "level0": ["Difficulty > Normal"]
+                "level0": ["Difficulty > Normal"],
+                "level1": [],
+                "level2": [],
+                "level3": [],
             },
             # "published" is not set since we haven't published it yet
         }
@@ -627,7 +660,10 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "last_published": 1680674828.0,
             "tags": {
                 "taxonomy": ["Difficulty"],
-                "level0": ["Difficulty > Normal"]
+                "level0": ["Difficulty > Normal"],
+                "level1": [],
+                "level2": [],
+                "level3": [],
             },
             "published": {
                 "num_children": 1,
@@ -701,7 +737,10 @@ class StudioDocumentsTest(SharedModuleStoreTestCase):
             "last_published": 1680674828.0,
             "tags": {
                 "taxonomy": ["Difficulty"],
-                "level0": ["Difficulty > Normal"]
+                "level0": ["Difficulty > Normal"],
+                "level1": [],
+                "level2": [],
+                "level3": [],
             },
             "published": {
                 "num_children": 1,


### PR DESCRIPTION
\[ Backport of https://github.com/openedx/openedx-platform/pull/38477 to Verawood]

(cherry picked from commit 8bcdd46e187f6bbef4c585cb6fc9efb9eed9bc3c)

## Description
This PR in conjunction with the openedx-core PR (https://github.com/openedx/openedx-core/pull/571) is the backend component for https://github.com/openedx/modular-learning/issues/260. The openedx-core PR (https://github.com/openedx/openedx-core/pull/571) ensures that when a tag and its descendants are deleted that CONTENT_OBJECT_ASSOCIATIONS_CHANGED events take place. This PR ensures that once those events happen, the Meilisearch index is properly updated to remove the deleted tags. Without this PR, those events were only leading to a partial update of the document, which was sufficient to update renamed tags but not sufficient to remove deleted tags from the search index.

*Goal*:
When a Course Author deletes a tag that is associated to Library content, they should be able to return to the Library page and not see those tags in the tag search filter.

## Supporting information
Github Issue: https://github.com/openedx/modular-learning/issues/260

## Testing instructions
1. Go to Taxonomies and select a taxonomy
2. Add new tags to this taxonomy that you plan to delete. (I have been adding a subtag (e.g. Wind1) with 2 sibbling children (W1.1 and W1.2) for my testing.)
3. Go to a Library and create 2 new pieces of content.
4. For one piece of content, associate the parent subtag (e.g. Wind1) and click Save.
5. For the other piece of content, associate a child (e.g. W1.2) and click Save.
6. Click on the tag search filter button and note that Wind1 and W1.2 appear in the tag search filter.
7. Return to the taxonomy and delete the subtag Wind1.
8. It should disappear from the taxonomy and a toast should display indicating what was deleted.
9. Go back to the Library and refresh the page in the browser.
10. The pieces of content you previously associated those tags to should now display that 0 tags are associated to them.
11. Click on the tag search filter button and note that Wind1 and W1.2 no longer appear in the tag search filter.

## Deadline

This PR missed the Verawood code cut, and without it, there is a bug in the delete tags functionality.