### PR TITLE
feat: redact email PII in UnregisteredLearnerCohortAssignments before deletion

### DIFF
--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -311,3 +311,25 @@ class UnregisteredLearnerCohortAssignments(DeletableByUserValue, models.Model): 
     course_user_group = models.ForeignKey(CourseUserGroup, on_delete=models.CASCADE)  # noqa: DJ012
     email = models.CharField(blank=True, max_length=255, db_index=True)
     course_id = CourseKeyField(max_length=255)
+
+    @classmethod
+    def delete_by_user_value(cls, value, field):
+        """
+        Redacts the email field then deletes records where
+        ``field`` equals ``value``.
+
+        Returns True if deleted, False if no matching records found.
+        """
+        filter_kwargs = {field: value}
+        records_matching_user_value = cls.objects.filter(**filter_kwargs)
+
+        if not records_matching_user_value.exists():
+            return False
+
+        # Extract IDs to prevent over-affecting unrelated records
+        ids = list(records_matching_user_value.values_list('id', flat=True))
+
+        # Redact email before deletion
+        cls.objects.filter(id__in=ids).update(email='redacted@retired.invalid')
+        cls.objects.filter(id__in=ids).delete()
+        return True

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -8,9 +8,10 @@ from unittest.mock import call, patch
 import ddt
 import pytest
 from django.contrib.auth.models import AnonymousUser, User  # pylint: disable=imported-auth-user
-from django.db import IntegrityError
+from django.db import IntegrityError, connection
 from django.http import Http404
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
 from openedx_events.testing import OpenEdxEventsTestMixin
@@ -807,3 +808,51 @@ class TestUnregisteredLearnerCohortAssignments(TestCase):
 
         assert not was_retired
         assert self.cohort_assignment.email == known_learner_email
+
+    def test_email_redacted_before_delete(self):
+        """
+        Verify email is redacted (UPDATE) before the record is deleted, using
+        ID-based filtering to prevent over-affecting unrelated rows.
+        """
+        # Create an unrelated assignment with the same email in a different course
+        other_course_key = CourseKey.from_string('course-v1:edX+OtherX+Other_Course')
+        other_cohort = CourseUserGroup.objects.create(
+            name='OtherCohort',
+            course_id=other_course_key,
+            group_type=CourseUserGroup.COHORT,
+        )
+        other_assignment = UnregisteredLearnerCohortAssignments.objects.create(
+            course_user_group=other_cohort,
+            course_id=other_course_key,
+            email='learner@example.com',
+        )
+
+        with CaptureQueriesContext(connection) as context:
+            was_retired = UnregisteredLearnerCohortAssignments.delete_by_user_value(
+                value='learner@example.com',
+                field='email'
+            )
+
+        assert was_retired
+
+        updates = [q for q in context.captured_queries if 'UPDATE' in q['sql']]
+        deletes = [q for q in context.captured_queries if 'DELETE' in q['sql']]
+
+        # Exactly one bulk UPDATE and one bulk DELETE
+        assert len(updates) == 1
+        assert len(deletes) == 1
+
+        # Both must use ID-based filtering
+        assert '"id" IN' in updates[0]['sql']
+        assert '"id" IN' in deletes[0]['sql']
+
+        # UPDATE must precede DELETE
+        assert context.captured_queries.index(updates[0]) < context.captured_queries.index(deletes[0])
+
+        # UPDATE must set email to the redacted sentinel value
+        assert 'redacted@retired.invalid' in updates[0]['sql']
+
+        # Both records must be deleted
+        assert not UnregisteredLearnerCohortAssignments.objects.filter(
+            id__in=[self.cohort_assignment.id, other_assignment.id]
+        ).exists()

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1504,6 +1504,71 @@ class TestAccountRetirementPost(RetirementTestCase):
         assert not CourseEnrollmentAllowed.objects.filter(email=self.original_email).exists()
         assert not UnregisteredLearnerCohortAssignments.objects.filter(email=self.original_email).exists()
 
