### PR TITLE
fix: casting issues with grading policy

### DIFF
--- a/lms/djangoapps/course_home_api/progress/api.py
+++ b/lms/djangoapps/course_home_api/progress/api.py
@@ -130,10 +130,10 @@ class _AssignmentTypeGradeAggregator:
         policy_map = {}
         for policy in self.grading_policy.get('GRADER', []):
             policy_map[policy.get('type')] = {
-                'weight': policy.get('weight', 0.0),
+                'weight': float(policy.get('weight', 0.0) or 0.0),
                 'short_label': policy.get('short_label', ''),
-                'num_droppable': policy.get('drop_count', 0),
-                'num_total': policy.get('min_count', 0),
+                'num_droppable': int(policy.get('drop_count', 0) or 0),
+                'num_total': int(policy.get('min_count', 0) or 0),
             }
         return policy_map
 

--- a/lms/djangoapps/course_home_api/progress/api.py
+++ b/lms/djangoapps/course_home_api/progress/api.py
@@ -17,6 +17,34 @@ from openedx.core.lib.grade_utils import round_away_from_zero
 User = get_user_model()
 
 
+def _to_float(value, default=0.0) -> float:
+    """Parse a grading policy value as a float, returning default for any unparseable input."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _to_int(value, default=0) -> int:
+    """
+    Parse a grading policy value as an int, returning default for non-integer or unparseable input.
+
+    Accepts string representations of both integers ('2') and whole-number floats ('2.0').
+    Returns default for non-finite values (nan/inf), fractional floats ('2.9'), and
+    anything that cannot be parsed as a number.
+    """
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not parsed.is_integer():
+        return default
+    try:
+        return int(parsed)
+    except (OverflowError, ValueError):
+        return default
+
+
 @dataclass
 class _AssignmentBucket:
     """Holds scores and visibility info for one assignment type.
@@ -130,10 +158,10 @@ class _AssignmentTypeGradeAggregator:
         policy_map = {}
         for policy in self.grading_policy.get('GRADER', []):
             policy_map[policy.get('type')] = {
-                'weight': float(policy.get('weight', 0.0) or 0.0),
+                'weight': _to_float(policy.get('weight')),
                 'short_label': policy.get('short_label', ''),
-                'num_droppable': int(policy.get('drop_count', 0) or 0),
-                'num_total': int(policy.get('min_count', 0) or 0),
+                'num_droppable': _to_int(policy.get('drop_count')),
+                'num_total': _to_int(policy.get('min_count')),
             }
         return policy_map
 

--- a/lms/djangoapps/course_home_api/progress/tests/test_api.py
+++ b/lms/djangoapps/course_home_api/progress/tests/test_api.py
@@ -88,8 +88,17 @@ _AGGREGATION_SCENARIOS = [
         {'avg': 0.0, 'weighted': 0.0, 'hidden': 'all', 'final': 0.0, 'last_grade_publish_date_days': 7},
     ),
     (
-        'string_typed_policy_counts',
+        'string_int_typed_policy_counts',
         {'type': 'Homework', 'weight': '1.0', 'drop_count': '1', 'min_count': '2', 'short_label': 'HW'},
+        [
+            _make_subsection('Homework', 1, 1, ShowCorrectness.ALWAYS),
+            _make_subsection('Homework', 0, 1, ShowCorrectness.ALWAYS),
+        ],
+        {'avg': 1.0, 'weighted': 1.0, 'hidden': 'none', 'final': 1.0},
+    ),
+    (
+        'string_float_typed_policy_counts',
+        {'type': 'Homework', 'weight': '1.0', 'drop_count': '1.0', 'min_count': '2.0', 'short_label': 'HW'},
         [
             _make_subsection('Homework', 1, 1, ShowCorrectness.ALWAYS),
             _make_subsection('Homework', 0, 1, ShowCorrectness.ALWAYS),
@@ -196,7 +205,7 @@ class ProgressApiTests(TestCase):
                 assert row['average_grade'] == expected['avg']
                 assert row['weighted_grade'] == expected['weighted']
                 assert row['has_hidden_contribution'] == expected['hidden']
-                assert row['num_droppable'] == int(policy['drop_count'])
+                assert row['num_droppable'] == int(float(policy['drop_count']))
                 assert (row['last_grade_publish_date'] is not None) == (
                     'last_grade_publish_date_days' in expected
                 )

--- a/lms/djangoapps/course_home_api/progress/tests/test_api.py
+++ b/lms/djangoapps/course_home_api/progress/tests/test_api.py
@@ -87,6 +87,15 @@ _AGGREGATION_SCENARIOS = [
         ],
         {'avg': 0.0, 'weighted': 0.0, 'hidden': 'all', 'final': 0.0, 'last_grade_publish_date_days': 7},
     ),
+    (
+        'string_typed_policy_counts',
+        {'type': 'Homework', 'weight': '1.0', 'drop_count': '1', 'min_count': '2', 'short_label': 'HW'},
+        [
+            _make_subsection('Homework', 1, 1, ShowCorrectness.ALWAYS),
+            _make_subsection('Homework', 0, 1, ShowCorrectness.ALWAYS),
+        ],
+        {'avg': 1.0, 'weighted': 1.0, 'hidden': 'none', 'final': 1.0},
+    ),
 ]
 
 
@@ -187,7 +196,7 @@ class ProgressApiTests(TestCase):
                 assert row['average_grade'] == expected['avg']
                 assert row['weighted_grade'] == expected['weighted']
                 assert row['has_hidden_contribution'] == expected['hidden']
-                assert row['num_droppable'] == policy['drop_count']
+                assert row['num_droppable'] == int(policy['drop_count'])
                 assert (row['last_grade_publish_date'] is not None) == (
                     'last_grade_publish_date_days' in expected
                 )


### PR DESCRIPTION
## Description

Fixes issues where incorrectly typed grading policies caused breakages on the progress page.

## Supporting information

Some courses were running into the error below which was a result of a grading policy using strings instead of numbers for their values.

```
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/course_home_api/progress/api.py", line 56, in with_placeholders
    scores=[0] * num_total,
           ~~~~^~~~~~~~~~~
TypeError: can't multiply sequence by non-int of type 'str'
```

This fix is to correctly cast `int`s and `float`s represented as either as strings or numerics to the correct data types to fix this issue.

## Testing instructions

1. Import a course with grading policies represented with strings rather than numbers (e.g. `"num_droppable": "2.0")
2. Load the progress page, verify page returns a `500` server error.
3. Load new changes.
4. Reload progress page, verify working.
5. Unit tests also updated.

## Deadline

ASAP - actively causes breakages in some courses.