### PR TITLE
feat: backport frontend site config translations to Verawood

### DIFF
--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from lms.djangoapps.mfe_config_api.views import mfe_name_to_app_id
+from lms.djangoapps.mfe_config_api.views import mfe_name_to_app_id, translate_paragon_theme_urls
 from openedx.core.release import doc_version
 
 # Default legacy configuration values, used in tests to build a correct expected response
@@ -373,6 +373,113 @@ class MfeNameToAppIdTests(SimpleTestCase):
         )
 
 
+class TranslateParagonThemeUrlsTests(SimpleTestCase):
+    """Tests for the translate_paragon_theme_urls helper."""
+
+    def test_brand_override_only(self):
+        """urls.brandOverride is selected and emitted as `url`; defaults pass through."""
+        legacy = {
+            "core": {
+                "urls": {
+                    "default": "https://cdn.example.com/paragon/core.css",
+                    "brandOverride": "https://cdn.example.com/brand/core.css",
+                },
+            },
+            "defaults": {"light": "light", "dark": "dark"},
+            "variants": {
+                "light": {
+                    "urls": {
+                        "default": "https://cdn.example.com/paragon/light.css",
+                        "brandOverride": "https://cdn.example.com/brand/light.css",
+                    },
+                },
+                "dark": {
+                    "urls": {
+                        "default": "https://cdn.example.com/paragon/dark.css",
+                        "brandOverride": "https://cdn.example.com/brand/dark.css",
+                    },
+                },
+            },
+        }
+        self.assertEqual(  # noqa: PT009
+            translate_paragon_theme_urls(legacy),
+            {
+                "core": {"url": "https://cdn.example.com/brand/core.css"},
+                "defaults": {"light": "light", "dark": "dark"},
+                "variants": {
+                    "light": {"url": "https://cdn.example.com/brand/light.css"},
+                    "dark": {"url": "https://cdn.example.com/brand/dark.css"},
+                },
+            },
+        )
+
+    def test_default_only_yields_no_theme(self):
+        """Input with only `urls.default` (Paragon defaults) yields no theme at all.
+
+        `defaults` is dropped too: it is meaningless without a URL to point at.
+        """
+        legacy = {
+            "core": {"urls": {"default": "https://cdn.example.com/paragon/core.css"}},
+            "defaults": {"light": "light"},
+            "variants": {
+                "light": {"urls": {"default": "https://cdn.example.com/paragon/light.css"}},
+            },
+        }
+        self.assertEqual(translate_paragon_theme_urls(legacy), {})  # noqa: PT009
+
+    def test_bare_url_ignored(self):
+        """Bare `url` (legacy Paragon-default form) is dropped."""
+        legacy = {
+            "core": {"url": "https://cdn.example.com/paragon/core.css"},
+            "variants": {
+                "light": {"url": "https://cdn.example.com/paragon/light.css"},
+                "green": {"url": "https://cdn.example.com/brand/green.css"},
+            },
+        }
+        self.assertEqual(translate_paragon_theme_urls(legacy), {})  # noqa: PT009
+
+    def test_mixed_variants(self):
+        """A variant with brandOverride is kept; siblings without it are dropped."""
+        legacy = {
+            "defaults": {"light": "light"},
+            "variants": {
+                "light": {
+                    "urls": {
+                        "default": "https://cdn.example.com/paragon/light.css",
+                        "brandOverride": "https://cdn.example.com/brand/light.css",
+                    },
+                },
+                "dark": {"urls": {"default": "https://cdn.example.com/paragon/dark.css"}},
+            },
+        }
+        self.assertEqual(  # noqa: PT009
+            translate_paragon_theme_urls(legacy),
+            {
+                "defaults": {"light": "light"},
+                "variants": {"light": {"url": "https://cdn.example.com/brand/light.css"}},
+            },
+        )
+
+    def test_non_dict_input(self):
+        """Non-dict inputs yield an empty translation."""
+        self.assertEqual(translate_paragon_theme_urls(None), {})  # noqa: PT009
+        self.assertEqual(translate_paragon_theme_urls("string"), {})  # noqa: PT009
+        self.assertEqual(translate_paragon_theme_urls([]), {})  # noqa: PT009
+
+    def test_empty_dict(self):
+        """An empty legacy theme dict yields an empty translation."""
+        self.assertEqual(translate_paragon_theme_urls({}), {})  # noqa: PT009
+
+    def test_empty_brand_override_string_skipped(self):
+        """A blank brandOverride is treated as absent."""
+        legacy = {
+            "variants": {
+                "light": {"urls": {"brandOverride": ""}},
+            },
+        }
+        self.assertEqual(translate_paragon_theme_urls(legacy), {})  # noqa: PT009
+
+
 class FrontendSiteConfigTestCase(APITestCase):
     """Tests for the FrontendSiteConfigView endpoint."""
 
