### PR TITLE
chore: tighten renovate config and add comments

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,45 +1,50 @@
 {
   extends: [
-    'config:recommended',
-    'schedule:weekly',
-    ':automergeLinters',
-    ':automergeMinor',
-    ':automergeTesters',
-    ':enableVulnerabilityAlerts',
-    ':semanticCommits',
-    ':updateNotScheduled',
+    'config:recommended',  // Renovate base defaults: dependency dashboard, monorepo grouping, sane PR limits
+    'schedule:weekly',     // Only open new PRs once a week
+    ':automergeLinters',   // Automerge linter updates (eslint, prettier, etc.)
+    ':automergeTesters',   // Automerge test runner updates (jest, mocha, etc.)
+    ':enableVulnerabilityAlerts',  // Open security PRs immediately, ignoring the weekly schedule
+    ':semanticCommits',    // Use conventional commit format (fix(deps):, chore(deps):)
+    ':updateNotScheduled', // Allow vulnerability fixes to bypass the weekly schedule
   ],
+
+  // Never auto-rebase PRs; let humans decide when to rebase
+  rebaseWhen: 'never',
+
+  // Wait 3 days after a release before opening a PR, giving time for early bugs and
+  // potentially malicious releases (e.g. supply chain attacks) to be detected
+  minimumReleaseAge: '3 days',
+
+  // Only manage npm dependencies
+  enabledManagers: [
+    'npm',
+  ],
+
+  // Only create PRs during Eastern time (aligns with the weekly schedule)
+  timezone: 'America/New_York',
+
+  // Cap the number of open Renovate PRs at any one time
+  prConcurrentLimit: 3,
+
+  // Packages with known breaking changes or no active maintainer
+  ignoreDeps: [
+    'karma-spec-reporter',
+  ],
+
   packageRules: [
     {
-      matchDepTypes: [
-        'devDependencies',
-      ],
-      matchUpdateTypes: [
-        'lockFileMaintenance',
-        'minor',
-        'patch',
-        'pin',
-      ],
-      automerge: true,
-    },
-    {
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-      ],
-      automerge: true,
+      // Automerge minor and patch updates for @edx and @openedx scoped packages;
+      // these are maintained by the same org so breakage is caught upstream
       matchPackageNames: [
         '/@edx/',
         '/@openedx/',
       ],
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
+      automerge: true,
     },
-  ],
-  ignoreDeps: [
-    'karma-spec-reporter',
-  ],
-  timezone: 'America/New_York',
-  prConcurrentLimit: 3,
-  enabledManagers: [
-    'npm',
   ],
 }


### PR DESCRIPTION
## Motivation

Renovate was generating a lot of PR churn — constantly rebasing open PRs and automerging 3rd party dependency updates without review. This created two problems:

1. **Noise:** PRs for major/breaking upgrades were being repeatedly rebased, cluttering the commit history and notification feeds with updates that weren't actionable.
2. **Security:** Automatically merging 3rd party packages without a waiting period is a supply chain risk — it leaves no window for malicious releases or early critical bugs to be detected and reported before they land in our codebase.

## Changes

- **`rebaseWhen: 'never'`** — stops Renovate from auto-rebasing PRs; humans decide when to rebase
- **`minimumReleaseAge: '3 days'`** — adds a buffer between a package release and Renovate opening a PR, giving the community time to detect malicious or broken releases
- **Automerge restricted to `@edx`/`@openedx` scopes** — removes the broad `devDependencies` automerge rule and the `:automergeMinor` preset; 3rd party packages now require human review before merging. Linters and testers (via `:automergeLinters`/`:automergeTesters`) remain automerged as they are low-risk.
- **Inline comments** added throughout so the intent of each setting is clear to future editors