### PR TITLE
DEMO: fire REGISTRATION_DEMOGRAPHICS_CAPTURED from authn

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -26,8 +26,11 @@ from django_countries import countries
 from django_ratelimit.decorators import ratelimit
 from edx_django_utils.monitoring import set_custom_attribute
 from edx_django_utils.user import generate_password  # pylint: disable=wrong-import-order
-from openedx_events.learning.data import UserData, UserPersonalData
-from openedx_events.learning.signals import STUDENT_REGISTRATION_COMPLETED
+from openedx_events.learning.data import RegistrationDemographicsData, UserData, UserPersonalData
+from openedx_events.learning.signals import (
+    REGISTRATION_DEMOGRAPHICS_CAPTURED,
+    STUDENT_REGISTRATION_COMPLETED,
+)
 from openedx_filters.learning.filters import StudentRegistrationRequested
 from requests import HTTPError
 from rest_framework.response import Response
@@ -272,6 +275,26 @@ def create_account_with_params(request, params):  # pylint: disable=too-many-sta
             ),
             id=user.id,
             is_active=user.is_active,
+        ),
+    )
+
+    # .. event_implemented_name: REGISTRATION_DEMOGRAPHICS_CAPTURED
+    # .. event_type: org.openedx.learning.student.registration.demographics.captured.v1
+    pronouns = (params.get("pronouns") or "").strip()
+    department = (params.get("department") or "").strip()
+    REGISTRATION_DEMOGRAPHICS_CAPTURED.send_event(
+        demographics=RegistrationDemographicsData(
+            user=UserData(
+                id=user.id,
+                is_active=user.is_active,
+                pii=UserPersonalData(
+                    username=user.username,
+                    email=user.email,
+                    name=user.profile.name,
+                ),
+            ),
+            pronouns=pronouns,
+            department=department,
         ),
     )
 


### PR DESCRIPTION
### For demonstration purposes only, do not merge.

Wires the LMS registration view to emit the new
`REGISTRATION_DEMOGRAPHICS_CAPTURED` signal (see [openedx-events](https://github.com/openedx/openedx-events/pull/574)) immediately after a successful registration.

The two new fields, ``pronouns`` and ``department``, are read directly out of ``params`` (which mirrors ``request.POST``) rather than added to the ``RegistrationForm`` itself. That choice is deliberate:

* The fields are *optional everywhere*. Adding them to the Django form would require every deployment - including those not running the demographics plugin - to either special-case them or carry a forked form definition.
* ``StudentRegistrationRequested`` (an existing ``openedx-filters`` filter) already runs against the raw request data, so plugin-side validation has the same view of these fields whether or not this patch is applied.
* The frontend slot (``org.openedx.frontend.authn.register.additional_fields.v1``) submits the fields as part of the standard form POST, so no API contract changes are needed.

If neither field is present in the POST, the event still fires but with empty-string values. This keeps receivers' code paths uniform; a receiver that only cares about populated demographics can short-circuit on ``not (demographics.pronouns or demographics.department)``.

Note that the hard coding of these parameters is a known anti-pattern and is used as a discussion point in the talk.

Reference: OEX 2026 workshop "Leveraging Open edX Extension Points"
