### PR TITLE
fix: backport openedx-forum 0.4.1 to ulmo for thread sort bug

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -68,6 +68,17 @@ openedx-learning==0.30.2
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35268
 openai<=0.28.1
 
+# Date: 2026-06-04
+# Cap openedx-forum to 0.4.1 on the Ulmo release line:
+#   * 0.4.1 contains the fix for the "pinned" NULL sort bug
+#     (https://github.com/openedx/forum/pull/270 — discussion threads were not
+#     ordering correctly when sorted by "recent first"). See user report:
+#     https://discuss.openedx.org/t/discuss-forum-messages-order-not-organized-as-expected-in-teak/18665
+#   * 0.4.2 drops Python 3.11 support.
+#   * 0.4.3 removes the MongoDB backend, which Ulmo deployments may still rely on.
+# Remove this cap on master / post-Ulmo release lines.
+openedx-forum<=0.4.1
+
 # Date: 2024-04-26
 # path==16.12.0 breaks the unit test collections check
 # needs to be investigated and fixed separately

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -661,7 +661,9 @@ html5lib==1.1
 httpcore==1.0.9
     # via httpx
 httpx[http2]==0.28.1
-    # via firebase-admin
+    # via
+    #   firebase-admin
+    #   typesense
 hyperframe==6.1.0
     # via h2
 icalendar==6.3.1
@@ -852,8 +854,10 @@ openedx-filters==2.1.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.8
-    # via -r requirements/edx/kernel.in
+openedx-forum==0.4.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/edx/kernel.in
 openedx-learning==0.30.2
     # via
     #   -c requirements/constraints.txt
@@ -1189,6 +1193,8 @@ tqdm==4.67.1
     # via
     #   nltk
     #   openai
+typesense==2.0.0
+    # via openedx-forum
 typing-extensions==4.15.0
     # via
     #   aiosignal
@@ -1204,6 +1210,7 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   referencing
     #   snowflake-connector-python
+    #   typesense
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1077,6 +1077,7 @@ httpx[http2]==0.28.1
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   firebase-admin
+    #   typesense
 hyperframe==6.1.0
     # via
     #   -r requirements/edx/doc.txt
@@ -1411,8 +1412,9 @@ openedx-filters==2.1.0
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.8
+openedx-forum==0.4.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
 openedx-learning==0.30.2
@@ -2129,6 +2131,11 @@ types-pyyaml==6.0.12.20250915
     #   djangorestframework-stubs
 types-requests==2.32.4.20250913
     # via djangorestframework-stubs
+typesense==2.0.0
+    # via
+    #   -r requirements/edx/doc.txt
+    #   -r requirements/edx/testing.txt
+    #   openedx-forum
 typing-extensions==4.15.0
     # via
     #   -r requirements/edx/doc.txt
@@ -2155,6 +2162,7 @@ typing-extensions==4.15.0
     #   referencing
     #   snowflake-connector-python
     #   starlette
+    #   typesense
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -790,6 +790,7 @@ httpx[http2]==0.28.1
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
+    #   typesense
 hyperframe==6.1.0
     # via
     #   -r requirements/edx/base.txt
@@ -1028,8 +1029,10 @@ openedx-filters==2.1.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.8
-    # via -r requirements/edx/base.txt
+openedx-forum==0.4.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/edx/base.txt
 openedx-learning==0.30.2
     # via
     #   -c requirements/constraints.txt
@@ -1503,6 +1506,10 @@ tqdm==4.67.1
     #   -r requirements/edx/base.txt
     #   nltk
     #   openai
+typesense==2.0.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   openedx-forum
 typing-extensions==4.15.0
     # via
     #   -r requirements/edx/base.txt
@@ -1520,6 +1527,7 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   referencing
     #   snowflake-connector-python
+    #   typesense
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -827,6 +827,7 @@ httpx[http2]==0.28.1
     # via
     #   -r requirements/edx/base.txt
     #   firebase-admin
+    #   typesense
 hyperframe==6.1.0
     # via
     #   -r requirements/edx/base.txt
