### PR TITLE
fix: django admin wasn't showing details of content libraries [FC-0117]

### DIFF
--- a/openedx/core/djangoapps/content_libraries/admin.py
+++ b/openedx/core/djangoapps/content_libraries/admin.py
@@ -16,9 +16,9 @@ class ContentLibraryAdmin(admin.ModelAdmin):
         "library_key",
         "org",
         "slug",
+        "learning_package",
         "allow_public_learning",
         "allow_public_read",
-        "authorized_lti_configs",
     )
     list_display = ("slug", "org",)
 
@@ -26,7 +26,7 @@ class ContentLibraryAdmin(admin.ModelAdmin):
         """
         Ensure that 'slug' and 'uuid' cannot be edited after creation.
         """
+        always_ro_fields = ["library_key", "learning_package"]
         if obj:
-            return ["library_key", "org", "slug"]
-        else:
-            return ["library_key", ]
+            return [*always_ro_fields, "org", "slug"]
+        return always_ro_fields


### PR DESCRIPTION

## Description

Accessing the django admin for content libraries is not working at the moment. This PR fixes it, and also adds in the "Learning Package ID" which is useful for debugging.

```
FieldError at /admin/content_libraries/contentlibrary/:id/change/ Unknown field(s) (authorized_lti_configs)
```


## Before

<img width="953" height="146" alt="Screenshot 2026-05-06 at 5 50 34 PM" src="https://github.com/user-attachments/assets/d63c313f-f09b-4474-b156-20136dfce710" />


## After

<img width="693" height="460" alt="Screenshot 2026-05-06 at 5 49 46 PM" src="https://github.com/user-attachments/assets/4a580c20-0f8d-411e-8ae4-e66f4fed92c6" />
