### PR TITLE
feat: adding CCX support to edx notes

### DIFF
--- a/lms/djangoapps/edxnotes/decorators.py
+++ b/lms/djangoapps/edxnotes/decorators.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from xblock.exceptions import NoSuchServiceError
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
+from common.djangoapps.student.auth import is_ccx_course
 
 
 def edxnotes(cls):
@@ -56,7 +57,7 @@ def edxnotes(cls):
                 "params": {
                     # Use camelCase to name keys.
                     "usageId": self.scope_ids.usage_id,
-                    "courseId": course.id,
+                    "courseId": course.id if not is_ccx_course(course.id) else course.id.for_branch(branch=None),
                     "token": get_edxnotes_id_token(user),
                     "tokenUrl": get_token_url(course.id),
                     "endpoint": get_public_endpoint(),


### PR DESCRIPTION
## Description

This PR addresses an issue where notes created within a CCX are not displayed in the Notes tab.

The root cause is a mismatch in the course_id used when saving versus retrieving notes:

- When a note is saved, the course_id includes branch and version
- When the Notes tab fetches notes, it uses the CCX course_id without branch or version

This inconsistency causes the Notes tab to return no results for CCX notes, even though they were successfully saved.

## Proposed Solution

This PR standardizes the course_id used when persisting notes to ensure consistency between write and read operations.

For CCX courses, the course_id may include branch and version information, which is not consistently used across consumers such as the Notes tab. This change normalizes the identifier for CCX contexts before saving, ensuring that stored notes can be reliably retrieved.

This approach aligns how course_id is handled across services while preserving existing behavior for non-CCX courses.