### PR TITLE
Cast string grading policy counts to int for progress API

### DIFF
--- a/lms/djangoapps/course_home_api/progress/api.py
+++ b/lms/djangoapps/course_home_api/progress/api.py
@@ -132,8 +132,8 @@ class _AssignmentTypeGradeAggregator:
             policy_map[policy.get('type')] = {
                 'weight': policy.get('weight', 0.0),
                 'short_label': policy.get('short_label', ''),
-                'num_droppable': policy.get('drop_count', 0),
-                'num_total': policy.get('min_count', 0),
+                'num_droppable': int(float(policy.get('drop_count', 0) or 0)),
+                'num_total': int(float(policy.get('min_count', 0) or 0)),
             }
         return policy_map
 


### PR DESCRIPTION
## Bug
Courses with string-typed `min_count` or `drop_count` values in the grading policy crash the learner progress page with `TypeError: can't multiply sequence by non-int of type 'str'` (#38631).

## Root cause
`_build_policy_map` passes `drop_count` and `min_count` through unchanged. When those values are strings (e.g. `"2.0"`), `_AssignmentBucket.with_placeholders` executes `[0] * num_total` with a string multiplier.

## Why this fix is correct
Cast both fields with `int(float(...))`, which accepts numeric strings and integers already stored in policy JSON, ensuring `num_total` and `num_droppable` are always integers before bucket math.

Fixes #38631

Made with [Cursor](https://cursor.com)