### PR TITLE
fix: surface EnrollmentNotAllowed message to instructor dashboard

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -18,6 +18,7 @@ from botocore.exceptions import ClientError
 from django.conf import settings
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.core import mail
+from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, TestCase
@@ -51,6 +52,7 @@ from common.djangoapps.student.models import (
     get_retired_email_by_email,
     get_retired_username_by_username,
 )
+from common.djangoapps.student.models.course_enrollment import EnrollmentNotAllowed
 from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
     CourseDataResearcherRole,
@@ -1135,6 +1137,60 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
             ]
         }
 
+        res_json = json.loads(response.content.decode('utf-8'))
+        assert res_json == expected
+
+    @patch("lms.djangoapps.instructor.utils.enroll_email")
+    def test_enroll_enrollment_not_allowed(self, mock_enroll_email):
+        """EnrollmentNotAllowed from a filter is returned by students_update_enrollment."""
+        mock_enroll_email.side_effect = EnrollmentNotAllowed("Enrollment requires NIF verification.")
+        url = reverse('students_update_enrollment', kwargs={'course_id': str(self.course.id)})
+        response = self.client.post(
+            url,
+            {'identifiers': self.notenrolled_student.email, 'action': 'enroll', 'email_students': False},
+        )
+        assert response.status_code == 200
+        expected = {
+            "action": "enroll",
+            "auto_enroll": False,
+            "results": [
+                {
+                    "identifier": self.notenrolled_student.email,
+                    "error": True,
+                    "success": False,
+                    "error_type": "enrollment_not_allowed",
+                    "error_message": "Enrollment requires NIF verification.",
+                }
+            ]
+        }
+        res_json = json.loads(response.content.decode('utf-8'))
+        assert res_json == expected
+
+    @patch("lms.djangoapps.instructor.utils.enroll_email")
+    def test_enroll_validation_error_during_enrollment(self, mock_enroll_email):
+        """ValidationError raised during enrollment is returned by students_update_enrollment."""
+        mock_enroll_email.side_effect = ValidationError(
+            ["This email is not allowed to enroll in this course."]
+        )
+        url = reverse('students_update_enrollment', kwargs={'course_id': str(self.course.id)})
+        response = self.client.post(
+            url,
+            {'identifiers': self.notregistered_email, 'action': 'enroll', 'email_students': False},
+        )
+        assert response.status_code == 200
+        expected = {
+            "action": "enroll",
+            "auto_enroll": False,
+            "results": [
+                {
+                    "identifier": self.notregistered_email,
+                    "error": True,
+                    "success": False,
+                    "error_type": "validation_error",
+                    "error_message": "This email is not allowed to enroll in this course.",
+                }
+            ]
+        }
         res_json = json.loads(response.content.decode('utf-8'))
         assert res_json == expected
 

--- a/lms/djangoapps/instructor/tests/test_utils.py
+++ b/lms/djangoapps/instructor/tests/test_utils.py
@@ -23,6 +23,7 @@ from common.djangoapps.student.models import (
     UNENROLLED_TO_UNENROLLED,
     EnrollStatusChange,
 )