@@ -1074,8 +1075,10 @@ openedx-filters==2.1.0
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.8
-    # via -r requirements/edx/base.txt
+openedx-forum==0.4.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/edx/base.txt
 openedx-learning==0.30.2
     # via
     #   -c requirements/constraints.txt
@@ -1578,6 +1581,10 @@ tqdm==4.67.1
     #   -r requirements/edx/base.txt
     #   nltk
     #   openai
+typesense==2.0.0
+    # via
+    #   -r requirements/edx/base.txt
+    #   openedx-forum
 typing-extensions==4.15.0
     # via
     #   -r requirements/edx/base.txt
@@ -1598,6 +1605,7 @@ typing-extensions==4.15.0
     #   referencing
     #   snowflake-connector-python
     #   starlette
+    #   typesense
     #   typing-inspection
 typing-inspection==0.4.2
     # via


### PR DESCRIPTION
## Summary

Bumps the `openedx-forum` pin from **0.3.8** to **0.4.1** on `release/ulmo` to backport the fix for the discussion-forum "pinned"-NULL sort bug.

- **Bug:** Threads sorted by *recent first* showed old threads above newer ones — the `pinned` column on `CommentThread` could be `NULL` (in addition to `0`/`1`), and SQL's NULL ordering scrambled the `ORDER BY -pinned, last_activity_at` result.
- **Upstream fix:** [openedx/forum#270](https://github.com/openedx/forum/pull/270) (commit `78b36e4`) — sets `default=False` on the `pinned` model field and backfills existing `NULL` rows via migration `0005_alter_commentthread_pinned`. Released as forum `0.4.1` on 2026-03-30.
- **User report:** https://discuss.openedx.org/t/discuss-forum-messages-order-not-organized-as-expected-in-teak/18665

Companion PR for `release/teak`: [#38709](https://github.com/openedx/edx-platform/pull/38709).

## What's in 0.3.8 → 0.4.1?

| forum tag | what it adds | safe for Ulmo? |
|---|---|---|
| 0.3.9 | Five small bug fixes (Mongo content_type, timestamps, MySQL read_states lookup, Forum V2 author field, build CI) | ✅ |
| 0.4.0 | MySQL backend N+1 / query optimizations (`select_related` / `prefetch_related`); backwards-compatible per commit message | ✅ |
| 0.4.1 | **The fix** + optional Typesense search backend (off by default) | ✅ |

## Why cap at 0.4.1?

A constraint `openedx-forum<=0.4.1` is added to `requirements/constraints.txt` to keep the Ulmo line on the safe side of two breaking releases:

| forum tag | change | safe for Ulmo? |
|---|---|---|
| 0.4.2 | Drops Python 3.11 support | ❌ if Ulmo still supports 3.11 |
| 0.4.3 | Removes the MongoDB backend | ❌ (Ulmo deployments may still use MongoDB) |

The constraint should be dropped on `master` / post-Ulmo release lines.

## Files changed

- `requirements/constraints.txt` — adds the `openedx-forum<=0.4.1` cap with an explanatory comment block.
- `requirements/edx/{base,development,testing,doc}.txt` — bumps the pinned `openedx-forum` line from 0.3.8 → 0.4.1, and adds the new transitive `typesense==2.0.0` dep that 0.4.1 pulls in.

`httpx`, `httpcore`, `h11`, and `anyio` (typesense's other transitive deps) are already pinned in `release/ulmo`'s `base.txt`, so the only new pin added is `typesense==2.0.0`.

If preferred, maintainers can re-run `make upgrade-package package=openedx-forum` to regenerate the compiled files canonically — the resulting diff should match this PR.

## Test plan

- [ ] Tutor Ulmo deployment running `openedx-forum==0.4.1` no longer shows old threads at the top of "recent first" sort.
- [ ] Forum migration `0005_alter_commentthread_pinned` applies cleanly and `pinned` column has no `NULL` rows after `manage.py lms migrate`.
- [ ] CI passes — `make upgrade-package package=openedx-forum` produces no further changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)