### PR TITLE
feat: backport filter for instructor dash tabs

### DIFF
--- a/common/djangoapps/util/tests/test_filters.py
+++ b/common/djangoapps/util/tests/test_filters.py
@@ -3,6 +3,7 @@ Test that various filters are fired for models/views in the student app.
 """
 from django.test import override_settings
 from openedx_filters import PipelineStep
+from openedx_filters.learning.filters import InstructorDashboardTabsRequested
 
 from common.djangoapps.util import course
 from openedx.core.djangolib.testing.utils import skip_unless_lms
@@ -76,3 +77,53 @@ class CourseAboutPageURLRequestedFiltersTest(ModuleStoreTestCase):
         )
 
         self.assertEqual(expected_course_about, course_about_url)  # noqa: PT009
+
+
+class TestInstructorDashCustomTab(PipelineStep):
+    """
+    Utility class used when getting steps for pipeline.
+    """
+
+    def run_filter(self, tabs, user, course_key):  # pylint: disable=arguments-differ,unused-argument
+        """Pipeline step that appends a custom instructor dashboard tab."""
+        result = {
+            "tabs": tabs + [{
+                "tab_id": "custom",
+                "title": "Custom Tab",
+                "url": f"/courses/{course_key}/instructor/custom",
+                "sort_order": 999,
+            }],
+        }
+        return result
+
+
+class TestPreventTabsGenerationWithTabs(PipelineStep):
+    """
+    Pipeline step that raises PreventTabsGeneration with a custom tabs list.
+    Used to test that the exception handler in get_tabs uses exc.tabs when present.
+    """
+
+    def run_filter(self, tabs, user, course_key):  # pylint: disable=arguments-differ,unused-argument
+        """Pipeline step that raises PreventTabsGeneration with custom tabs."""
+        raise InstructorDashboardTabsRequested.PreventTabsGeneration(
+            "Preventing default tabs in favor of custom ones.",
+            tabs=[{
+                "tab_id": "plugin_tab",
+                "title": "Plugin Tab",
+                "url": f"/courses/{course_key}/instructor/plugin",
+                "sort_order": 5,
+            }],
+        )
+
+
+class TestPreventTabsGenerationWithoutTabs(PipelineStep):
+    """
+    Pipeline step that raises PreventTabsGeneration without a tabs list.
+    Used to test that the exception handler in get_tabs falls back to an empty list.
+    """
+
+    def run_filter(self, tabs, user, course_key):  # pylint: disable=arguments-differ,unused-argument
+        """Pipeline step that raises PreventTabsGeneration without providing tabs."""
+        raise InstructorDashboardTabsRequested.PreventTabsGeneration(
+            "Preventing all tabs from being generated."
+        )

--- a/lms/djangoapps/instructor/tests/views/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_api_v2.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -692,3 +693,94 @@ class ScoreOverrideViewTestCase(GradingEndpointTestBase):
             format='json',
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+class CourseMetadataViewTestCase(ModuleStoreTestCase):
+    """
+    Tests for GET /api/instructor/v2/courses/{course_id} with InstructorDashboardTabsRequested filter.
+    """
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.course = CourseFactory.create()
+        self.instructor = InstructorFactory.create(course_key=self.course.id)
+        self.client.force_authenticate(user=self.instructor)
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.instructor.dashboard.tabs.requested.v1": {
+                "pipeline": [
+                    "common.djangoapps.util.tests.test_filters.TestInstructorDashCustomTab",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_tabs_filter_adds_custom_tab(self):
+        """Test that override settings drive a custom instructor dashboard tab."""
+        url = reverse("instructor_api_v2:course_metadata", kwargs={"course_id": str(self.course.id)})
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        tabs_by_id = {tab["tab_id"]: tab for tab in data["tabs"]}
+
+        assert "course_info" in tabs_by_id
+        assert "custom" in tabs_by_id
+        assert tabs_by_id["custom"] == {
+            "tab_id": "custom",
+            "title": "Custom Tab",
+            "url": f"/courses/{self.course.id}/instructor/custom",
+            "sort_order": 999,
+        }
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.instructor.dashboard.tabs.requested.v1": {
+                "pipeline": [
+                    "common.djangoapps.util.tests.test_filters.TestPreventTabsGenerationWithTabs",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_tabs_filter_prevent_tabs_generation_with_custom_tabs(self):
+        """
+        Test that when PreventTabsGeneration is raised with a tabs attribute,
+        the serializer uses those custom tabs instead of the default ones.
+        """
+        url = reverse("instructor_api_v2:course_metadata", kwargs={"course_id": str(self.course.id)})
+        with self.assertLogs('openedx_filters.tooling', level='ERROR'):
+            response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["tabs"] == [{
+            "tab_id": "plugin_tab",
+            "title": "Plugin Tab",
+            "url": f"/courses/{self.course.id}/instructor/plugin",
+            "sort_order": 5,
+        }]
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.instructor.dashboard.tabs.requested.v1": {
+                "pipeline": [
+                    "common.djangoapps.util.tests.test_filters.TestPreventTabsGenerationWithoutTabs",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_tabs_filter_prevent_tabs_generation_without_tabs_attr(self):
+        """
+        Test that when PreventTabsGeneration is raised without a tabs attribute,
+        the serializer falls back to an empty list.
+        """
+        url = reverse("instructor_api_v2:course_metadata", kwargs={"course_id": str(self.course.id)})
+        with self.assertLogs('openedx_filters.tooling', level='ERROR'):
+            response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["tabs"] == []

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -13,6 +13,7 @@ from django.contrib.auth import get_user_model
 from django.utils.html import escape
 from django.utils.translation import gettext as _
 from edx_when.api import is_enabled_for_course
+from openedx_filters.learning.filters import InstructorDashboardTabsRequested
 from rest_framework import serializers
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -305,6 +306,19 @@ class CourseInformationSerializerV2(serializers.Serializer):
                 'sort_order': 110,
             })
 
+        try:
+            # .. filter_implemented_name: InstructorDashboardTabsRequested
+            # .. filter_type: org.openedx.learning.instructor.dashboard.tabs.requested.v1
+            filtered_tabs = InstructorDashboardTabsRequested.run_filter(
+                tabs=tabs,
+                user=request.user,
+                course_key=course_key
+            )
+            custom_tabs = filtered_tabs if filtered_tabs is not None else tabs
+        except InstructorDashboardTabsRequested.PreventTabsGeneration as exc:
+            # Plugin provided custom tabs or prevented tab generation
+            custom_tabs = getattr(exc, 'tabs', None) or []
+
         # We provide the tabs in a specific order based on how it was
         # historically presented in the frontend.  The frontend can use
         # this info or choose to ignore the ordering.
@@ -322,8 +336,7 @@ class CourseInformationSerializerV2(serializers.Serializer):
             'special_exams',
         ]
         order_index = {tab: i for i, tab in enumerate(tabs_order)}
-        tabs = sorted(tabs, key=lambda x: order_index.get(x['tab_id'], float("inf")))
-        return tabs
+        return sorted(custom_tabs, key=lambda x: order_index.get(x['tab_id'], float("inf")))
 
     def get_course_id(self, data):
         """Get course ID as string."""

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -309,7 +309,7 @@ class CourseInformationSerializerV2(serializers.Serializer):
         try:
             # .. filter_implemented_name: InstructorDashboardTabsRequested
             # .. filter_type: org.openedx.learning.instructor.dashboard.tabs.requested.v1
-            filtered_tabs = InstructorDashboardTabsRequested.run_filter(
+            filtered_tabs, _user, _course_key = InstructorDashboardTabsRequested.run_filter(
                 tabs=tabs,
                 user=request.user,
                 course_key=course_key

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -861,7 +861,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.4.0
+openedx-filters==3.4.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -861,7 +861,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.1.0
+openedx-filters==3.4.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1413,7 +1413,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.4.0
+openedx-filters==3.4.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1413,7 +1413,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.1.0
+openedx-filters==3.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1041,7 +1041,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.4.0
+openedx-filters==3.4.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1041,7 +1041,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.1.0
+openedx-filters==3.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1081,7 +1081,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.4.0
+openedx-filters==3.4.1
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1081,7 +1081,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.1.0
+openedx-filters==3.4.0
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
## Description

This is a backport for verawood of: https://github.com/openedx/openedx-platform/pull/38499

In order to achieve https://github.com/openedx/frontend-app-instructor-dashboard/issues/86 this PR will add use the new filter for the instructor dash tabs

depens on: https://github.com/openedx/openedx-filters/pull/355

Once this is in place any operator / plugin creator can do something like:



```py
# Add the pipeline step to the LMS configuration
hooks.Filters.ENV_PATCHES.add_item(
    (
        "openedx-lms-common-settings",
        """
