### PR TITLE
fix: add #page-notification to container_editor.html for XBlock error display

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -4756,3 +4756,20 @@ class TestXblockEditView(CourseTestCase):
 
         self.assertGreater(len(resource_links), 0, f"No CSS resources found in HTML. Found: {resource_links}")  # noqa: PT009  # pylint: disable=line-too-long
         self.assertGreater(len(script_sources), 0, f"No JS resources found in HTML. Found: {script_sources}")  # noqa: PT009  # pylint: disable=line-too-long
+
+    def test_xblock_edit_view_contains_page_notification(self):
+        """
+        The page-notification element is required for XBlock runtime error
+        notifications (e.g. ORA validation errors) to be visible to the user.
+        """
+        url = reverse_usage_url("xblock_edit_handler", self.video.location)
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)  # noqa: PT009
+
+        html_content = resp.content.decode(resp.charset)
+        soup = BeautifulSoup(html_content, "html.parser")
+        self.assertIsNotNone(  # noqa: PT009
+            soup.find(id="page-notification"),
+            "container_editor.html must include a #page-notification element "
+            "so that XBlock runtime error notifications are rendered.",
+        )

--- a/cms/templates/container_editor.html
+++ b/cms/templates/container_editor.html
@@ -100,6 +100,7 @@ from openedx.core.release import RELEASE_LINE
 </head>
 
 <body class="${static.dir_rtl()} <%block name='bodyclass'></%block> lang_${LANGUAGE_CODE} view-container">
+    <div id="page-notification"></div>
     <%static:js group='base_vendor' />
     <%static:webpack entry='commons' />
 


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

The container_editor.html template was missing a #page-notification element.
This template is used when the Course Authoring MFE opens legacy XBlock editors
(like ORA) in a ModalIframe via /xblock/{id}/action/edit. Without this element,
the NotificationView had no DOM target, causing XBlock runtime error notifications
(e.g. "Validation error: dates out of order") to fail silently on save.

Useful information to include:

- Which edX user roles will this change impact? Course Author
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).

<img width="1857" height="991" alt="image" src="https://github.com/user-attachments/assets/21c9a8e6-1c60-4fab-a091-c46809b6237f" />


- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

https://github.com/mitodl/hq/issues/11318

## Testing instructions



**Testing Instructions:**

1. Navigate to a course in Studio (via the Course Authoring MFE) and open a unit containing an ORA (Open Response Assessment) component, or create a new ORA problem

2. Click the **Edit** button on the ORA component to open the legacy editor modal.

3. In the ORA editor, configure step dates **out of order** — e.g., set a step's start date earlier than the previous step's start date.

4. Click **Save**.

5. **Expected (after fix):** A red error notification appears at the bottom of the editor modal with a message like *"OpenAssessment Save Error: Validation error: This step's start date cannot be earlier than the previous step's start date."* The XBlock data is **not** saved.

6. **Expected (before fix):** No error notification is shown. The save fails silently with no feedback to the user.

7. Verify that saving with **valid** dates still works correctly — the modal closes and the component refreshes.

## Deadline

"None"
