### PR TITLE
Fix Container Blocks in the New Unit Editor

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_vertical_block.py
@@ -7,6 +7,8 @@ from urllib.parse import quote
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
 from rest_framework import status
+from xblock.core import XBlock
+from xblock.utils.studio_editable import NestedXBlockSpec, StudioContainerWithNestedXBlocksMixin
 from xblock.validation import ValidationMessage
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
@@ -16,6 +18,31 @@ from xmodule.modulestore import ModuleStoreEnum  # pylint: disable=wrong-import-
 from xmodule.modulestore.django import modulestore  # pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import BlockFactory  # pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID, Group, UserPartition
+
+
+class TestNestedContainerBlock(StudioContainerWithNestedXBlocksMixin, XBlock):
+    """
+    Test-only XBlock that simulates a third-party container (e.g. Problem Builder)
+    which restricts and annotates its allowed child types via allowed_nested_blocks.
+
+    Third-party container XBlocks often declare child types that are not part of the
+    standard course-wide component_templates (e.g. "Ranged Value Slider"). If the
+    backend simply filtered the course-wide list, those custom types would be silently
+    dropped and authors would have no way to add them in Studio. This block lets us
+    verify that the API builds component_templates from the spec instead, and correctly
+    surfaces single_instance/disabled/disabled_reason so the MFE can disable buttons
+    and show tooltips.
+    """
+    CATEGORY = 'nested-container-test'
+    STUDIO_LABEL = 'Nested Container Test'
+
+    @property
+    def allowed_nested_blocks(self):
+        return [
+            NestedXBlockSpec(None, category='html', label='HTML', single_instance=True),
+            NestedXBlockSpec(None, category='video', label='Video', disabled=True, disabled_reason='Not available'),
+        ]
+
 
 
 class BaseXBlockContainer(CourseTestCase, ContentLibrariesRestApiTest):
@@ -199,6 +226,53 @@ class ContainerHandlerViewTest(BaseXBlockContainer):
         url = self.get_reverse_url(usage_key_string)
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)  # noqa: PT009
+
+    def _all_templates(self, response):
+        """Return a flat list of all template dicts from a component_templates response."""
+        return [
+            template
+            for group in response.json().get('component_templates', [])
+            for template in group.get('templates', [])
+        ]
+
+    @XBlock.register_temp_plugin(TestNestedContainerBlock, identifier='nested-container-test')
+    def test_component_templates_for_mixin_xblock(self):
+        """
+        Test for containers implementing StudioContainerWithNestedXBlocksMixin.
+        """
+        container = self.create_block(self.vertical.location, 'nested-container-test', 'Test Container')
+        response = self.client.get(self.get_reverse_url(container.location))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
+        component_templates = response.json().get('component_templates', [])
+
+        # Each spec maps to its own top-level group.
+        group_types = {group['type'] for group in component_templates}
+        self.assertEqual(group_types, {'html', 'video'})  # noqa: PT009
+        self.assertNotIn('advanced', group_types)  # noqa: PT009
+
+        # Each group carries exactly one template whose category matches the group type.
+        all_templates = self._all_templates(response)
+        self.assertEqual({t['category'] for t in all_templates}, {'html', 'video'})  # noqa: PT009
+
+        html_template = next(t for t in all_templates if t['category'] == 'html')
+        self.assertTrue(html_template.get('single_instance'))  # noqa: PT009
+
+        video_template = next(t for t in all_templates if t['category'] == 'video')
+        self.assertTrue(video_template.get('disabled'))  # noqa: PT009
+        self.assertEqual(video_template.get('disabled_reason'), 'Not available')  # noqa: PT009
+
+    def test_component_templates_for_non_mixin_xblock(self):
+        """
+        Test for containers do not implementing StudioContainerWithNestedXBlocksMixin.
+        """
+        response = self.client.get(self.get_reverse_url(self.vertical.location))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
+        group_types = {group['type'] for group in response.json().get('component_templates', [])}
+        self.assertIn('html', group_types)  # noqa: PT009
+        self.assertIn('problem', group_types)  # noqa: PT009
+        self.assertIn('video', group_types)  # noqa: PT009
 
 
 class ContainerVerticalViewTest(BaseXBlockContainer):

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -34,6 +34,7 @@ from openedx_events.learning.signals import COURSE_NOTIFICATION_REQUESTED
 from pytz import UTC
 from rest_framework.fields import BooleanField
 from xblock.fields import Scope
