### PR TITLE
fix: don't sleep for a half second every time we update meilisearch [FC-0117]

### DIFF
--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -152,6 +152,10 @@ def _wait_for_meili_task(info: TaskInfo) -> None:
     Simple helper method to wait for a Meilisearch task to complete
     This method will block until the task is completed, so it should only be used in celery tasks
     or management commands.
+
+    ✨ Note: "Meilisearch processes tasks in the order they were added to the queue."
+       per https://www.meilisearch.com/docs/capabilities/indexing/tasks_and_batches/monitor_tasks#monitoring-task-status
+       so if you need to wait for multiple tasks, simply wait for the final (last) task.
     """
     client = _get_meilisearch_client()
     # This function almost always gets called immediately after enqueing a task, and from experiments, an initial wait
@@ -170,15 +174,6 @@ def _wait_for_meili_task(info: TaskInfo) -> None:
         except (TypeError, KeyError):
             err_reason = "Unknown error"
         raise MeilisearchError(err_reason)
-
-
-def _wait_for_meili_tasks(info_list: list[TaskInfo]) -> None:
-    """
-    Simple helper method to wait for multiple Meilisearch tasks to complete
-    """
-    while info_list:
-        info = info_list.pop()
-        _wait_for_meili_task(info)
 
 
 def _index_exists(index_name: str) -> bool:
@@ -330,13 +325,10 @@ def _update_index_docs(docs) -> None:
     client = _get_meilisearch_client()
     current_rebuild_index_name = _get_running_rebuild_index_name()
 
-    tasks = []
     if current_rebuild_index_name:
         # If there is a rebuild in progress, the document will also be added to the new index.
-        tasks.append(client.index(current_rebuild_index_name).update_documents(docs))
-    tasks.append(client.index(STUDIO_INDEX_NAME).update_documents(docs))
-
-    _wait_for_meili_tasks(tasks)
+        client.index(current_rebuild_index_name).update_documents(docs)
+    _wait_for_meili_task(client.index(STUDIO_INDEX_NAME).update_documents(docs))
 
 
 def only_if_meilisearch_enabled(f):
@@ -834,13 +826,10 @@ def _delete_documents(filter_query: str) -> None:
     client = _get_meilisearch_client()
     current_rebuild_index_name = _get_running_rebuild_index_name()
 
-    tasks = []
     if current_rebuild_index_name:
         # If there is a rebuild in progress, the document will also be removed from the new index.
-        tasks.append(client.index(current_rebuild_index_name).delete_documents(filter=filter_query))
-    tasks.append(client.index(STUDIO_INDEX_NAME).delete_documents(filter=filter_query))
-
-    _wait_for_meili_tasks(tasks)
+        client.index(current_rebuild_index_name).delete_documents(filter=filter_query)
+    _wait_for_meili_task(client.index(STUDIO_INDEX_NAME).delete_documents(filter=filter_query))
 
 
 def _delete_index_doc(doc_id) -> None:
@@ -855,14 +844,11 @@ def _delete_index_doc(doc_id) -> None:
     client = _get_meilisearch_client()
     current_rebuild_index_name = _get_running_rebuild_index_name()
 
-    tasks = []
     if current_rebuild_index_name:
         # If there is a rebuild in progress, the document will also be removed from the new index.
-        tasks.append(client.index(current_rebuild_index_name).delete_document(doc_id))
+        client.index(current_rebuild_index_name).delete_document(doc_id)
 
-    tasks.append(client.index(STUDIO_INDEX_NAME).delete_document(doc_id))
-
-    _wait_for_meili_tasks(tasks)
+    _wait_for_meili_task(client.index(STUDIO_INDEX_NAME).delete_document(doc_id))
 
 
 def upsert_library_block_index_doc(usage_key: UsageKey) -> None:

--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -154,9 +154,15 @@ def _wait_for_meili_task(info: TaskInfo) -> None:
     or management commands.
     """
     client = _get_meilisearch_client()
+    # This function almost always gets called immediately after enqueing a task, and from experiments, an initial wait
+    # of at least 15ms is warranted, as the task is almost never done in less than 10ms. We are using 20ms which seems
+    # to work well without requiring an additional wait in most cases.
+    sleep_delay = 0.020  # Initial wait is only 20ms but we will back off exponentially
+    time.sleep(sleep_delay)
     current_status = client.get_task(info.task_uid)
     while current_status.status in ("enqueued", "processing"):
-        time.sleep(0.5)
+        time.sleep(sleep_delay)
+        sleep_delay = min(sleep_delay * 1.5, 2.0)  # Increase delay up to 2s
         current_status = client.get_task(info.task_uid)
     if current_status.status != "succeeded":
         try:


### PR DESCRIPTION
## Description

Various actions in the platform like changing a course's schedule or importing a course from modulestore into a library seem much slower than they should be at the moment, due to the fact that devstack runs all tasks synchronously (not in separate celery workers) and the tasks that update Meilisearch specifically are slow.

When investigating various slowness, I discovered that every update to Meilisearch was taking ~0.5s almost exactly, and then I found the culprit:

https://github.com/openedx/openedx-platform/blob/6efb92cd61b899c4445a75c0560acff19357c7a7/openedx/core/djangoapps/content/search/api.py#L156-L159

It turns out that the Meilisearch task is never _immediately_ complete, so this always results in a wait of 500ms every time we call Meilisearch 🤦🏻‍♂️. But, Meilisearch updates are actually pretty fast and usually done in **10-20ms**, so we simply need to reduce the sleep delay and we see a huge boost in performance.

Note: it would obviously be better to use `asyncio.sleep()` here, but we aren't set up for that in openedx-platform.

## Supporting information

Found in the context of https://github.com/openedx/openedx-core/issues/584

## Testing instructions

The easiest way to test this is:

1. Go to any course's Schedule & Details page. Change the **start date** and press save. Time how long it takes.

Repeat with and without the fix.

Why this test: updating a course's start date results in **19** `XBLOCK_UPDATED` events for the meta blocks in each course: `type@course+block@course`, `type@about+block@subtitle`, `type@about+block@duration`, `type@about+block@description`, `type@about+block@short_description`,`type@about+block@overview`, `type@about+block@entrance_exam_enabled`, `type@about+block@entrance_exam_id`, `type@about+block@entrance_exam_minimum_score_pct`, `type@about+block@about_sidebar_html`. For some reason, all of these but the `course` block actually have two `XBLOCK_UPDATED` events for each block, hence the total of 19. Note: some of these shouldn't even be XBlocks, and I'm not sure why we're getting two `XBLOCK_UPDATED` events for each one, but I want to keep this PR focused on the main source of delay.

## Deadline

ASAP, need to backport this to Verawood.

## Other information

Private ref BB-10823