+    @mock.patch('openedx.core.djangoapps.user_api.accounts.views.get_profile_image_names')
+    @mock.patch('openedx.core.djangoapps.user_api.accounts.views.remove_profile_images')
+    def test_cohort_assignment_email_redacted_before_delete(
+        self, mock_remove_profile_images, mock_get_profile_image_names
+    ):
+        """
+        Verify that UnregisteredLearnerCohortAssignments email is redacted (UPDATE) before the
+        record is deleted, so downstream systems (e.g. Snowflake) never see the raw email in
+        CDC/replication logs.
+
+        Uses CaptureQueriesContext to assert the UPDATE precedes the DELETE at the SQL level,
+        and that both operations use ID-based filtering to prevent over-affecting unrelated rows.
+        """
+        other_cohort = CourseUserGroup.objects.create(
+            name="OtherCohort",
+            course_id=self.course_key,
+            group_type=CourseUserGroup.COHORT,
+        )
+        other_assignment = UnregisteredLearnerCohortAssignments.objects.create(
+            course_user_group=other_cohort,
+            course_id=CourseKey.from_string('course-v1:edX+OtherX+Other_Course'),
+            email=self.original_email,
+        )
+
+        data = {'username': self.original_username}
+        with CaptureQueriesContext(connection) as context:
+            self.post_and_assert_status(data)
+
+        cohort_updates = [
+            q for q in context.captured_queries
+            if 'UPDATE' in q['sql'] and 'course_groups_unregisteredlearnercohortassignments' in q['sql']
+        ]
+        cohort_deletes = [
+            q for q in context.captured_queries
+            if 'DELETE' in q['sql'] and 'course_groups_unregisteredlearnercohortassignments' in q['sql']
+        ]
+
+        # Exactly one bulk UPDATE and one bulk DELETE — not per-record queries
+        assert len(cohort_updates) == 1, f"Expected 1 UPDATE, got {len(cohort_updates)}"
+        assert len(cohort_deletes) == 1, f"Expected 1 DELETE, got {len(cohort_deletes)}"
+
+        # UPDATE must use ID-based filtering to avoid over-redacting
+        assert '"id" IN' in cohort_updates[0]['sql'], (
+            f"UPDATE should use ID-based filtering: {cohort_updates[0]['sql']}"
+        )
+        # DELETE must use ID-based filtering to avoid over-deletion
+        assert '"id" IN' in cohort_deletes[0]['sql'], (
+            f"DELETE should use ID-based filtering: {cohort_deletes[0]['sql']}"
+        )
+
+        # UPDATE must appear before DELETE in the query stream
+        update_pos = context.captured_queries.index(cohort_updates[0])
+        delete_pos = context.captured_queries.index(cohort_deletes[0])
+        assert update_pos < delete_pos, "Email redaction (UPDATE) must precede record deletion (DELETE)"
+
+        # UPDATE must set email to the retired value
+        assert self.retired_email in cohort_updates[0]['sql'], (
+            f"UPDATE should set email to retired_email '{self.retired_email}': {cohort_updates[0]['sql']}"
+        )
+
+        # Both cohort assignments for original_email must be gone
+        assert not UnregisteredLearnerCohortAssignments.objects.filter(
+            id__in=[self.cohort_assignment.id, other_assignment.id]
+        ).exists()
+
     def test_retire_user_twice_idempotent(self):
         data = {'username': self.original_username}
         self.post_and_assert_status(data)

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1559,9 +1559,9 @@ class TestAccountRetirementPost(RetirementTestCase):
         delete_pos = context.captured_queries.index(cohort_deletes[0])
         assert update_pos < delete_pos, "Email redaction (UPDATE) must precede record deletion (DELETE)"
 