# Custom tabs plugin configuration and pipeline step
import logging
from django.conf import settings

# Define the pipeline step class
class CustomTabsStep:
    def __init__(self, filter_type, running_pipeline, **kwargs):
        self.filter_type = filter_type
        self.running_pipeline = running_pipeline

    def run_filter(self, tabs, user, course_key, **kwargs):
        logger = logging.getLogger(__name__)
        logger.error(f"DEBUG: CustomTabsStep.run_filter called for user {user.username if hasattr(user, 'username') else 'unknown'}")

        modified_tabs = tabs.copy()

        # Check if user has permission
        user_has_access = (
            getattr(user, 'is_staff', False) or 
            getattr(user, 'is_superuser', False)
        )
        logger.error(f"DEBUG: User access check - is_staff: {getattr(user, 'is_staff', False)}, is_superuser: {getattr(user, 'is_superuser', False)}, has_access: {user_has_access}")

        if not user_has_access:
            logger.error("DEBUG: User does not have access to custom tabs")
            return {"tabs": modified_tabs}

        # Add custom tab
        custom_tab = {
            'tab_id': 'custom_analytics',
            'title': 'Custom Analytics',
            'url': f"{getattr(settings, 'CUSTOM_TABS_URL', '/instructor-dashboard/course-v1:OpenedX+DemoX+DemoCourse/custom_analytics')}",
            'sort_order': 120,
        }

        modified_tabs.append(custom_tab)
        logger.error(f"DEBUG: Added custom tab. Total tabs: {len(modified_tabs)}")

        return {"tabs": modified_tabs}

