### PR TITLE
[WIP] fix: prevent XBlock container crash when JS resources are blocked by browser extensions

### DIFF
--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -191,7 +191,9 @@ function($, _, Backbone, gettext, BasePage,
                         xblockWrapper.addClass('is-selected');
                         break;
                     default:
-                        console.warn('Unhandled message type:', data.type);
+                        if (data.type) {
+                            console.warn('Unhandled message type:', data.type);
+                        }
                     }
                 });
             }

--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -58,7 +58,7 @@ function($, _, ViewUtils, BaseView, XBlock, HtmlUtils) {
                 aside;
 
             fragmentsRendered = this.renderXBlockFragment(fragment, wrapper);
-            fragmentsRendered.always(function() {
+            fragmentsRendered.done(function() {
                 xblockElement = self.$('.xblock').first();
                 try {
                     xblock = XBlock.initializeBlock(xblockElement);
@@ -180,13 +180,16 @@ function($, _, ViewUtils, BaseView, XBlock, HtmlUtils) {
             var self = this,
                 applyResource,
                 numResources,
-                deferred;
+                deferred,
+                failedJs = false;
             numResources = resources.length;
             deferred = $.Deferred();
             applyResource = function(index) {
                 var hash, resource, value, promise;
                 if (index >= numResources) {
-                    deferred.resolve();
+                    deferred.resolve({
+                        failedJs: failedJs
+                    });
                     return;
                 }
                 value = resources[index];
@@ -194,6 +197,19 @@ function($, _, ViewUtils, BaseView, XBlock, HtmlUtils) {
                 if (!window.loadedXBlockResources) {
                     window.loadedXBlockResources = [];
                 }
+                if (!window.failedXBlockResources) {
+                    window.failedXBlockResources = [];
+                }
+                // A JS resource that previously failed (e.g., blocked by an extension):
+                // mark failedJs so the specific XBlock that needs it gets skipped,
+                // but continue loading the rest of the fragment's resources so that
+                // other XBlocks in the same fragment are not affected.
+                if (_.indexOf(window.failedXBlockResources, hash) >= 0) {
+                    failedJs = true;
+                    applyResource(index + 1);
+                    return;
+                }
+
                 if (_.indexOf(window.loadedXBlockResources, hash) < 0) {
                     resource = value[1];
                     promise = self.loadResource(resource);
@@ -201,8 +217,24 @@ function($, _, ViewUtils, BaseView, XBlock, HtmlUtils) {
                     promise.done(function() {
                         applyResource(index + 1);
                     }).fail(function() {
-                        deferred.reject();
+                        console.warn(
+                            'Failed to load XBlock resource:',
+                            resource.data || resource.kind
+                        );
+
+                        if (resource.mimetype === 'application/javascript') {
+                            failedJs = true;
+
+                            // Remember this hash so subsequent fragments that reference
+                            // the same resource skip it without a network round-trip.
+                            window.failedXBlockResources.push(hash);
+                        }
+
+                        // Always continue — other resources in this fragment may belong
+                        // to unrelated XBlocks and must still be loaded.
+                        applyResource(index + 1);
                     });
+
                 } else {
                     applyResource(index + 1);
                 }
@@ -235,7 +267,20 @@ function($, _, ViewUtils, BaseView, XBlock, HtmlUtils) {
                     // xss-lint: disable=javascript-jquery-append,javascript-concat-html
                     $head.append('<script>' + data + '</script>');
                 } else if (kind === 'url') {
-                    return ViewUtils.loadJavaScript(data);
+                    // Use a raw <script> tag instead of ViewUtils.loadJavaScript because
+                    // the underlying $script (scriptjs) library invokes its callback on
+                    // both onload AND onerror, making it impossible to detect blocked
+                    // resources (e.g. from browser extensions). A raw tag fires onerror
+                    // only on genuine network failure, letting addXBlockFragmentResources
+                    // track failedJs correctly.
+                    var scriptDeferred = $.Deferred();
+                    var scriptEl = document.createElement('script');
+                    scriptEl.type = 'text/javascript';
+                    scriptEl.src = data;
+                    scriptEl.onload = function() { scriptDeferred.resolve(); };
+                    scriptEl.onerror = function() { scriptDeferred.reject(); };
+                    $head[0].appendChild(scriptEl);
+                    return scriptDeferred.promise();
                 }
             } else if (mimetype === 'text/html') {
                 if (placement === 'head') {

--- a/common/static/common/js/xblock/core.js
+++ b/common/static/common/js/xblock/core.js
@@ -61,6 +61,13 @@
             block = (function() {
                 var initFn = window[$element.data('init')];
 
+                // initFn can be undefined when its JS was blocked (e.g. by an ad-blocker).
+                // Return null so the caller can fall back gracefully instead of crashing.
+                if (!initFn) {
+                    console.warn('XBlock init function not found:', $element.data('init'));
+                    return null;
+                }
+
                 // This create a new constructor that can then apply() the block_args
                 // to the initFn.
                 function Block() {
@@ -70,6 +77,14 @@
 
                 return new Block();
             }());
+
+            if (!block) {
+                $element.trigger('xblock-initialized');
+                $element.data('initialized', true);
+                $element.addClass('xblock-initialized xblock-initialization-failed');
+                return {element: element, name: $element.data('name'), type: $element.data('block-type')};
+            }
+
             block.runtime = runtime;
         } else {
             block = {};


### PR DESCRIPTION
## Description

Fixes a resilience bug in Studio's XBlock container page where Chrome extensions (e.g. AdBlock) that block certain JS resources cause an infinite loading spinner and crash the entire container page — preventing all XBlocks in the unit from rendering, not just the one whose resource was blocked.

**Affected user role:** Course Authors using Chrome with content-blocking extensions.

**Root causes fixed:**

1. **`loadResource` used `ViewUtils.loadJavaScript` (backed by `$script`/scriptjs)**, which calls its callback on both `onload` and `onerror`. When AdBlock blocks a script, the promise always resolved — making failures invisible to the application. Fixed by replacing it with a raw `<script>` element that wires `onerror → reject` directly.

2. **`addXBlockFragmentResources` aborted on first JS failure**, skipping all subsequent resources in the list. A vertical fragment's resource list is shared across all child XBlocks. Aborting early prevented unrelated XBlocks (Problem, Video, etc.) from loading their resources, cascading the failure across the entire unit. Fixed by always continuing to the next resource regardless of failure.

3. **`constructBlock` in `core.js` crashed with `TypeError` when an XBlock's init function was undefined** (because its JS never loaded). The crash propagated to the outer `try/catch` in `handleXBlockFragment`, which called `errorCallback()` instead of `successCallback()` — leaving the container page stuck. Fixed by adding a null check that marks only the affected XBlock as `xblock-initialization-failed` and returns a stub, allowing the rest of the vertical to initialize normally.

4. **`container.js` message handler logged a spurious warning loop** for every `postMessage` event with `type: undefined` sent by browser extension proxies (e.g. Redux DevTools) via `setInterval`. Fixed by only logging for defined, unrecognized message types.

**Behavior after this fix:**

- XBlocks whose JS resources are blocked by a browser extension render their HTML and get the `xblock-initialization-failed` CSS class. Their JS is not initialized, so interactive behavior (e.g. drag and drop) is unavailable — but the block is visible and the page does not crash.
- All other XBlocks in the same unit are completely unaffected.
- A `console.warn` is emitted for each blocked resource and each skipped init function, replacing the previous silent freeze.

**Before:** Chrome + AdBlock → infinite spinner, `TypeError: Cannot read properties of undefined (reading 'prototype')`, all XBlocks in the unit broken.

**After:** Chrome + AdBlock → affected XBlock shows its default loading state, all other XBlocks render and initialize normally, no JS crash.

## Supporting information

- Originally identified and developed on the NAU fork of edX Teak (`eduNEXT/edx-platform`, branch `nau/teak.master`).
- The `$script`/scriptjs issue with `onerror` is a known limitation of that library: it does not distinguish between successful load and network/block failure.
- Firefox is unaffected by this bug due to stricter extension sandboxing.

## Testing instructions

**Prerequisites:** Chrome browser with uBlock Origin or AdBlock Plus installed and active. A Studio course unit containing a **Drag & Drop v2** XBlock alongside at least one other XBlock type (e.g. Problem/Single Select).

**Steps:**

1. Open Studio and navigate to a unit containing a Drag & Drop v2 XBlock and a Problem XBlock on the same page.
2. With AdBlock **disabled**, verify both XBlocks render and initialize correctly (baseline).
3. Enable AdBlock and reload the page.
4. **Expected (after fix):**
   - The Drag & Drop XBlock shows its default "Loading drag and drop problem." state (no crash, no infinite spinner).
   - The Problem XBlock and all other XBlocks on the page render and initialize normally.
   - The browser console shows `console.warn` messages: `Failed to load XBlock resource: .../virtual-dom-1.3.0.min.js` and `XBlock init function not found: DragAndDropBlock`.
   - No `TypeError: Cannot read properties of undefined (reading 'prototype')`.
5. **Expected (before fix):** All XBlocks show an infinite spinner or are blank, and the console shows the `TypeError` crash.

**Also verify:** With AdBlock disabled, the page behaves identically to before this change — no regression for users without content blockers.

## Deadline

None.

## Other information

- No database migrations, configuration changes, or deprecations.
- The `window.failedXBlockResources` global is introduced alongside the existing `window.loadedXBlockResources` pattern to track resource hashes that have previously failed, preventing redundant network requests for known-bad resources on subsequent XBlock renders within the same page session.
- This fix targets the legacy Studio container page (`/container/...`). The authoring MFE embeds this page in an iframe and is also covered by this fix.