+from xblock.utils.studio_editable import StudioContainerWithNestedXBlocksMixin
 
 from cms.djangoapps.contentstore.toggles import (
     enable_course_optimizer,
@@ -1934,6 +1935,47 @@ def _get_course_index_context(request, course_key, course_block):
     return course_index_context
 
 
+def _get_component_templates_for_xblock(component_templates, xblock):
+    """
+    Return the component templates to display for the given XBlock container.
+
+    If the XBlock implements ``StudioContainerWithNestedXBlocksMixin``, ``component_templates``
+    is ignored entirely and the list is built from ``get_nested_blocks_spec()`` alone.
+    This is necessary because the spec may contain custom child types (e.g. Problem Builder's
+    "Ranged Value Slider" or "Long Answer Recap") that are not part of the standard
+    course-wide ``component_templates``, so intersecting the two lists would silently drop them.
+
+    If the XBlock does not implement the mixin, ``component_templates`` is returned unchanged.
+    """
+    if not isinstance(xblock, StudioContainerWithNestedXBlocksMixin):
+        return component_templates
+
+    groups = []
+    for spec in xblock.get_nested_blocks_spec():
+        template = {
+            "display_name": spec.label,
+            "category": spec.category,
+            "boilerplate_name": spec.boilerplate,
+            "hinted": False,
+            "tab": "common",
+            "support_level": True,
+        }
+        if spec.single_instance:
+            template["single_instance"] = True
+        if spec.disabled:
+            template["disabled"] = True
+        if spec.disabled_reason:
+            template["disabled_reason"] = spec.disabled_reason
+        groups.append({
+            "type": spec.category,
+            "display_name": spec.label or spec.category,
+            "templates": [template],
+            "support_legend": {"show_legend": False},
+        })
+
+    return groups
+
+
 def get_container_handler_context(request, usage_key, course, xblock):  # pylint: disable=too-many-statements
     """
     Utils is used to get context for container xblock requests.
@@ -1955,6 +1997,9 @@ def get_container_handler_context(request, usage_key, course, xblock):  # pylint
 
     course_sequence_ids = get_sequence_usage_keys(course)
     component_templates = get_component_templates(course)
+
+    component_templates = _get_component_templates_for_xblock(component_templates, xblock)
+
     ancestor_xblocks = []
     parent = get_parent_xblock(xblock)
     action = request.GET.get('action', 'view')

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -313,9 +313,10 @@ function($, _, Backbone, gettext, BasePage,
 
         renderAddXBlockComponents: function() {
             var self = this;
-            // If the container is the Unit element(aka Vertical), then we don't render the
-            // add buttons because those should get rendered by the authoring MFE
-            if (self.options.canEdit && (!self.options.isIframeEmbed || !self.model.isVertical())) {
+            // When rendered inside the authoring MFE iframe, add buttons are always rendered
+            // natively by the MFE (for every container type, not just verticals), so the
+            // legacy add-button widgets must never be initialised here.
+            if (self.options.canEdit && !self.options.isIframeEmbed) {
                 this.$('.add-xblock-component').each(function(index, element) {
                     var component = new AddXBlockComponent({
                         el: element,


### PR DESCRIPTION
## Description

Note: The changes in this PR is generated by Claude Sonet 4.6, reviewed by Salman. Based on the implementation plan suggested on the original ticket (https://github.com/openedx/frontend-app-authoring/issues/2620)

The bug details can be found on the ticket: https://github.com/openedx/frontend-app-authoring/issues/2620

As per the [proposed implementation plan](https://github.com/openedx/frontend-app-authoring/issues/2620) 
In this PR we fixes issues caused by legacy add-component buttons being rendered for non-vertical container types inside the MFE iframe.
We introduce changes to ensure that container blocks rendered inside the MFE only expose component templates that are explicitly allowed by the container XBlock configuration.

frontend-app-authoring changes PR is available: https://github.com/openedx/frontend-app-authoring/pull/3058


## Acceptance Criteria

Using the Steps to reproduce mention [here](https://github.com/openedx/frontend-app-authoring/issues/2620) (conditional + at least one of xblock-controlled-navigation, xblock-content-restrictions, xblock-extemporaneous-grading):

- All Add New Component buttons function — no silent no-ops on Text / Library Content / Open Response / Advanced.
- Video editor closes cleanly; no "connection error" panel afterwards.
- No oversized grey iframe around Problem/Video editors.
- A container block that declares a restricted allowed_nested_blocks shows only the declared subset, with disabled / single_instance honored if surfaced.
- A container block that does not use StudioContainerWithNestedXBlocksMixin shows the full standard button set and behaves identically to a normal unit.
- No additional API round-trips on container open vs. today.

## Testing:

Sandbox for testing: https://github.com/openedx/frontend-app-authoring/pull/3058/checks?check_run_id=75731943406
