### PR TITLE
fix: Fixes the enrollment counts for audit courses in Instructor Dashboard

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -342,13 +342,17 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase, MasqueradeMixin):
         self.assertGreaterEqual(enrollment_counts['honor'], 1)  # noqa: PT009
         self.assertGreaterEqual(enrollment_counts['total'], 3)  # noqa: PT009
 
-    def test_enrollment_counts_excludes_unconfigured_modes(self):
+    def test_enrollment_counts_includes_unconfigured_modes_with_enrollments(self):
         """
-        Test that enrollment counts only include modes configured for the course,
-        not modes that exist on other courses.
+        Test that enrollment counts include modes with active enrollments even
+        when those modes are not explicitly configured for the course.
+
+        Regression test for https://github.com/openedx/frontend-app-instructor-dashboard/issues/210
+        The default enrollment mode (e.g. audit) may not be explicitly configured,
+        but learners can still be enrolled in it. The total must equal the sum of
+        all mode counts.
         """
-        # Only configure audit and honor for this course (not verified)
-        CourseModeFactory.create(course_id=self.course_key, mode_slug='audit')
+        # Only configure 'honor' for this course — do NOT configure 'audit'
         CourseModeFactory.create(course_id=self.course_key, mode_slug='honor')
 
         self.client.force_authenticate(user=self.instructor)
@@ -357,14 +361,13 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase, MasqueradeMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
         enrollment_counts = response.data['enrollment_counts']
 
-        # Only configured modes should appear
+        # 'audit' is not configured but has enrollments from setUp — it must appear
         self.assertIn('audit', enrollment_counts)  # noqa: PT009
-        self.assertIn('honor', enrollment_counts)  # noqa: PT009
-        self.assertIn('total', enrollment_counts)  # noqa: PT009
+        self.assertGreaterEqual(enrollment_counts['audit'], 1)  # noqa: PT009
 
-        # verified is not configured, so it should not appear
-        # (even though there are verified enrollments from setUp)
-        self.assertNotIn('verified', enrollment_counts)  # noqa: PT009
+        # The sum of all mode counts must equal total
+        mode_sum = sum(v for k, v in enrollment_counts.items() if k != 'total')
+        self.assertEqual(enrollment_counts['total'], mode_sum)  # noqa: PT009
 
     def _get_tabs_from_response(self, user, course_id=None):
         """Helper to get tabs from API response."""

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -355,19 +355,31 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase, MasqueradeMixin):
         # Only configure 'honor' for this course — do NOT configure 'audit'
         CourseModeFactory.create(course_id=self.course_key, mode_slug='honor')
 
+        # Explicitly create an enrollment in an unconfigured mode
+        CourseEnrollmentFactory.create(
+            user=UserFactory.create(),
+            course_id=self.course_key,
+            mode='audit',
+            is_active=True,
+        )
+
         self.client.force_authenticate(user=self.instructor)
         response = self.client.get(self._get_url())
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
+        assert response.status_code == status.HTTP_200_OK
         enrollment_counts = response.data['enrollment_counts']
 
-        # 'audit' is not configured but has enrollments from setUp — it must appear
-        self.assertIn('audit', enrollment_counts)  # noqa: PT009
-        self.assertGreaterEqual(enrollment_counts['audit'], 1)  # noqa: PT009
+        # Configured mode must appear
+        assert 'honor' in enrollment_counts
+        # Unconfigured mode with enrollments must also appear
+        assert 'audit' in enrollment_counts
+        assert enrollment_counts['audit'] >= 1
+        # Total key must be present
+        assert 'total' in enrollment_counts
 
         # The sum of all mode counts must equal total
         mode_sum = sum(v for k, v in enrollment_counts.items() if k != 'total')
-        self.assertEqual(enrollment_counts['total'], mode_sum)  # noqa: PT009
+        assert enrollment_counts['total'] == mode_sum
 
     def _get_tabs_from_response(self, user, course_id=None):
         """Helper to get tabs from API response."""

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -404,11 +404,15 @@ class CourseInformationSerializerV2(serializers.Serializer):
         return self.get_total_enrollment(data) - self.get_learner_count(data)
 
     def get_enrollment_counts(self, data):
-        """Get enrollment counts for all configured course modes."""
+        """Get enrollment counts for all configured modes and any mode with active enrollments."""
         course_id = data['course'].id
         counts = CourseEnrollment.objects.enrollment_counts(course_id)
         configured_modes = CourseMode.modes_for_course(course_id)
         result = {mode.slug: counts[mode.slug] for mode in configured_modes}
+        # Include any mode that has enrollments, even if not explicitly configured
+        for mode_slug, count in counts.items():
+            if mode_slug != 'total' and mode_slug not in result:
+                result[mode_slug] = count
         result['total'] = counts['total']
         return result
 

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -411,7 +411,7 @@ class CourseInformationSerializerV2(serializers.Serializer):
         result = {mode.slug: counts[mode.slug] for mode in configured_modes}
         # Include any mode that has enrollments, even if not explicitly configured
         for mode_slug, count in counts.items():
-            if mode_slug != 'total' and mode_slug not in result:
+            if mode_slug != 'total' and mode_slug not in result and count > 0:
                 result[mode_slug] = count
         result['total'] = counts['total']
         return result


### PR DESCRIPTION
## Description

Fixes a regression in the enrollment track visibility on the Course Info page of the Instructor Dashboard MFE.

In PR #38007, `get_enrollment_counts()` was refactored to only return modes explicitly configured via `CourseMode.modes_for_course()`. The intent was to show configured modes with 0 enrollments (e.g., a "professional" track with no learners yet). However, this inadvertently hid learners enrolled in modes that aren't explicitly configured, most notably the default "audit" track, which learners are placed into automatically but may not be listed as a configured course mode.

The result: the total count could be higher than the sum of the displayed mode counts, and entire enrollment tracks were invisible in the UI.

The fix returns the union of configured modes and modes with active enrollments, preserving both behaviors:
1. Configured modes with 0 enrollments still appear (original intent of #38007)
2. Modes with actual learners that aren't explicitly configured now appear as well (the bug fix)

Impacted roles: Course Author, Operator (Instructor Dashboard MFE consumers)

## Supporting information

- Fixes: https://github.com/openedx/frontend-app-instructor-dashboard/issues/210

## Testing instructions

1. Create a course and configure only "honor" as a course mode (do NOT explicitly add "audit")
2. Enroll learners; some will land in the default "audit" track
3. Navigate to the Instructor Dashboard -> Course Info tab
4. Both "honor" and "audit" appear, and the sum of all mode counts equals the total

## Deadline

None

## Other information

- No database migrations required
- No dependencies on other changes