### PR TITLE
fix: django admin wasn't showing details of content libraries (#38578) [Verawood Backport]

### DIFF
--- a/openedx/core/djangoapps/content_libraries/admin.py
+++ b/openedx/core/djangoapps/content_libraries/admin.py
@@ -16,9 +16,9 @@ class ContentLibraryAdmin(admin.ModelAdmin):
         "library_key",
         "org",
         "slug",
+        "learning_package",
         "allow_public_learning",
         "allow_public_read",
-        "authorized_lti_configs",
     )
     list_display = ("slug", "org",)
 
@@ -26,7 +26,7 @@ class ContentLibraryAdmin(admin.ModelAdmin):
         """
         Ensure that 'slug' and 'uuid' cannot be edited after creation.
         """
+        always_ro_fields = ["library_key", "learning_package"]
         if obj:
-            return ["library_key", "org", "slug"]
-        else:
-            return ["library_key", ]
+            return [*always_ro_fields, "org", "slug"]
+        return always_ro_fields


### PR DESCRIPTION
## Problem
When we enter the Verawood sandbox in the Django Admin and try to check a specific content library, the web returns a 500 error.

Link in Django Admin: https://verawood.demo.edly.io/admin/content_libraries/contentlibrary/
Link with the error 500: https://verawood.demo.edly.io/admin/content_libraries/contentlibrary/1/change/

You can test the error with the sandbox credentials: https://docs.google.com/spreadsheets/d/1j1uDhVIVLwHUfrMLBzx6lM55gYL6i4nUqbzkbLHpaHQ/edit?usp=sharing

The problem was introduced in this PR #38297 when we removed the `authorized_lti_configs` field, and it was solved in #38578.

## Description
This is a cherry-pick of #38578

## Why this should be in Verawood

To not have that view broken. An admin user should be able to see their libraries in the model.

## Notes

I tested in a verawood env and worked as expected. You can test it using this branch, and enter it in yourlms/admin/content_libraries/contentlibrary/1/change/ (you should be able to see the library details and not get a 500 error)

