### PR TITLE
docs: improve app-level docs discoverability (#35014)

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -5,3 +5,5 @@ references/docstrings/common
 references/docstrings/lms
 references/docstrings/openedx
 references/docstrings/xmodule
+apps/index.rst
+decisions/app_decisions.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -338,7 +338,10 @@ def on_init(app):  # pylint: disable=redefined-outer-name, unused-argument
     avoid checking in the generated reStructuredText files.
     """
     repo_docs_build_path = f'{root}/docs/references/docs'
-    RepositoryDocs(root, repo_docs_build_path).build_rst_docs()
+    repo_docs = RepositoryDocs(root, repo_docs_build_path)
+    repo_docs.build_rst_docs()
+    repo_docs.build_apps_index(root / 'docs' / 'apps' / 'index.rst')
+    repo_docs.build_decisions_index(root / 'docs' / 'decisions' / 'app_decisions.rst')
 
     docs_path = root / 'docs'
     apidoc_path = 'sphinx-apidoc'

--- a/docs/decisions/index.rst
+++ b/docs/decisions/index.rst
@@ -2,3 +2,4 @@
 
 .. toctree::
    0*
+   app_decisions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ locations.
     concepts/index
     extensions/tinymce_plugins
     decisions/index
+    apps/index
 
 .. grid:: 1 2 2 2
    :gutter: 3
@@ -90,6 +91,18 @@ locations.
          :expand:
 
          Hooks Extensions Framework
+
+   .. grid-item-card:: App Documentation
+      :class-card: sd-shadow-md sd-p-2
+      :class-footer: sd-border-0
+
+      * :doc:`apps/index`
+      * :doc:`decisions/app_decisions`
+      +++
+      .. button-ref:: apps/index
+         :color: primary
+         :outline:
+         :expand:
 
 
 Change History

--- a/docs/repository_docs.py
+++ b/docs/repository_docs.py
@@ -1,6 +1,7 @@
 import fnmatch
 import os
 import shutil
+from pathlib import Path
 
 DEFAULT_PATTERNS_TO_EXCLUDE_DIRS = (
     '*.tox',
@@ -16,7 +17,6 @@ DEFAULT_PATTERNS_TO_EXCLUDE_DIRS = (
 )
 
 DEFAULT_PATTERNS_TO_EXCLUDE_FILES = (
-    'readme.rst',
     'changelog.rst',
 )
 
@@ -42,7 +42,7 @@ class RepositoryDocs:
 
     def _copy_files(self, files):
         for file in files:
-            if file.name.lower() in self.patterns_to_exclude_files:
+            if os.path.basename(file).lower() in self.patterns_to_exclude_files:
                 continue
             relative_path = os.path.relpath(os.path.dirname(file), self.root)
             destination_path = os.path.join(self.build_path, relative_path)
@@ -64,7 +64,7 @@ class RepositoryDocs:
 
     def _create_index_rst_file(self, directory_path):
         directory_name = os.path.basename(directory_path)
-        file_path = f"{directory_path}/index.rst"
+        file_path = os.path.join(directory_path, "index.rst")
         if os.path.exists(file_path):
             return
         file_content = f"""{directory_name}
@@ -77,7 +77,7 @@ class RepositoryDocs:
    *
    */*index
 """
-        with open(file_path, "w") as file:
+        with open(file_path, "w", encoding="utf-8") as file:
             file.write(file_content)
 
     def _find_rst_files(self):
@@ -94,3 +94,108 @@ class RepositoryDocs:
             if '__pycache__' in dir_names:
                 dir_names.remove('__pycache__')
         return rst_files
+
+    # Service directories to scan when building the apps overview index.
+    _SERVICE_DIRS = [
+        'lms/djangoapps',
+        'cms/djangoapps',
+        'openedx/core/djangoapps',
+        'openedx/features',
+        'common/djangoapps',
+        'xmodule',
+    ]
+
+    def build_apps_index(self, output_path):
+        """
+        Generate a flat, scannable index of all Django apps that have a README
+        or a docs/ subdirectory, grouped by service area.
+
+        Written to output_path (overwritten on each build).
+        """
+        lines = [
+            'App-Level Documentation',
+            '=======================',
+            '',
+            'Quick-scan index of Django apps that have README files or documentation.',
+            'Each link opens the auto-generated index for that app.',
+            '',
+        ]
+
+        for service_dir in self._SERVICE_DIRS:
+            service_path = os.path.join(self.root, service_dir)
+            if not os.path.isdir(service_path):
+                continue
+
+            app_entries = []
+            for app_name in sorted(os.listdir(service_path)):
+                app_path = os.path.join(service_path, app_name)
+                if not os.path.isdir(app_path):
+                    continue
+                has_readme = os.path.isfile(os.path.join(app_path, 'README.rst'))
+                has_docs = os.path.isdir(os.path.join(app_path, 'docs'))
+                if has_readme or has_docs:
+                    # Path relative to docs/references/docs/ (where the generated tree lives)
+                    rel = f'{service_dir}/{app_name}'
+                    app_entries.append((app_name, rel))
+
+            if not app_entries:
+                continue
+
+            heading = service_dir
+            lines += [heading, '-' * len(heading), '']
+            for app_name, rel in app_entries:
+                lines.append(f'* :doc:`{app_name} <../references/docs/{rel}/index>`')
+            lines.append('')
+
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        Path(output_path).write_text('\n'.join(lines), encoding="utf-8")
+
+    def build_decisions_index(self, output_path):
+        """
+        Generate a comprehensive ADR index that links to every app-level
+        docs/decisions/ directory, grouped by service area.
+
+        Written to output_path (overwritten on each build).
+        """
+        # Collect all app-level decisions directories (skip top-level docs/decisions)
+        top_level_decisions = os.path.join(self.root, 'docs', 'decisions')
+        decisions_by_service = {}
+
+        for service_dir in self._SERVICE_DIRS:
+            service_path = os.path.join(self.root, service_dir)
+            if not os.path.isdir(service_path):
+                continue
+            entries = []
+            for dir_path, _dir_names, _file_names in os.walk(service_path):
+                if os.path.basename(dir_path) == 'decisions':
+                    parent = os.path.dirname(dir_path)
+                    if os.path.basename(parent) == 'docs' and dir_path != top_level_decisions:
+                        rel_from_root = os.path.relpath(dir_path, self.root)
+                        # Human-readable label: just the app directory name
+                        label = os.path.basename(os.path.dirname(os.path.dirname(dir_path)))
+                        entries.append((label, rel_from_root))
+            if entries:
+                decisions_by_service[service_dir] = sorted(entries)
+
+        lines = [
+            'App-Level Architecture Decision Records',
+            '========================================',
+            '',
+            'Links to per-app ADR directories, supplementing the top-level',
+            ':doc:`repo-wide decisions <0001-courses-in-lms>`.',
+            '',
+        ]
+
+        for service_dir, entries in decisions_by_service.items():
+            heading = service_dir
+            lines += [heading, '-' * len(heading), '']
+            for label, rel_from_root in entries:
+                # Path relative to docs/decisions/ (where this file lives)
+                link = f'../references/docs/{rel_from_root}/index'
+                # Normalise to forward slashes
+                link = link.replace(os.sep, '/')
+                lines.append(f'* :doc:`{label} <{link}>`')
+            lines.append('')
+
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        Path(output_path).write_text('\n'.join(lines), encoding="utf-8")

--- a/lms/djangoapps/certificates/docs/diagrams/README.rst
+++ b/lms/djangoapps/certificates/docs/diagrams/README.rst
@@ -1,3 +1,6 @@
+Certificate Flow Diagrams
+=========================
+
 Certificate management workflows are spread across a few different apps of edx-platform and can be hard to trace and
 understand. This folder contains high level visualizations to help maintainers understand how the Certificate awarding
 and revoking flows work, and how they interact with other pieces of the Open edX ecosystem (e.g. the Credentials IDA and

--- a/lms/djangoapps/discussion/django_comment_client/README.rst
+++ b/lms/djangoapps/discussion/django_comment_client/README.rst
@@ -1,1 +1,4 @@
+Django Comment Client
+=====================
+
 See ``lms/djangoapps/discussion/README.rst``

--- a/lms/djangoapps/discussion/notification_prefs/README.rst
+++ b/lms/djangoapps/discussion/notification_prefs/README.rst
@@ -1,1 +1,4 @@
+Notification Preferences
+========================
+
 See ``lms/djangoapps/discussion/README.rst``

--- a/lms/djangoapps/monitoring/README.rst
+++ b/lms/djangoapps/monitoring/README.rst
@@ -1,3 +1,6 @@
+Monitoring
+==========
+
 This directory contains utilities for adding a code_owner custom attribute for help with split-ownership of the LMS.
 
 For details on the decision to implement the code_owner custom attribute, see:

--- a/lms/static/sass/partials/README.rst
+++ b/lms/static/sass/partials/README.rst
@@ -1,3 +1,6 @@
+SASS Partials
+=============
+
 Any partials in this directory can be overridden by a theme by matching
 the directory structure as in lms/static/sass/partials.
 

--- a/openedx/core/djangoapps/catalog/README.rst
+++ b/openedx/core/djangoapps/catalog/README.rst
@@ -1,3 +1,6 @@
+Catalog
+=======
+
 This app serves as an interface to the discovery a.k.a. "catalog" service. It contains
 management commands for caching data from the discovery service, functions for accessing
 that data, and a config model that can be used to control access to the service.

--- a/openedx/core/djangoapps/course_live/README.rst
+++ b/openedx/core/djangoapps/course_live/README.rst
@@ -1,2 +1,5 @@
+Course Live
+===========
+
 This plugin app allow you to enable/disable the live tab in a course. The live
 tab is used to integrate video conferencing tools like "Zoom".

--- a/openedx/core/djangoapps/django_comment_common/README.rst
+++ b/openedx/core/djangoapps/django_comment_common/README.rst
@@ -1,1 +1,4 @@
+Django Comment Common
+=====================
+
 See ``lms/djangoapps/discussion/README.rst``

--- a/openedx/core/djangoapps/django_comment_common/comment_client/README.rst
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/README.rst
@@ -1,1 +1,4 @@
+Comment Client
+==============
+
 See ``lms/djangoapps/discussion/README.rst``

--- a/openedx/core/djangoapps/notifications/docs/README.rst
+++ b/openedx/core/djangoapps/notifications/docs/README.rst
@@ -1,1 +1,4 @@
+Notifications
+=============
+
 See `docs.openedx.org <https://docs.openedx.org/en/latest/site_ops/how-tos/enable_notifications.html>`_ for more information on notifications.

--- a/openedx/tests/completion_integration/README.rst
+++ b/openedx/tests/completion_integration/README.rst
@@ -1,0 +1,2 @@
+Completion Integration Tests
+============================


### PR DESCRIPTION
## Summary

Addresses #35014 based on [robrap's comment](https://github.com/openedx/openedx-platform/issues/35014#issuecomment-4007785741).

- **README files now appear in ReadTheDocs** — removes `readme.rst` from the exclusion list in `repository_docs.py` so all 68 app-level `README.rst` files are included in the auto-generated nav tree under References.
- **Apps overview index** — auto-generates `docs/apps/index.rst` at build time: a flat, scannable list of every Django app that has a README or `docs/` directory, grouped by service area (`lms/djangoapps`, `cms/djangoapps`, `openedx/`, etc.). Eliminates the need to expand the full nav tree to find which apps have docs.
- **Comprehensive ADR index** — auto-generates `docs/decisions/app_decisions.rst` at build time: links to all 39 app-level `docs/decisions/` directories, grouped by service area, supplementing the existing 9 top-level repo ADRs.

Both generated files are listed in `docs/.gitignore` (like `references/docs/*`) since they are produced during the Sphinx build.

### Also fixes

- Pre-existing `AttributeError` bug in `repository_docs._copy_files`: `file.name` was called on `str` objects after the `path` library import was removed in e99347eb — replaced with `os.path.basename(file)`. This bug silently prevented `build_rst_docs()` from ever running.
- Added RST title headings to 11 `README.rst` files that were missing them, which caused ~8,700 `[toc.no_title]` Sphinx warnings once the files were included.

## Test plan

- [ ] `tutor dev exec lms sphinx-build -M html docs docs/_build` completes with exit 0
- [ ] `docs/_build/html/index.html` — "App Documentation" grid card visible on homepage
- [ ] `docs/_build/html/apps/index.html` — flat app list renders, all links resolve
- [ ] `docs/_build/html/decisions/app_decisions.html` — 39 app ADR directories listed
- [ ] `docs/_build/html/references/docs/lms/djangoapps/courseware/README.html` — README renders
- [ ] Warning count does not regress beyond ~2,370 (all pre-existing, none from our changes)

**Testing**
<img width="1493" height="932" alt="image" src="https://github.com/user-attachments/assets/953b296f-eb99-4bd1-ba5c-9efcb3a20789" />
<img width="1559" height="971" alt="image" src="https://github.com/user-attachments/assets/d57a4a10-1d43-493c-9193-6d4ee07a60a6" />
<img width="1598" height="1005" alt="image" src="https://github.com/user-attachments/assets/b847415a-a9e9-451b-8190-60b2be3bc3da" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)