-        # UPDATE must set email to the retired value
-        assert self.retired_email in cohort_updates[0]['sql'], (
-            f"UPDATE should set email to retired_email '{self.retired_email}': {cohort_updates[0]['sql']}"
+        # UPDATE must set email to the redacted sentinel value
+        assert 'redacted@retired.invalid' in cohort_updates[0]['sql'], (
+            f"UPDATE should set email to 'redacted@retired.invalid': {cohort_updates[0]['sql']}"
         )
 
         # Both cohort assignments for original_email must be gone

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1176,7 +1176,19 @@ class AccountRetirementView(ViewSet):
 
             # Retire any objects linked to the user via their original email
             CourseEnrollmentAllowed.delete_by_user_value(original_email, field="email")
-            UnregisteredLearnerCohortAssignments.delete_by_user_value(original_email, field="email")
+            # Redact email PII before deletion so downstream systems (e.g. Snowflake) see only
+            # redacted data in CDC/replication logs, not the original email address.
+            cohort_assignment_ids = list(
+                UnregisteredLearnerCohortAssignments.objects.filter(
+                    email=original_email
+                ).values_list('id', flat=True)
+            )
+            UnregisteredLearnerCohortAssignments.objects.filter(
+                id__in=cohort_assignment_ids
+            ).update(email=retired_email)
+            UnregisteredLearnerCohortAssignments.objects.filter(
+                id__in=cohort_assignment_ids
+            ).delete()
 
             # This signal allows code in higher points of LMS to retire the user as necessary
             USER_RETIRE_LMS_CRITICAL.send(

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1176,19 +1176,7 @@ class AccountRetirementView(ViewSet):
 
             # Retire any objects linked to the user via their original email
             CourseEnrollmentAllowed.delete_by_user_value(original_email, field="email")
-            # Redact email PII before deletion so downstream systems (e.g. Snowflake) see only
-            # redacted data in CDC/replication logs, not the original email address.
-            cohort_assignment_ids = list(
-                UnregisteredLearnerCohortAssignments.objects.filter(
-                    email=original_email
-                ).values_list('id', flat=True)
-            )
-            UnregisteredLearnerCohortAssignments.objects.filter(
-                id__in=cohort_assignment_ids
-            ).update(email=retired_email)
-            UnregisteredLearnerCohortAssignments.objects.filter(
-                id__in=cohort_assignment_ids
-            ).delete()
+            UnregisteredLearnerCohortAssignments.delete_by_user_value(original_email, field="email")
 
             # This signal allows code in higher points of LMS to retire the user as necessary
             USER_RETIRE_LMS_CRITICAL.send(


### PR DESCRIPTION
## Description

During user retirement, `UnregisteredLearnerCohortAssignments` records were being deleted without first redacting the email field. This meant downstream systems (e.g. Snowflake) could see the raw email address in CDC/replication logs at the moment of deletion.

This change redacts the email to its retired (hashed) value before deleting the record, consistent with how PII is handled for other tables during the retirement pipeline.

## Private JIRA ticket

https://2u-internal.atlassian.net/browse/BOMS-565

## Changes

**`openedx/core/djangoapps/user_api/accounts/views.py`**
- Replaced `UnregisteredLearnerCohortAssignments.delete_by_user_value()` with an explicit ID-based redact-then-delete:
  1. Collect matching record IDs by `original_email`
  2. Bulk `UPDATE` email to `retired_email` using `id__in`
  3. Bulk `DELETE` those same IDs

**`openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py`**
- Added `test_cohort_assignment_email_redacted_before_delete` to verify at the SQL level (via `CaptureQueriesContext`) that:
  - UPDATE precedes DELETE in the query stream
  - Both operations use `id IN (...)` filtering
  - The UPDATE sets email to the retired (hashed) value
  - An unrelated record with the same email is not affected

## Testing

- New test `test_cohort_assignment_email_redacted_before_delete` in `TestAccountRetirementPost` covers the fix end-to-end including the SQL query order and ID-based filtering assertions.
- Existing `test_retire_user` continues to assert the record is deleted.