@@ -668,6 +775,142 @@ class FrontendSiteConfigTestCase(APITestCase):
         for app in data["apps"]:
             self.assertNotIn("LANGUAGE_PREFERENCE_COOKIE_NAME", app["config"])  # noqa: PT009
             self.assertNotIn("LOGO_URL", app["config"])  # noqa: PT009
+
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
+    def test_paragon_theme_urls_translated_to_theme(self, configuration_helpers_mock):
+        """PARAGON_THEME_URLS is translated to a top-level `theme` site config entry."""
+        def side_effect(key, default=None):
+            if key == "MFE_CONFIG":
+                return {
+                    "PARAGON_THEME_URLS": {
+                        "core": {
+                            "urls": {
+                                "default": "https://cdn.example.com/paragon/core.css",
+                                "brandOverride": "https://cdn.example.com/brand/core.css",
+                            },
+                        },
+                        "defaults": {"light": "light"},
+                        "variants": {
+                            "light": {
+                                "urls": {
+                                    "default": "https://cdn.example.com/paragon/light.css",
+                                    "brandOverride": "https://cdn.example.com/brand/light.css",
+                                },
+                            },
+                        },
+                    },
+                }
+            if key == "MFE_CONFIG_OVERRIDES":
+                return {}
+            return default
+        configuration_helpers_mock.get_value.side_effect = side_effect
+
+        response = self.client.get(self.url)
+        data = response.json()
+
+        self.assertEqual(  # noqa: PT009
+            data["theme"],
+            {
+                "core": {"url": "https://cdn.example.com/brand/core.css"},
+                "defaults": {"light": "light"},
+                "variants": {"light": {"url": "https://cdn.example.com/brand/light.css"}},
+            },
+        )
+        # The legacy key must not leak into commonAppConfig.
+        self.assertNotIn("PARAGON_THEME_URLS", data["commonAppConfig"])  # noqa: PT009
+
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
+    def test_paragon_theme_urls_without_brand_override_omits_theme(self, configuration_helpers_mock):
+        """A PARAGON_THEME_URLS with only Paragon-default URLs produces no `theme` entry."""
+        def side_effect(key, default=None):
+            if key == "MFE_CONFIG":
+                return {
+                    "PARAGON_THEME_URLS": {
+                        "core": {"url": "https://cdn.example.com/paragon/core.css"},
+                        "defaults": {"light": "light"},
+                        "variants": {
+                            "light": {"url": "https://cdn.example.com/paragon/light.css"},
+                        },
+                    },
+                }
+            if key == "MFE_CONFIG_OVERRIDES":
+                return {}
+            return default
+        configuration_helpers_mock.get_value.side_effect = side_effect
+
+        response = self.client.get(self.url)
+        data = response.json()
+
+        self.assertNotIn("theme", data)  # noqa: PT009
+        self.assertNotIn("PARAGON_THEME_URLS", data["commonAppConfig"])  # noqa: PT009
+
+    @patch("lms.djangoapps.mfe_config_api.views.get_legacy_config_overrides", return_value={})
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
+    def test_paragon_theme_urls_stripped_from_app_overrides(
+        self, configuration_helpers_mock, _legacy_overrides_mock,  # noqa: PT019
+    ):
+        """PARAGON_THEME_URLS in MFE_CONFIG_OVERRIDES is stripped (theme is site-level only)."""
+        def side_effect(key, default=None):
+            if key == "MFE_CONFIG":
+                return {}
+            if key == "MFE_CONFIG_OVERRIDES":
+                return {
+                    "authn": {
+                        "PARAGON_THEME_URLS": {
+                            "variants": {
+                                "light": {"urls": {"brandOverride": "https://example.com/light.css"}},
+                            },
+                        },
+                        "APP_SPECIFIC_KEY": "app_value",
+                    },
+                }
+            return default
+        configuration_helpers_mock.get_value.side_effect = side_effect
+
+        response = self.client.get(self.url)
+        data = response.json()
+
+        self.assertNotIn("theme", data)  # noqa: PT009
+        app_config = data["apps"][0]["config"]
+        self.assertNotIn("PARAGON_THEME_URLS", app_config)  # noqa: PT009
+        self.assertEqual(app_config["APP_SPECIFIC_KEY"], "app_value")  # noqa: PT009
+
+    @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
+    def test_frontend_site_config_theme_overrides_legacy_theme(self, configuration_helpers_mock):
+        """FRONTEND_SITE_CONFIG.theme replaces the translated legacy theme wholesale."""
+        def side_effect(key, default=None):
+            if key == "MFE_CONFIG":
+                return {
+                    "PARAGON_THEME_URLS": {
+                        "variants": {
+                            "light": {"urls": {"brandOverride": "https://legacy.example.com/light.css"}},
+                        },
+                    },
+                }
+            if key == "MFE_CONFIG_OVERRIDES":
+                return {}
+            if key == "FRONTEND_SITE_CONFIG":
+                return {
+                    "theme": {
+                        "core": {"url": "https://new.example.com/core.css"},
+                        "defaults": {"light": "light"},
+                        "variants": {"light": {"url": "https://new.example.com/light.css"}},
+                    },
+                }
+            return default
+        configuration_helpers_mock.get_value.side_effect = side_effect
+
+        response = self.client.get(self.url)
+        data = response.json()
+
+        self.assertEqual(  # noqa: PT009
+            data["theme"],
+            {
+                "core": {"url": "https://new.example.com/core.css"},
+                "defaults": {"light": "light"},
+                "variants": {"light": {"url": "https://new.example.com/light.css"}},
+            },
+        )
 
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")
     def test_frontend_site_config_overrides_translated(self, configuration_helpers_mock):

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -457,13 +457,16 @@ class FrontendSiteConfigTestCase(APITestCase):
         response = self.client.get(self.url)
         data = response.json()
 
