### PR TITLE
fix(third_party_auth): don't exit early in create_or_update_bulk_saml_provider_data when one key has duplicates

### DIFF
--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -207,14 +207,14 @@ def create_or_update_bulk_saml_provider_data(entity_id, public_keys, sso_url, ex
                 obj.expires_at = expires_at
                 obj.fetched_at = fetched_at
             SAMLProviderData.objects.bulk_update(existing_data_objects, ['sso_url', 'expires_at', 'fetched_at'])
-            return True
+            new_records_created = True
         else:
             _, created = SAMLProviderData.objects.update_or_create(
                 public_key=key, entity_id=entity_id,
                 defaults={'sso_url': sso_url, 'expires_at': expires_at, 'fetched_at': fetched_at},
             )
-        if created:
-            new_records_created = True
+            if created:
+                new_records_created = True
 
     return new_records_created
 


### PR DESCRIPTION
## Bug

In `common/djangoapps/third_party_auth/utils.py`, `create_or_update_bulk_saml_provider_data` iterates over `public_keys` and, for each key, either bulk-updates duplicate `SAMLProviderData` rows or calls `update_or_create` for the single/no-row case.

The duplicate branch does:

```python
SAMLProviderData.objects.bulk_update(existing_data_objects, [...])
return True
```

`return True` exits the entire function, so any remaining keys in the same `public_keys` list are silently skipped — they're never created and never refreshed (no `fetched_at` update).

## Root cause

When `len(existing_data_objects) > 1` the loop returns instead of continuing. The condition is rare (it requires pre-existing duplicate rows), so the existing tests (`test_bulk_updates_multiple_existing`) only call the function with a single key and didn't surface the early exit.

## Fix

Replace the early `return True` with `new_records_created = True` so the loop continues processing the rest of `public_keys`, and move the `if created:` check inside the `else` branch (it was relying on `created` from the `update_or_create` path; it would NameError if reached via the duplicate path now that we no longer return).

The function still returns `True` whenever any key had a change (new record or duplicates refreshed), preserving the existing return contract used by `tasks.fetch_saml_metadata` for the `num_updated` counter.