### PR TITLE
build: Test on the head of the release branches.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - master
+      - release/*
 
 concurrency:
   # We only need to be running tests for the latest commit on each PR


### PR DESCRIPTION
Purposefully not adding the older releases here but for any new releases
we should test on the branch once PRs are merged to make sure there are
no regressions that were missed by weird merge timing.

This is a Backport of https://github.com/openedx/openedx-platform/pull/38541