-        # Site-level key translated to top level
+        common = data["commonAppConfig"]
+        # Site-level keys are translated to top level
         self.assertEqual(data["lmsBaseUrl"], "https://courses.example.com")  # noqa: PT009
+        self.assertEqual(data["cmsBaseUrl"], "https://studio.example.com")  # noqa: PT009
+        # Site-level keys translated to top level don't appear in commonAppConfig
+        self.assertNotIn("LMS_BASE_URL", common)  # noqa: PT009
+        self.assertNotIn("STUDIO_BASE_URL", common)  # noqa: PT009
         # Unmapped MFE_CONFIG keys appear in commonAppConfig (not at the top level)
         self.assertNotIn("CREDENTIALS_BASE_URL", data)  # noqa: PT009
-        common = data["commonAppConfig"]
         self.assertEqual(common["CREDENTIALS_BASE_URL"], "https://credentials.example.com")  # noqa: PT009
-        self.assertEqual(common["STUDIO_BASE_URL"], "https://studio.example.com")  # noqa: PT009
         # Legacy config keys also appear in commonAppConfig
         for legacy_key in default_legacy_config:
             self.assertIn(legacy_key, common)  # noqa: PT009
@@ -609,12 +612,13 @@ class FrontendSiteConfigTestCase(APITestCase):
         response = self.client.get(self.url)
         data = response.json()
 
-        # Site-level key is promoted to the top level
+        # Site-level keys are promoted to the top level
         self.assertEqual(data["lmsBaseUrl"], "https://courses.example.com")  # noqa: PT009
+        self.assertEqual(data["cmsBaseUrl"], "https://studio.example.com")  # noqa: PT009
         # Unmapped keys are preserved in commonAppConfig
         common = data["commonAppConfig"]
         self.assertEqual(common["CREDENTIALS_BASE_URL"], "https://credentials.example.com")  # noqa: PT009
