### PR TITLE
fix: Fix unit tests failing with release branch env variable

### DIFF
--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -9,11 +9,11 @@ from django.conf import settings
 from django.core.cache import cache
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
-from openedx.core.release import doc_version
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from lms.djangoapps.mfe_config_api.views import mfe_name_to_app_id
+from openedx.core.release import doc_version
 
 # Default legacy configuration values, used in tests to build a correct expected response
 default_legacy_config = {

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
+from openedx.core.release import doc_version
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -24,7 +25,7 @@ default_legacy_config = {
     "ENABLE_COURSE_DISCOVERY": False,
 }
 
-INSTRUCTOR_SUPPORT_URL_PATTERN = r"^https://docs\.openedx\.org/en/[^/]+/educators/index\.html$"
+INSTRUCTOR_SUPPORT_URL = f"https://docs.openedx.org/en/{doc_version()}/educators/index.html"
 
 
 @ddt.ddt
@@ -313,9 +314,9 @@ class MFEConfigTestCase(APITestCase):
         response = self.client.get(f"{self.mfe_config_api_url}?mfe=instructor-dashboard")
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
         data = response.json()
-        self.assertRegex(  # noqa: PT009
+        self.assertEqual(  # noqa: PT009
             data["SUPPORT_URL"],
-            INSTRUCTOR_SUPPORT_URL_PATTERN,
+            INSTRUCTOR_SUPPORT_URL,
         )
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
@@ -787,9 +788,9 @@ class FrontendSiteConfigTestCase(APITestCase):
 
         apps_by_id = {app["appId"]: app for app in data["apps"]}
         instructor = apps_by_id["org.openedx.frontend.app.instructorDashboard"]
-        self.assertRegex(  # noqa: PT009
+        self.assertEqual(  # noqa: PT009
             instructor["config"]["SUPPORT_URL"],
-            INSTRUCTOR_SUPPORT_URL_PATTERN,
+            INSTRUCTOR_SUPPORT_URL,
         )
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -24,6 +24,8 @@ default_legacy_config = {
     "ENABLE_COURSE_DISCOVERY": False,
 }
 
+INSTRUCTOR_SUPPORT_URL_PATTERN = r"^https://docs\.openedx\.org/en/[^/]+/educators/index\.html$"
+
 
 @ddt.ddt
 class MFEConfigTestCase(APITestCase):
@@ -311,9 +313,9 @@ class MFEConfigTestCase(APITestCase):
         response = self.client.get(f"{self.mfe_config_api_url}?mfe=instructor-dashboard")
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
         data = response.json()
-        self.assertEqual(  # noqa: PT009
+        self.assertRegex(  # noqa: PT009
             data["SUPPORT_URL"],
-            "https://docs.openedx.org/en/latest/educators/index.html",
+            INSTRUCTOR_SUPPORT_URL_PATTERN,
         )
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
@@ -785,9 +787,9 @@ class FrontendSiteConfigTestCase(APITestCase):
 
         apps_by_id = {app["appId"]: app for app in data["apps"]}
         instructor = apps_by_id["org.openedx.frontend.app.instructorDashboard"]
-        self.assertEqual(  # noqa: PT009
+        self.assertRegex(  # noqa: PT009
             instructor["config"]["SUPPORT_URL"],
-            "https://docs.openedx.org/en/latest/educators/index.html",
+            INSTRUCTOR_SUPPORT_URL_PATTERN,
         )
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")


### PR DESCRIPTION
## Description

My [Verawood PR](https://github.com/openedx/openedx-platform/pull/38495) has unit tests failing on what appears to be an unrelated environment variable issue:
```
FAILED lms/djangoapps/mfe_config_api/tests/test_views.py::MFEConfigTestCase::test_legacy_overrides_instructor_dashboard - AssertionError: 'https://docs.openedx.org/en/open-release-verawood.master/educators/index.html' != 'https://docs.openedx.org/en/latest/educators/index.html'
- https://docs.openedx.org/en/open-release-verawood.master/educators/index.html
?                             ^^ ---------------------  --
+ https://docs.openedx.org/en/latest/educators/index.html
?                             ^^^
FAILED lms/djangoapps/mfe_config_api/tests/test_views.py::FrontendSiteConfigTestCase::test_legacy_overrides_instructor_dashboard_support_url - AssertionError: 'https://docs.openedx.org/en/open-release-verawood.master/educators/index.html' != 'https://docs.openedx.org/en/latest/educators/index.html'
- https://docs.openedx.org/en/open-release-verawood.master/educators/index.html
?                             ^^ ---------------------  --
+ https://docs.openedx.org/en/latest/educators/index.html
?                             ^^^
```

## Supporting information
This is blocking getting https://github.com/openedx/openedx-platform/pull/38495 into the Verawood release.

## Testing instructions
```
python -m pytest lms/djangoapps/mfe_config_api/tests/test_views.py
```

## Deadline

This is blocking getting https://github.com/openedx/openedx-platform/pull/38495 into the Verawood release.