# Add the class to sys.modules so it can be imported by string
import sys
import types

# Create a module for our custom class
custom_module = types.ModuleType('custom_tabs_module')
custom_module.CustomTabsStep = CustomTabsStep
sys.modules['custom_tabs_module'] = custom_module

# Register the filter configuration
if "OPEN_EDX_FILTERS_CONFIG" not in locals():
    OPEN_EDX_FILTERS_CONFIG = {}

OPEN_EDX_FILTERS_CONFIG.update({
    "org.openedx.learning.instructor.dashboard.tabs.requested.v1": {
        "pipeline": [
            "custom_tabs_module.CustomTabsStep",
        ],
        "fail_silently": False,
    },
})
""",
    )
)
```


in whichever shape fits their need to be able to conditionally add or modify data of the tabs for the instructor dashboard.

## Testing instructions

**Note:** to test this through the API or the UI edx-filters changes need to be in place

- While having instructor dashbboard app and openedx-platform working add the example tutor-plugin from the description
- Save configs
- Restart server
- Go to instructor dashboard, the new tab should be available

Take in account that the frontend should have a slot to manage the URL that it's being returned for example a slot like this

```ts
{
    slotId: 'org.openedx.frontend.slot.instructorDashboard.routes.v1',
    id: 'org.openedx.frontend.widget.instructorDashboard.route.custom_analytics',
    op: WidgetOperationTypes.APPEND,
    element: <PlaceholderSlot tabId="custom_analytics" content={<div>Dynamic Content</div>} />,
  }
```

is added to the frontend-base build then the `custom_analytics` from the path from the plugin example will match the tabId `custom_analytics` from here and the tab will be displayed


The API request that uses this is: `http://local.openedx.io:8000/api/instructor/v2/courses/{:courseId}`

## Deadline

None

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Depens on https://github.com/openedx/openedx-filters/pull/355
- No deprecations, no migrations