-        self.assertEqual(common["STUDIO_BASE_URL"], "https://studio.example.com")  # noqa: PT009
+        self.assertNotIn("STUDIO_BASE_URL", common)  # noqa: PT009
 
     @patch("lms.djangoapps.mfe_config_api.views.get_legacy_config_overrides", return_value={})
     @patch("lms.djangoapps.mfe_config_api.views.configuration_helpers")

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -30,6 +30,7 @@ SITE_CONFIG_TRANSLATION_MAP: dict[str, str] = {
     "LOGIN_URL": "loginUrl",
     "LOGOUT_URL": "logoutUrl",
     # OptionalSiteConfig
+    "STUDIO_BASE_URL": "cmsBaseUrl",
     "LOGO_URL": "headerLogoImageUrl",
     "ACCESS_TOKEN_COOKIE_NAME": "accessTokenCookieName",
     "LANGUAGE_PREFERENCE_COOKIE_NAME": "languagePreferenceCookieName",

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -40,6 +40,12 @@ SITE_CONFIG_TRANSLATION_MAP: dict[str, str] = {
     "SEGMENT_KEY": "segmentKey",
 }
 
+# Legacy MFE_CONFIG keys that get promoted to site-level fields in frontend-base's
+# SiteConfig and therefore must not leak into per-app config.  Includes both the
+# 1:1 renames in SITE_CONFIG_TRANSLATION_MAP and the structurally-translated
+# PARAGON_THEME_URLS (mapped to `theme`).
+LEGACY_SITE_LEVEL_KEYS: set[str] = set(SITE_CONFIG_TRANSLATION_MAP) | {"PARAGON_THEME_URLS"}
+
 
 # Translation map from known MFE names to reverse-domain appIds.
 MFE_NAME_TO_APP_ID: dict[str, str] = {
@@ -168,6 +174,58 @@ def get_mfe_config_overrides() -> dict:
     }
 
 
+def translate_paragon_theme_urls(legacy_theme) -> dict:
+    """Translate legacy PARAGON_THEME_URLS into frontend-base's `theme` site config.
+
+    frontend-base loads Paragon's base CSS via its shell stylesheet, so the runtime
+    `theme` setting is only for brand overrides.  Only `urls.brandOverride` entries
+    are kept; legacy `url` and `urls.default` values point at Paragon defaults and
+    would clobber the bundled CSS, so they are dropped.  `defaults` passes through
+    unchanged.
+
+    Non-dict inputs (e.g., misconfigured settings) yield an empty dict.
+    """
+    if not isinstance(legacy_theme, dict):
+        return {}
+
+    def _brand_override(entry) -> str | None:
+        if not isinstance(entry, dict):
+            return None
+        urls = entry.get("urls")
+        if isinstance(urls, dict):
+            override = urls.get("brandOverride")
+            if isinstance(override, str) and override:
+                return override
+        return None
+
+    theme: dict = {}
+
+    core_url = _brand_override(legacy_theme.get("core"))
+    if core_url:
+        theme["core"] = {"url": core_url}
+
+    variants = legacy_theme.get("variants")
+    if isinstance(variants, dict):
+        translated_variants = {
+            name: {"url": url}
+            for name, entry in variants.items()
+            if (url := _brand_override(entry))
+        }
+        if translated_variants:
+            theme["variants"] = translated_variants
+
+    # `defaults` alone is meaningless without at least one URL to point at,
+    # so emit nothing if no core/variants survived.
+    if not theme:
+        return {}
+
+    defaults = legacy_theme.get("defaults")
+    if isinstance(defaults, dict) and defaults:
+        theme["defaults"] = dict(defaults)
+
+    return theme
+
+
 def get_frontend_site_config() -> dict:
     """Return frontend site configuration from settings or site configuration.
 
@@ -281,6 +339,10 @@ def translate_legacy_mfe_config() -> dict:
     get_legacy_config/get_mfe_config/get_mfe_config_overrides helpers) is fully
     deprecated.
 
+    Most legacy keys are renamed via SITE_CONFIG_TRANSLATION_MAP.  PARAGON_THEME_URLS
+    is structurally translated into the new `theme` setting and intentionally narrowed
+    to brand-override URLs only (see translate_paragon_theme_urls).
+
     Returns a dict in the shape expected by frontend-base's SiteConfig.
     """
     mfe_config = get_mfe_config()
@@ -293,7 +355,11 @@ def translate_legacy_mfe_config() -> dict:
     site_config = {}
     common_app_config = get_legacy_config()
     for key, value in mfe_config.items():
-        if key in SITE_CONFIG_TRANSLATION_MAP:
+        if key == "PARAGON_THEME_URLS":
+            theme = translate_paragon_theme_urls(value)
+            if theme:
+                site_config["theme"] = theme
+        elif key in SITE_CONFIG_TRANSLATION_MAP:
             site_config[SITE_CONFIG_TRANSLATION_MAP[key]] = value
         else:
             common_app_config[key] = value
@@ -319,7 +385,7 @@ def translate_legacy_mfe_config() -> dict:
         overrides = {
             k: v
             for k, v in mfe_config_overrides[mfe_name].items()
-            if k not in SITE_CONFIG_TRANSLATION_MAP
+            if k not in LEGACY_SITE_LEVEL_KEYS
         }
         apps.append(
             {


### PR DESCRIPTION
### Description

Backports two frontend site config translation features from master to `release/verawood`.

#38577 maps the legacy `STUDIO_BASE_URL` key to the optional `cmsBaseUrl` field in `SITE_CONFIG_TRANSLATION_MAP`, matching frontend-base's `OptionalSiteConfig` interface. With this change, `FrontendSiteConfigView` surfaces the Studio base URL at the top level of the response rather than nesting it inside `commonAppConfig`.

#38610 adds a structural translator from the legacy `PARAGON_THEME_URLS` shape (frontend-platform's `env.config.jsx`) into the frontend-base `SiteConfig.theme` setting served by `FrontendSiteConfigView`. The translator narrows to `urls.brandOverride` only, since frontend-base loads Paragon's base CSS via its shell stylesheet and the runtime `theme` setting is exclusively a brand-override mechanism. `PARAGON_THEME_URLS` is also added to the set of site-level keys stripped from per-app `MFE_CONFIG_OVERRIDES`.

Both commits cherry-pick cleanly with no conflicts.

### LLM usage notice

Built with assistance from Claude.