### PR TITLE
style: fix pylint and ruff issues in LTI nonce replay test

### DIFF
--- a/lms/djangoapps/lti_provider/tests/test_signature_validator.py
+++ b/lms/djangoapps/lti_provider/tests/test_signature_validator.py
@@ -123,16 +123,21 @@ class SignatureValidatorTest(TestCase):
             request.build_absolute_uri(), 'POST', body.encode('utf-8'), headers)
 
 
-@patch('lms.djangoapps.lti_provider.signature_validator.time.time', return_value=FIXED_TIMESTAMP)
 class TimestampAndNonceValidatorTest(CacheIsolationMixin, TestCase):
+    """
+    Tests for the validate_timestamp_and_nonce method in SignatureValidator.
+    """
+
     ENABLED_CACHES = ['default']
-    """
-    Tests for validate_timestamp_and_nonce. The clock is frozen via a class-level
-    patch so every test method receives a consistent `time.time` return value.
-    """
 
     def setUp(self):
         super().setUp()
+        patcher = patch(
+            'lms.djangoapps.lti_provider.signature_validator.time.time',
+            return_value=FIXED_TIMESTAMP,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
         self.validator = SignatureValidator(get_lti_consumer())
 
     def _call(self, timestamp, nonce, client_key='Consumer Key'):
@@ -140,29 +145,29 @@ class TimestampAndNonceValidatorTest(CacheIsolationMixin, TestCase):
             client_key, str(timestamp), nonce, request=None,
         )
 
-    def test_valid_timestamp_and_new_nonce(self, _mock_time):
+    def test_valid_timestamp_and_new_nonce(self):
         assert self._call(FIXED_TIMESTAMP, 'nonce-a')
 
-    def test_stale_timestamp_rejected(self, _mock_time):
+    def test_stale_timestamp_rejected(self):
         assert not self._call(FIXED_TIMESTAMP - 301, 'nonce-b')
 
-    def test_future_timestamp_rejected(self, _mock_time):
+    def test_future_timestamp_rejected(self):
         assert not self._call(FIXED_TIMESTAMP + 301, 'nonce-c')
 
-    def test_malformed_timestamp_rejected(self, _mock_time):
+    def test_malformed_timestamp_rejected(self):
         assert not self.validator.validate_timestamp_and_nonce(
             'Consumer Key', 'not-a-number', 'nonce-d', request=None,
         )
 
-    def test_replay_rejected(self, _mock_time):
+    def test_replay_rejected(self):
         assert self._call(FIXED_TIMESTAMP, 'nonce-e')
         assert not self._call(FIXED_TIMESTAMP, 'nonce-e')
 
-    def test_different_nonce_same_consumer_accepted(self, _mock_time):
+    def test_different_nonce_same_consumer_accepted(self):
         assert self._call(FIXED_TIMESTAMP, 'nonce-f1')
         assert self._call(FIXED_TIMESTAMP, 'nonce-f2')
 
-    def test_same_nonce_different_consumer_accepted(self, _mock_time):
+    def test_same_nonce_different_consumer_accepted(self):
         # Nonces are scoped per client_key; the same nonce string from two
         # different consumers must not block each other.
         assert self._call(FIXED_TIMESTAMP, 'nonce-g', client_key='Consumer Key')

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1576,16 +1576,19 @@ SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = ""
 SOCIAL_AUTH_SAML_SP_PRIVATE_KEY_DICT = {}
 SOCIAL_AUTH_SAML_SP_PUBLIC_CERT_DICT = {}
 
-# .. setting_name: SAML_METADATA_URL_ALLOW_PRIVATE_IPS
-# .. setting_default: False
-# .. setting_description: When False (the default), fetching SAML metadata from
+# .. toggle_name: SAML_METADATA_URL_ALLOW_PRIVATE_IPS
+# .. toggle_default: False
+# .. toggle_description: When False (the default), fetching SAML metadata from
 #   private IP address ranges (RFC 1918: 10.x, 172.16.x, 192.168.x) is blocked
 #   as a defense against SSRF attacks. Set to True only in deployments where the
 #   SAML Identity Provider is hosted on the same private network as the Open edX
 #   server. Note: loopback (127.x) and link-local (169.254.x) addresses remain
-#   blocked regardless of this setting. Operators are also encouraged to enforce
+#   blocked regardless of this toggle. Operators are also encouraged to enforce
 #   network-level egress filtering as a complementary control, particularly to
 #   cover hostname-based URLs that are not subject to IP validation.
+# .. toggle_implementation: DjangoSetting
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2026-04-24
 SAML_METADATA_URL_ALLOW_PRIVATE_IPS = False
 
 ########################### django-fernet-fields ###########################


### PR DESCRIPTION
Fixes pylint C0115 and ruff PT019 violations introduced in a previous fix. Backport of #38715 to release/ulmo.