### PR TITLE
fix: make studio reindex more robust, provide better logging (backport of #38498)

### DIFF
--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -541,7 +541,11 @@ def init_index(status_cb: Callable[[str], None] | None = None, warn_cb: Callable
     reconcile_index(status_cb=status_cb, warn_cb=warn_cb)
 
 
-def index_course(course_key: CourseKey, index_name: str | None = None) -> list:
+def index_course(
+    course_key: CourseKey,
+    index_name: str | None = None,
+    status_cb: Callable[[str], None] | None = None,
+) -> list[dict]:
     """
     Rebuilds the index for a given course.
     """
@@ -550,8 +554,15 @@ def index_course(course_key: CourseKey, index_name: str | None = None) -> list:
     docs = []
     if index_name is None:
         index_name = STUDIO_INDEX_NAME
+    if status_cb is None:
+        status_cb = log.info
+
     # Pre-fetch the course with all of its children:
     course = store.get_course(course_key, depth=None)
+
+    if course is None:
+        status_cb(f"Error: course {course_key} does not seem to exist! It may have been incompletely deleted.")
+        return []
 
     def add_with_children(block):
         """Recursively index the given XBlock/component"""
@@ -585,6 +596,8 @@ def rebuild_index(  # pylint: disable=too-many-statements
     keys_indexed = []
     if incremental:
         keys_indexed = list(IncrementalIndexCompleted.objects.values_list("context_key", flat=True))
+        if keys_indexed:
+            status_cb(f"Resuming incremental index - {len(keys_indexed)} courses/libraries already indexed.")
     lib_keys = [
         lib.library_key
         for lib in lib_api.ContentLibrary.objects.select_related("org").only("org", "slug").order_by("-id")
@@ -698,7 +711,8 @@ def rebuild_index(  # pylint: disable=too-many-statements
             collections = content_api.get_collections(library.learning_package_id, enabled=True)
             num_collections = collections.count()
             num_collections_done = 0
-            status_cb(f"{num_collections_done}/{num_collections}. Now indexing collections in library {lib_key}")
+            if num_collections:
+                status_cb(f"Now indexing {num_collections} collections in library {lib_key}")
             paginator = Paginator(collections, 100)
             for p in paginator.page_range:
                 num_collections_done = index_collection_batch(
@@ -706,15 +720,14 @@ def rebuild_index(  # pylint: disable=too-many-statements
                     num_collections_done,
                     lib_key,
                 )
-            if incremental:
-                IncrementalIndexCompleted.objects.get_or_create(context_key=lib_key)
-            status_cb(f"{num_collections_done}/{num_collections} collections indexed for library {lib_key}")
+            status_cb(f"Indexed {num_collections_done}/{num_collections} collections in library {lib_key}")
 
             # Similarly, batch process Containers (units, sections, etc) in pages of 100
             containers = content_api.get_containers(library.learning_package_id)
             num_containers = containers.count()
             num_containers_done = 0
-            status_cb(f"{num_containers_done}/{num_containers}. Now indexing containers in library {lib_key}")
+            if num_containers:
+                status_cb(f"Now indexing {num_containers} containers in library {lib_key}")
             paginator = Paginator(containers, 100)
             for p in paginator.page_range:
                 num_containers_done = index_container_batch(
@@ -722,7 +735,9 @@ def rebuild_index(  # pylint: disable=too-many-statements
                     num_containers_done,
                     lib_key,
                 )
-                status_cb(f"{num_containers_done}/{num_containers} containers indexed for library {lib_key}")
+                status_cb(f"Indexed {num_containers_done}/{num_containers} containers in library {lib_key}")
+
+            # Mark this library as indexed:
             if incremental:
                 IncrementalIndexCompleted.objects.get_or_create(context_key=lib_key)
 
@@ -732,7 +747,7 @@ def rebuild_index(  # pylint: disable=too-many-statements
         status_cb("Indexing courses...")
         # To reduce memory usage on large instances, split up the CourseOverviews into pages of 1,000 courses:
 
-        paginator = Paginator(CourseOverview.objects.only("id", "display_name"), 1000)
+        paginator = Paginator(CourseOverview.objects.only("id", "display_name").order_by("-created", "id"), 1000)
         for p in paginator.page_range:
             for course in paginator.page(p).object_list:
                 status_cb(
@@ -741,7 +756,7 @@ def rebuild_index(  # pylint: disable=too-many-statements
                 if course.id in keys_indexed:
                     num_contexts_done += 1
                     continue
-                course_docs = index_course(course.id, index_name)
+                course_docs = index_course(course.id, index_name, status_cb)
                 if incremental:
                     IncrementalIndexCompleted.objects.get_or_create(context_key=course.id)
                 num_contexts_done += 1


### PR DESCRIPTION
This backports https://github.com/openedx/openedx-platform/pull/38498 to Verawood:


> 1. Improves the `reindex_studio` management command so that it will gracefully log and continue when it tries to index a deleted course, rather than crashing.
>    
>    * The list of course IDs is retrieved from `CourseOverview`, but if there is a `CourseOverview` entry that no longer exists in modulestore, the whole reindex process would crash.
> 2. Addresses a warning seen when running `reindex_studio`:
>    ```
>    UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list:
>    <class 'openedx.core.djangoapps.content.course_overviews.models.CourseOverview'> QuerySet.
>    ```
> 3. Improves the logging when resuming an interrupted reindex. In such cases, it would say something like "Found 28 courses, 0 libraries." even when you have more courses or libraries than that, which was confusing. It now explicitly says "Resuming incremental index - NNN courses/libraries already indexed."
> 4. Fixes a bug where a library could be marked as indexed before its containers were fully indexed.
> 5. Improves formatting and verbosity of the logging.

