### PR TITLE
fix: ValidationError when trying to add components to a collection [FC-0117]

### DIFF
--- a/openedx/core/djangoapps/content_libraries/api/collections.py
+++ b/openedx/core/djangoapps/content_libraries/api/collections.py
@@ -125,7 +125,7 @@ def update_library_collection_items(
     assert content_library.library_key == library_key
 
     # Fetch the Component.entity_ref values for the provided UsageKeys.
-    item_refs = []
+    entity_ids: list[PublishableEntity.ID] = []
     for opaque_key in opaque_keys:
         if isinstance(opaque_key, LibraryContainerLocator):
             try:
@@ -136,7 +136,7 @@ def update_library_collection_items(
             except Collection.DoesNotExist as exc:
                 raise ContentLibraryContainerNotFound(opaque_key) from exc
 
-            item_refs.append(container.entity_ref)
+            entity_ids.append(container.id)
         elif isinstance(opaque_key, UsageKeyV2):
             # Parse the block_family from the key to use as namespace.
             block_type = BlockTypeKey.from_string(str(opaque_key))
@@ -150,14 +150,12 @@ def update_library_collection_items(
             except Component.DoesNotExist as exc:
                 raise ContentLibraryBlockNotFound(opaque_key) from exc
 
-            item_refs.append(component.entity_ref)
+            entity_ids.append(component.id)
         else:
             # This should never happen, but just in case.
             raise ValueError(f"Invalid opaque_key: {opaque_key}")
 
-    entities_qset = PublishableEntity.objects.filter(
-        entity_ref__in=item_refs,
-    )
+    entities_qset = content_api.get_publishable_entities(content_library.learning_package_id).filter(id__in=entity_ids)
 
     if remove:
         collection = content_api.remove_from_collection(


### PR DESCRIPTION
## Description

If a component exists in multiple libraries with the same component `code`, it will trigger a validation error when trying to add it to a collection. Probably the same for containers too.

Example traceback:
```
  File "/openedx/edx-platform/openedx/core/djangoapps/content_libraries/rest_api/collections.py", line 235, in update_items
    api.update_library_collection_items(
  File "/openedx/edx-platform/openedx/core/djangoapps/content_libraries/api/collections.py", line 169, in update_library_collection_items
    collection = content_api.add_to_collection(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/openedx-core/src/openedx_content/applets/collections/api.py", line 199, in add_to_collection
    raise ValidationError(
django.core.exceptions.ValidationError: ['Cannot add entity 538 in learning package 8 to collection test-collection in learning package 10.']
```

## Testing instructions

How I discovered this:

1. Migrate a course into [empty] Library 1
2. Migrate the same course into [empty] Library 2
3. In Library 2, create a new collection.
4. Add any of the components in the library to the new collection. Without this fix, you'll see a `ValidationError` in the CMS logs, and the request will fail.



Private ref: BB-10823