+from common.djangoapps.student.models.course_enrollment import EnrollmentNotAllowed
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.instructor.enrollment import EmailEnrollmentState
 from lms.djangoapps.instructor.utils import (
@@ -234,6 +235,56 @@ class TestProcessSingleStudentEnrollment(TestCase):
         self.assertEqual(  # noqa: PT009
             result["error_message"],
             "Something went wrong while processing this learner. Please try again or contact support.",
+        )
+
+    @patch("lms.djangoapps.instructor.utils.enroll_email")
+    def test_process_single_student_enrollment_not_allowed(self, mock_enroll_email: Mock):
+        """Test enrollment blocked by a pipeline filter that raises EnrollmentNotAllowed."""
+        mock_enroll_email.side_effect = EnrollmentNotAllowed("Enrollment requires NIF verification.")
+
+        result = process_single_student_enrollment(
+            request_user=self.request_user,
+            course_key=self.course_key,
+            action=EnrollStatusChange.enroll,
+            identifier=self.user.email,
+            auto_enroll=False,
+            email_students=True,
+            reason="Test enrollment",
+            email_params=self.email_params,
+        )
+
+        self.assertFalse(result["success"])  # noqa: PT009
+        self.assertEqual(result["identifier"], self.user.email)  # noqa: PT009
+        self.assertTrue(result["error"])  # noqa: PT009
+        self.assertEqual(result["error_type"], "enrollment_not_allowed")  # noqa: PT009
+        self.assertEqual(result["error_message"], "Enrollment requires NIF verification.")  # noqa: PT009
+
+    @patch("lms.djangoapps.instructor.utils.enroll_email")
+    def test_process_single_student_enrollment_validation_error_during_enrollment(
+        self, mock_enroll_email: Mock
+    ):
+        """Test enrollment blocked by ValidationError raised during enrollment (not email format)."""
+        error = ValidationError(["This email is not allowed to enroll in this course."])
+        mock_enroll_email.side_effect = error
+
+        result = process_single_student_enrollment(
+            request_user=self.request_user,
+            course_key=self.course_key,
+            action=EnrollStatusChange.enroll,
+            identifier=self.user.email,
+            auto_enroll=False,
+            email_students=True,
+            reason="Test enrollment",
+            email_params=self.email_params,
+        )
+
+        self.assertFalse(result["success"])  # noqa: PT009
+        self.assertEqual(result["identifier"], self.user.email)  # noqa: PT009
+        self.assertTrue(result["error"])  # noqa: PT009
+        self.assertEqual(result["error_type"], "validation_error")  # noqa: PT009
+        self.assertEqual(  # noqa: PT009
+            result["error_message"],
+            "This email is not allowed to enroll in this course.",
         )
 
 

--- a/lms/djangoapps/instructor/utils.py
+++ b/lms/djangoapps/instructor/utils.py
@@ -29,6 +29,7 @@ from common.djangoapps.student.models import (
     ManualEnrollmentAudit,
     get_user_by_username_or_email,
 )
+from common.djangoapps.student.models.course_enrollment import EnrollmentNotAllowed
 from lms.djangoapps.instructor.enrollment import (
     enroll_email,
     get_email_params,
@@ -136,7 +137,16 @@ def process_single_student_enrollment(
 
     try:
         validate_email(email)  # Raises ValidationError if invalid
+    except ValidationError:
+        return {
+            "identifier": identifier,
+            "invalidIdentifier": True,
+            "success": False,
+            "error_type": "invalid_identifier",
+            "error_message": _("Invalid email address"),
+        }
 
+    try:
         # Wrap enrollment and audit operations in an atomic transaction
         # to ensure both succeed or both are rolled back
         with transaction.atomic():
@@ -171,13 +181,28 @@ def process_single_student_enrollment(
             "success": True,
             "state_transition": state_transition,
         }
-    except ValidationError:
+    except EnrollmentNotAllowed as exc:
+        # Enrollment was blocked by a pipeline filter (e.g. NIF requirement).
+        # Surface the specific message so the instructor knows the reason.
+        log.warning("Enrollment not allowed for %s: %s", identifier, exc)
         return {
             "identifier": identifier,
-            "invalidIdentifier": True,
+            "error": True,
             "success": False,
-            "error_type": "invalid_identifier",
-            "error_message": _("Invalid email address"),
+            "error_type": "enrollment_not_allowed",
+            "error_message": str(exc),
+        }
+    except ValidationError as exc:
+        # ValidationError raised during enrollment (e.g. a pre_save signal guard
+        # blocking CourseEnrollmentAllowed creation for a restricted course).
+        # Surface the specific message so the instructor knows the reason.
+        log.warning("ValidationError while enrolling %s: %s", identifier, exc)
+        return {
+            "identifier": identifier,
+            "error": True,
+            "success": False,
+            "error_type": "validation_error",
+            "error_message": exc.messages[0] if exc.messages else str(exc),
         }
     except Exception as exc:  # pylint: disable=broad-exception-caught
         log.exception("Error while processing student %s: %s", identifier, exc)


### PR DESCRIPTION
# fix: surface EnrollmentNotAllowed message to instructor dashboard

## Problem

When a pipeline filter blocks enrollment (e.g. `FilterEnrollmentRequireNIF`), the specific error message was never shown to the instructor. Instead, a generic error was returned with no explanation.

Two cases were broken in `process_single_student_enrollment`:

1. **Registered user blocked by a filter** — `enroll_email()` raises `EnrollmentNotAllowed` with a descriptive message, which was caught by the broad `except Exception` handler and replaced with a generic "Something went wrong" message.

2. **Unregistered email blocked by a pre_save signal guard** — a `ValidationError` raised during enrollment was caught by the same `except ValidationError` used for email format validation, returning `invalidIdentifier: True` and "Invalid email address" — completely misleading.

## Solution

- Separated `validate_email` into its own `try/except` block so email format errors are handled independently from errors raised during enrollment.
- Added `except EnrollmentNotAllowed as exc` to capture filter-blocked enrollments and surface `str(exc)` in the response.
- Added `except ValidationError as exc` for `ValidationError` raised during the enrollment process itself, surfacing `exc.messages[0]` instead of a hardcoded message.

## Testing

1. Set up a course with a pipeline filter that blocks enrollment (e.g. a NIF requirement filter).
2. Try to enroll a registered user who does not meet the filter requirement via the instructor dashboard.
3. Verify the instructor sees the specific message from the filter instead of a generic error.
4. Try to enroll an unregistered email on the same course.
5. Verify the instructor sees the specific message from the pre_save guard instead of "Invalid email address".
