### PR TITLE
fix: add missing org scope support in instructor dashboard

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -728,7 +728,7 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
         the AuthZ course authoring toggle is enabled.
         """
         _, _, authz_courses, legacy_courses = self._create_courses()
-        org_scope = OrgCourseOverviewGlobData(external_key='course-v1:Org1+*')
+        org_scope = OrgCourseOverviewGlobData.build_external_key("Org1")
         assign_role_to_user_in_scope(
             self.authorized_user.username,
             COURSE_STAFF.external_key,
@@ -761,7 +761,7 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
         authz_keys, _, _, _ = self._create_courses()
         # enable only the first and third course keys
         enabled_keys = {str(authz_keys[0]), str(authz_keys[2])}
-        org_scope = OrgCourseOverviewGlobData(external_key='course-v1:Org1+*')
+        org_scope = OrgCourseOverviewGlobData.build_external_key("Org1")
         assign_role_to_user_in_scope(
             self.authorized_user.username,
             COURSE_STAFF.external_key,
@@ -788,7 +788,7 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
         courses, `get_courses_accessible_to_user` should return an empty
         list.
         """
-        org_scope = OrgCourseOverviewGlobData(external_key='course-v1:Org2+*')
+        org_scope = OrgCourseOverviewGlobData.build_external_key("Org2")
         assign_role_to_user_in_scope(
             self.authorized_user.username,
             COURSE_STAFF.external_key,
@@ -810,8 +810,8 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
         """
         Verify that course overviews are fetched once with all authorized orgs.
         """
-        org_scope1 = OrgCourseOverviewGlobData(external_key='course-v1:Org1+*')
-        org_scope2 = OrgCourseOverviewGlobData(external_key='course-v1:Org2+*')
+        org_scope1 = OrgCourseOverviewGlobData.build_external_key("Org1")
+        org_scope2 = OrgCourseOverviewGlobData.build_external_key("Org2")
         assign_role_to_user_in_scope(
             self.authorized_user.username,
             COURSE_STAFF.external_key,

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -728,11 +728,10 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
         the AuthZ course authoring toggle is enabled.
         """
         _, _, authz_courses, legacy_courses = self._create_courses()
-        org_scope = OrgCourseOverviewGlobData.build_external_key("Org1")
         assign_role_to_user_in_scope(
             self.authorized_user.username,
             COURSE_STAFF.external_key,
-            org_scope.external_key,
+            OrgCourseOverviewGlobData.build_external_key("Org1"),
         )
 
         request = self._make_request(self.authorized_user)
@@ -761,11 +760,10 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
         authz_keys, _, _, _ = self._create_courses()
         # enable only the first and third course keys
         enabled_keys = {str(authz_keys[0]), str(authz_keys[2])}
-        org_scope = OrgCourseOverviewGlobData.build_external_key("Org1")
         assign_role_to_user_in_scope(
             self.authorized_user.username,
             COURSE_STAFF.external_key,
-            org_scope.external_key,
+            OrgCourseOverviewGlobData.build_external_key("Org1"),
         )
 
         request = self._make_request(self.authorized_user)
@@ -788,11 +786,10 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
         courses, `get_courses_accessible_to_user` should return an empty
         list.
         """
-        org_scope = OrgCourseOverviewGlobData.build_external_key("Org2")
         assign_role_to_user_in_scope(
             self.authorized_user.username,
             COURSE_STAFF.external_key,
-            org_scope.external_key,
+            OrgCourseOverviewGlobData.build_external_key("Org2"),
         )
 
         request = self._make_request(self.authorized_user)
@@ -810,17 +807,15 @@ class TestCourseListingAuthz(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase)
         """
         Verify that course overviews are fetched once with all authorized orgs.
         """
-        org_scope1 = OrgCourseOverviewGlobData.build_external_key("Org1")
-        org_scope2 = OrgCourseOverviewGlobData.build_external_key("Org2")
         assign_role_to_user_in_scope(
             self.authorized_user.username,
             COURSE_STAFF.external_key,
-            org_scope1.external_key,
+            OrgCourseOverviewGlobData.build_external_key("Org1"),
         )
         assign_role_to_user_in_scope(
             self.authorized_user.username,
             COURSE_STAFF.external_key,
-            org_scope2.external_key,
+            OrgCourseOverviewGlobData.build_external_key("Org2"),
         )
 
         request = self._make_request(self.authorized_user)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -930,6 +930,10 @@ def _get_legacy_accessible_courses_list(request: HttpRequest) -> set[CourseKey]:
             an organization
     """
     user = request.user
+    # Query CourseAccessRole directly instead of UserBasedRole.courses_with_role(),
+    # which merges legacy DB records with AuthZ assignments. AuthZ access is resolved
+    # separately in _get_authz_accessible_courses_list(). Exact role names (not
+    # RoleCache inheritance) exclude limited_staff, matching strict_role_checking().
     legacy_accesses = CourseAccessRole.objects.filter(
         user=user,
         role__in=[CourseInstructorRole.ROLE, CourseStaffRole.ROLE],

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -17,7 +17,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import FieldError, ImproperlyConfigured, PermissionDenied
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import QuerySet
-from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
+from django.http import Http404, HttpRequest, HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -67,6 +67,7 @@ from common.djangoapps.student.auth import (
     has_studio_write_access,
     is_content_creator,
 )
+from common.djangoapps.student.models.user import CourseAccessRole
 from common.djangoapps.student.roles import (
     CourseInstructorRole,
     CourseStaffRole,
@@ -903,20 +904,39 @@ def _get_authz_accessible_courses_list(request):
 
     return _get_course_keys_from_scopes(authz_scopes)
 
-def _get_legacy_accessible_courses_list(request):
+
+def _get_legacy_accessible_courses_list(request: HttpRequest) -> set[CourseKey]:
     """
-    List all courses available to the logged in user by
-    evaluating legacy Django group roles and organization-level access.
+    Resolve candidate course keys from legacy ``CourseAccessRole`` records.
+
+    Only database-backed legacy roles are considered. AuthZ-managed access,
+    including org-wide scopes, is resolved separately by
+    ``_get_authz_accessible_courses_list``.
+
+    Course-level roles (``instructor``, ``staff``) are mapped directly to their
+    course keys. Org-wide roles expand to every course in that organization via
+    a single ``CourseOverview.get_all_courses(orgs=...)`` query. The ``staff``
+    role is matched exactly, so ``limited_staff`` assignments are excluded.
+
+    Args:
+        request: The incoming HTTP request; ``request.user`` determines which
+            legacy role records are evaluated.
+
+    Returns:
+        set[CourseKey]: Course keys the user may access through legacy roles.
+
+    Raises:
+        AccessListFallback: If a legacy role record has neither a course key nor
+            an organization
     """
     user = request.user
-    instructor_courses = UserBasedRole(user, CourseInstructorRole.ROLE).courses_with_role()
-
-    with strict_role_checking():
-        staff_courses = UserBasedRole(user, CourseStaffRole.ROLE).courses_with_role()
+    legacy_accesses = CourseAccessRole.objects.filter(
+        user=user,
+        role__in=[CourseInstructorRole.ROLE, CourseStaffRole.ROLE],
+    )
 
     group_keys = set()
     org_accesses = set()
-    legacy_accesses = instructor_courses | staff_courses
 
     for access in legacy_accesses:
         if access.course_id is not None:

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -15,7 +15,7 @@ from opaque_keys.edx.django.models import CourseKeyField
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
 from openedx_authz.api import users as authz_api
-from openedx_authz.api.data import CourseOverviewData, RoleAssignmentData
+from openedx_authz.api.data import CourseOverviewData, OrgCourseOverviewGlobData, RoleAssignmentData
 from openedx_authz.constants import roles as authz_roles
 
 from common.djangoapps.student.models import CourseAccessRole
@@ -74,17 +74,6 @@ def authz_add_role(user: User, authz_role: str, course_key: str):
     legacy_role = get_legacy_role_from_authz_role(authz_role)
     emit_course_access_role_added(user, course_locator, course_locator.org, legacy_role)
 
-def authz_get_all_course_assignments_for_user(user: User) -> list[RoleAssignmentData]:
-    """
-    Get all course assignments for a user.
-    """
-    assignments = authz_api.get_user_role_assignments(user_external_key=user.username)
-    # filter courses only
-    filtered_assignments = [
-        assignment for assignment in assignments
-        if isinstance(assignment.scope, CourseOverviewData)
-    ]
-    return filtered_assignments
 
 def get_org_from_key(key: str) -> str:
     """
@@ -92,6 +81,7 @@ def get_org_from_key(key: str) -> str:
     """
     parsed_key = CourseKey.from_string(key)
     return parsed_key.org
+
 
 def register_access_role(cls):
     """
@@ -141,34 +131,108 @@ class AuthzCompatCourseAccessRole:
     """
     Generic data class for storing CourseAccessRole-compatible data
     to be used inside BulkRoleCache and RoleCache.
+
     This allows the cache to store both legacy and openedx-authz compatible roles
     """
     user_id: int
     username: str
     org: str
-    course_id: str  # Course key
+    course_id: str | None
     role: str
+
+
+def authz_get_all_course_assignments_for_user(user: User) -> list[RoleAssignmentData]:
+    """
+    Return AuthZ role assignments for a user that apply to courses.
+
+    Includes assignments scoped to a specific course (``CourseOverviewData``) and
+    assignments scoped to all courses in an organization (``OrgCourseOverviewGlobData``).
+    Assignments for other resource types, such as content libraries, are excluded.
+
+    Args:
+        user (User): The user whose AuthZ role assignments should be retrieved.
+
+    Returns:
+        list[RoleAssignmentData]: Role assignments whose scope is course-level or org-wide
+    """
+    assignments = authz_api.get_user_role_assignments(user_external_key=user.username)
+    return [
+        assignment
+        for assignment in assignments
+        if isinstance(assignment.scope, CourseOverviewData | OrgCourseOverviewGlobData)
+    ]
+
+
+def _compat_roles_from_authz_assignment(
+    user: User,
+    assignment: RoleAssignmentData,
+) -> set[AuthzCompatCourseAccessRole]:
+    """
+    Convert an AuthZ role assignment into legacy-compatible course access roles.
+
+    Course-scoped assignments produce roles tied to a specific course key.
+    Org-wide assignments produce org-level roles with no course key (``course_id``
+    is ``None``), matching legacy ``OrgStaffRole`` / ``OrgInstructorRole`` behavior.
+    AuthZ roles without a legacy mapping are skipped.
+
+    Args:
+        user (User): The user associated with the assignment.
+        assignment (RoleAssignmentData): A single AuthZ role assignment, including
+            its scope and assigned roles.
+
+    Returns:
+        set[AuthzCompatCourseAccessRole]: Legacy-compatible role records for the
+            assignment. Returns an empty set if the scope is unsupported, the org
+            is missing for an org-wide assignment, or no roles could be mapped.
+    """
+    scope = assignment.scope
+    if isinstance(scope, CourseOverviewData):
+        course_id = scope.external_key
+        org = get_org_from_key(course_id)
+    elif isinstance(scope, OrgCourseOverviewGlobData):
+        org = scope.org
+        if not org:
+            return set()
+        course_id = None
+    else:
+        return set()
+
+    compat_roles = set()
+    for role in assignment.roles:
+        legacy_role = get_legacy_role_from_authz_role(authz_role=role.external_key)
+        if legacy_role is None:
+            continue
+        compat_roles.add(
+            AuthzCompatCourseAccessRole(
+                user_id=user.id,
+                username=user.username,
+                org=org,
+                course_id=course_id,
+                role=legacy_role,
+            )
+        )
+    return compat_roles
 
 
 def get_authz_compat_course_access_roles_for_user(user: User) -> set[AuthzCompatCourseAccessRole]:
     """
-    Retrieve all CourseAccessRole objects for a given user and convert them to AuthzCompatCourseAccessRole objects.
+    Retrieve AuthZ course and org role assignments for a user in legacy format.
+
+    Fetches all course-level and org-wide AuthZ assignments for the user and
+    converts each one into ``AuthzCompatCourseAccessRole`` records suitable for
+    ``RoleCache`` and other legacy permission checks.
+
+    Args:
+        user (User): The user whose AuthZ role assignments should be converted.
+
+    Returns:
+        set[AuthzCompatCourseAccessRole]: Legacy-compatible role records derived
+            from the user's AuthZ assignments. Returns an empty set if the user
+            has no applicable assignments.
     """
     compat_role_assignments = set()
-    assignments = authz_get_all_course_assignments_for_user(user)
-    for assignment in assignments:
-        for role in assignment.roles:
-            legacy_role = get_legacy_role_from_authz_role(authz_role=role.external_key)
-            course_key = assignment.scope.external_key
-            org = get_org_from_key(course_key)
-            compat_role = AuthzCompatCourseAccessRole(
-                user_id=user.id,
-                username=user.username,
-                org=org,
-                course_id=course_key,
-                role=legacy_role
-            )
-            compat_role_assignments.add(compat_role)
+    for assignment in authz_get_all_course_assignments_for_user(user):
+        compat_role_assignments.update(_compat_roles_from_authz_assignment(user, assignment))
     return compat_role_assignments
 
 
@@ -843,11 +907,9 @@ class UserBasedRole:
         """
         Return a set of AuthzCompatCourseAccessRole for all of the courses with this user x (or derived from x) role.
         """
+        # Get all assignments for a user to a role
         roles = RoleCache.get_roles(self.role)
         legacy_assignments = CourseAccessRole.objects.filter(role__in=roles, user=self.user)
-
-        # Get all assignments for a user to a role
-        new_authz_roles = [get_authz_role_from_legacy_role(role) for role in roles]
         all_authz_user_assignments = authz_get_all_course_assignments_for_user(self.user)
 
         all_assignments = set()
@@ -863,19 +925,9 @@ class UserBasedRole:
                 ))
 
         for assignment in all_authz_user_assignments:
-            for role in assignment.roles:
-                if role.external_key not in new_authz_roles:
-                    continue
-                legacy_role = get_legacy_role_from_authz_role(authz_role=role.external_key)
-                course_key = assignment.scope.external_key
-                org = get_org_from_key(course_key)
-                all_assignments.add(AuthzCompatCourseAccessRole(
-                    user_id=self.user.id,
-                    username=self.user.username,
-                    org=org,
-                    course_id=course_key,
-                    role=legacy_role
-                ))
+            for compat_role in _compat_roles_from_authz_assignment(self.user, assignment):
+                if compat_role.role in roles:
+                    all_assignments.add(compat_role)
 
         return all_assignments
 
@@ -899,18 +951,12 @@ class UserBasedRole:
             return True
 
         # Then check for authz assignments
-        new_authz_roles = [get_authz_role_from_legacy_role(role) for role in roles]
         all_authz_user_assignments = authz_get_all_course_assignments_for_user(self.user)
 
         for assignment in all_authz_user_assignments:
-            for role in assignment.roles:
-                if role.external_key not in new_authz_roles:
+            for compat_role in _compat_roles_from_authz_assignment(self.user, assignment):
+                if compat_role.role not in roles:
                     continue
-                if org is None:
-                    # There is at least one assignment, short circuit
-                    return True
-                course_key = assignment.scope.external_key
-                parsed_org = get_org_from_key(course_key)
-                if org == parsed_org:
+                if org is None or org == compat_role.org:
                     return True
         return False

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -176,12 +176,10 @@ def authz_get_all_course_assignments_for_user(user: User) -> list[RoleAssignment
     Returns:
         list[RoleAssignmentData]: Role assignments whose scope is course-level or org-wide
     """
-    assignments = authz_api.get_user_role_assignments(user_external_key=user.username)
-    return [
-        assignment
-        for assignment in assignments
-        if isinstance(assignment.scope, CourseOverviewData | OrgCourseOverviewGlobData)
-    ]
+    return authz_api.get_user_role_assignments_per_scope_type(
+        user_external_key=user.username,
+        scope_types=(CourseOverviewData, OrgCourseOverviewGlobData),
+    )
 
 
 def _compat_roles_from_authz_assignment(

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -141,6 +141,27 @@ class AuthzCompatCourseAccessRole:
     role: str
 
 
+def _get_org_and_course_id_from_authz_scope(
+    scope: CourseOverviewData | OrgCourseOverviewGlobData,
+) -> tuple[str, str | None] | None:
+    """
+    Extract the org and course key from an AuthZ course assignment scope.
+
+    Course-scoped assignments return ``(org, course_external_key)``.
+    Org-wide assignments return ``(org, None)``.
+
+    Returns ``None`` when the org cannot be determined. For org-wide scopes,
+    ``OrgGlobData.org`` is typed as ``str | None`` because it is parsed from
+    ``external_key`` and returns ``None`` for malformed glob patterns.
+    """
+    if isinstance(scope, CourseOverviewData):
+        course_id = scope.external_key
+        return get_org_from_key(course_id), course_id
+    if isinstance(scope, OrgCourseOverviewGlobData):
+        return scope.org, None
+    return None
+
+
 def authz_get_all_course_assignments_for_user(user: User) -> list[RoleAssignmentData]:
     """
     Return AuthZ role assignments for a user that apply to courses.
@@ -182,20 +203,13 @@ def _compat_roles_from_authz_assignment(
 
     Returns:
         set[AuthzCompatCourseAccessRole]: Legacy-compatible role records for the
-            assignment. Returns an empty set if the scope is unsupported, the org
-            is missing for an org-wide assignment, or no roles could be mapped.
+            assignment. Returns an empty set if the org cannot be determined from
+            the scope or no roles could be mapped.
     """
-    scope = assignment.scope
-    if isinstance(scope, CourseOverviewData):
-        course_id = scope.external_key
-        org = get_org_from_key(course_id)
-    elif isinstance(scope, OrgCourseOverviewGlobData):
-        org = scope.org
-        if not org:
-            return set()
-        course_id = None
-    else:
+    org_and_course_id = _get_org_and_course_id_from_authz_scope(assignment.scope)
+    if org_and_course_id is None:
         return set()
+    org, course_id = org_and_course_id
 
     compat_roles = set()
     for role in assignment.roles:

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -319,20 +319,24 @@ class RolesTestCase(TestCase):
         with patch("openedx_authz.api.users.get_user_role_assignments", return_value=[assignment]):
             result = get_authz_compat_course_access_roles_for_user(self.student)
 
-        assert result == {
-            AuthzCompatCourseAccessRole(
-                user_id=self.student.id,
-                username=self.student.username,
-                org="OpenedX",
-                course_id=None,
-                role="instructor",
-            )
-        }
+        self.assertCountEqual(  # noqa: PT009
+            result,
+            {
+                AuthzCompatCourseAccessRole(
+                    user_id=self.student.id,
+                    username=self.student.username,
+                    org="OpenedX",
+                    course_id=None,
+                    role="instructor",
+                )
+            },
+        )
 
     def test_org_scope_authz_role_grants_instructor_dashboard_permissions(self):
         """
         Org-wide AuthZ course_admin should grant legacy org instructor access used by the instructor dashboard.
         """
+        # pylint: disable=protected-access
         course_key = CourseKey.from_string("course-v1:OpenedX+DemoX+DemoCourse")
         org_scope = OrgCourseOverviewGlobData(external_key="course-v1:OpenedX+*")
         assignment = RoleAssignmentData(
@@ -343,12 +347,12 @@ class RolesTestCase(TestCase):
         with patch("openedx_authz.api.users.get_user_role_assignments", return_value=[assignment]):
             if hasattr(self.student, "_roles"):
                 del self.student._roles
-            cache = RoleCache(self.student)
+            self.student._roles = RoleCache(self.student)
 
-        assert cache.has_role("instructor", None, "OpenedX")
-        assert OrgInstructorRole("OpenedX").has_user(self.student)
-        assert self.student.has_perm(instructor_permissions.VIEW_DASHBOARD, course_key)
-        assert self.student.has_perm(instructor_permissions.SHOW_TASKS, course_key)
+        self.assertTrue(self.student._roles.has_role("instructor", None, "OpenedX"))  # noqa: PT009
+        self.assertTrue(OrgInstructorRole("OpenedX").has_user(self.student)) # noqa: PT009
+        self.assertTrue(self.student.has_perm(instructor_permissions.VIEW_DASHBOARD, course_key)) # noqa: PT009
+        self.assertTrue(self.student.has_perm(instructor_permissions.SHOW_TASKS, course_key)) # noqa: PT009
 
 
 @ddt.ddt

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -10,7 +10,14 @@ from django.test import TestCase
 from edx_toggles.toggles.testutils import override_waffle_flag
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator
-from openedx_authz.api.data import ContentLibraryData, CourseOverviewData, RoleAssignmentData, RoleData, UserData
+from openedx_authz.api.data import (
+    ContentLibraryData,
+    CourseOverviewData,
+    OrgCourseOverviewGlobData,
+    RoleAssignmentData,
+    RoleData,
+    UserData,
+)
 from openedx_authz.constants.roles import COURSE_ADMIN, COURSE_STAFF
 from openedx_authz.engine.enforcer import AuthzEnforcer
 
@@ -39,6 +46,7 @@ from common.djangoapps.student.roles import (
     get_role_cache_key_for_course,
 )
 from common.djangoapps.student.tests.factories import AnonymousUserFactory, InstructorFactory, StaffFactory, UserFactory
+from lms.djangoapps.instructor import permissions as instructor_permissions
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.toggles import AUTHZ_COURSE_AUTHORING_FLAG
 
@@ -297,6 +305,50 @@ class RolesTestCase(TestCase):
         ):
             result = get_authz_compat_course_access_roles_for_user(self.student)
         assert result == set()
+
+    def test_get_authz_compat_course_access_roles_for_user_org_scope(self):
+        """
+        Org-wide AuthZ assignments should map to legacy org-level course access roles.
+        """
+        org_scope = OrgCourseOverviewGlobData(external_key="course-v1:OpenedX+*")
+        assignment = RoleAssignmentData(
+            subject=UserData(external_key=self.student.username),
+            roles=[RoleData(external_key=COURSE_ADMIN.external_key)],
+            scope=org_scope,
+        )
+        with patch("openedx_authz.api.users.get_user_role_assignments", return_value=[assignment]):
+            result = get_authz_compat_course_access_roles_for_user(self.student)
+
+        assert result == {
+            AuthzCompatCourseAccessRole(
+                user_id=self.student.id,
+                username=self.student.username,
+                org="OpenedX",
+                course_id=None,
+                role="instructor",
+            )
+        }
+
+    def test_org_scope_authz_role_grants_instructor_dashboard_permissions(self):
+        """
+        Org-wide AuthZ course_admin should grant legacy org instructor access used by the instructor dashboard.
+        """
+        course_key = CourseKey.from_string("course-v1:OpenedX+DemoX+DemoCourse")
+        org_scope = OrgCourseOverviewGlobData(external_key="course-v1:OpenedX+*")
+        assignment = RoleAssignmentData(
+            subject=UserData(external_key=self.student.username),
+            roles=[RoleData(external_key=COURSE_ADMIN.external_key)],
+            scope=org_scope,
+        )
+        with patch("openedx_authz.api.users.get_user_role_assignments", return_value=[assignment]):
+            if hasattr(self.student, "_roles"):
+                del self.student._roles
+            cache = RoleCache(self.student)
+
+        assert cache.has_role("instructor", None, "OpenedX")
+        assert OrgInstructorRole("OpenedX").has_user(self.student)
+        assert self.student.has_perm(instructor_permissions.VIEW_DASHBOARD, course_key)
+        assert self.student.has_perm(instructor_permissions.SHOW_TASKS, course_key)
 
 
 @ddt.ddt

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -16,6 +16,7 @@ from openedx_authz.api.data import (
     OrgCourseOverviewGlobData,
     RoleAssignmentData,
     RoleData,
+    ScopeData,
     UserData,
 )
 from openedx_authz.constants.roles import COURSE_ADMIN, COURSE_STAFF
@@ -310,11 +311,12 @@ class RolesTestCase(TestCase):
         """
         Org-wide AuthZ assignments should map to legacy org-level course access roles.
         """
-        org_scope = OrgCourseOverviewGlobData.build_external_key("OpenedX")
         assignment = RoleAssignmentData(
             subject=UserData(external_key=self.student.username),
             roles=[RoleData(external_key=COURSE_ADMIN.external_key)],
-            scope=org_scope,
+            scope=ScopeData(
+                external_key=OrgCourseOverviewGlobData.build_external_key("OpenedX"),
+            ),
         )
         with patch("openedx_authz.api.users.get_user_role_assignments", return_value=[assignment]):
             result = get_authz_compat_course_access_roles_for_user(self.student)
@@ -338,11 +340,12 @@ class RolesTestCase(TestCase):
         """
         # pylint: disable=protected-access
         course_key = CourseKey.from_string("course-v1:OpenedX+DemoX+DemoCourse")
-        org_scope = OrgCourseOverviewGlobData.build_external_key("OpenedX")
         assignment = RoleAssignmentData(
             subject=UserData(external_key=self.student.username),
             roles=[RoleData(external_key=COURSE_ADMIN.external_key)],
-            scope=org_scope,
+            scope=ScopeData(
+                external_key=OrgCourseOverviewGlobData.build_external_key("OpenedX"),
+            ),
         )
         with patch("openedx_authz.api.users.get_user_role_assignments", return_value=[assignment]):
             if hasattr(self.student, "_roles"):
@@ -350,9 +353,9 @@ class RolesTestCase(TestCase):
             self.student._roles = RoleCache(self.student)
 
         self.assertTrue(self.student._roles.has_role("instructor", None, "OpenedX"))  # noqa: PT009
-        self.assertTrue(OrgInstructorRole("OpenedX").has_user(self.student)) # noqa: PT009
-        self.assertTrue(self.student.has_perm(instructor_permissions.VIEW_DASHBOARD, course_key)) # noqa: PT009
-        self.assertTrue(self.student.has_perm(instructor_permissions.SHOW_TASKS, course_key)) # noqa: PT009
+        self.assertTrue(OrgInstructorRole("OpenedX").has_user(self.student))  # noqa: PT009
+        self.assertTrue(self.student.has_perm(instructor_permissions.VIEW_DASHBOARD, course_key))  # noqa: PT009
+        self.assertTrue(self.student.has_perm(instructor_permissions.SHOW_TASKS, course_key))  # noqa: PT009
 
 
 @ddt.ddt

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -310,7 +310,7 @@ class RolesTestCase(TestCase):
         """
         Org-wide AuthZ assignments should map to legacy org-level course access roles.
         """
-        org_scope = OrgCourseOverviewGlobData(external_key="course-v1:OpenedX+*")
+        org_scope = OrgCourseOverviewGlobData.build_external_key("OpenedX")
         assignment = RoleAssignmentData(
             subject=UserData(external_key=self.student.username),
             roles=[RoleData(external_key=COURSE_ADMIN.external_key)],
@@ -338,7 +338,7 @@ class RolesTestCase(TestCase):
         """
         # pylint: disable=protected-access
         course_key = CourseKey.from_string("course-v1:OpenedX+DemoX+DemoCourse")
-        org_scope = OrgCourseOverviewGlobData(external_key="course-v1:OpenedX+*")
+        org_scope = OrgCourseOverviewGlobData.build_external_key("OpenedX")
         assignment = RoleAssignmentData(
             subject=UserData(external_key=self.student.username),
             roles=[RoleData(external_key=COURSE_ADMIN.external_key)],

--- a/openedx/core/djangoapps/course_groups/permissions.py
+++ b/openedx/core/djangoapps/course_groups/permissions.py
@@ -5,7 +5,8 @@ Permissions for cohorts API
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import permissions
 
-from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, GlobalStaff
+from common.djangoapps.student.roles import GlobalStaff
+from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.discussion.django_comment_client.utils import get_user_role_names
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
@@ -23,15 +24,15 @@ class IsStaffOrAdmin(permissions.BasePermission):
         """Returns true if the user is admin or staff and request method is GET."""
         if GlobalStaff().has_user(request.user) or request.user.is_superuser:
             return True
-        course_key = CourseKey.from_string(view.kwargs.get('course_key_string'))
+        course_key = CourseKey.from_string(view.kwargs.get("course_key_string"))
         user_roles = get_user_role_names(request.user, course_key)
-        has_discussion_privileges = bool(user_roles & {
-            FORUM_ROLE_ADMINISTRATOR,
-            FORUM_ROLE_MODERATOR,
-            FORUM_ROLE_COMMUNITY_TA,
-        })
-        return (
-            CourseInstructorRole(course_key).has_user(request.user) or
-            CourseStaffRole(course_key).has_user(request.user) or
-            has_discussion_privileges and request.method == "GET"
+        has_discussion_privileges = bool(
+            user_roles
+            & {
+                FORUM_ROLE_ADMINISTRATOR,
+                FORUM_ROLE_MODERATOR,
+                FORUM_ROLE_COMMUNITY_TA,
+            }
         )
+        has_course_team_access = has_access(request.user, "staff", course_key).has_access
+        return has_course_team_access or has_discussion_privileges and request.method == "GET"

--- a/openedx/core/djangoapps/course_groups/permissions.py
+++ b/openedx/core/djangoapps/course_groups/permissions.py
@@ -6,7 +6,7 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework import permissions
 
 from common.djangoapps.student.roles import GlobalStaff
-from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.access import administrative_accesses_to_course_for_user
 from lms.djangoapps.discussion.django_comment_client.utils import get_user_role_names
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
@@ -34,5 +34,5 @@ class IsStaffOrAdmin(permissions.BasePermission):
                 FORUM_ROLE_COMMUNITY_TA,
             }
         )
-        has_course_team_access = has_access(request.user, "staff", course_key).has_access
-        return has_course_team_access or has_discussion_privileges and request.method == "GET"
+        _, staff_access, instructor_access = administrative_accesses_to_course_for_user(request.user, course_key)
+        return staff_access or instructor_access or (has_discussion_privileges and request.method == "GET")


### PR DESCRIPTION
## Description

This PR extends the legacy role compatibility layer to support AuthZ role assignments with org-wide scopes (`OrgCourseOverviewGlobData`, e.g., `course-v1:OpenedX+*`). Previously, AuthZ roles were only mapped when the scope was a specific course (`CourseOverviewData`). Users with organization-level permissions did not receive access in code paths that rely on the legacy role system.

Additionally, it fixes a bug in the legacy role system where roles assigned at the org level were also not working correctly, only course-level roles.

### Additional Information

* `has_access(..., "staff", course_key)` already considers `OrgStaffRole` and `OrgInstructorRole` via `administrative_accesses_to_course_for_user`, which is why it is the correct check for APIs such as cohorts.
* `_get_legacy_accessible_courses_list` was modified since `UserBasedRole.courses_with_role()` was not reading only legacy data, but was merging AuthZ permissions. The direct query to `CourseAccessRole` ensures that only legacy assignments are retrieved.

## Supporting information

- https://github.com/openedx/wg-build-test-release/issues/591

## Testing instructions

> [!NOTE]
>  Perform the test using both the legacy system and the new RBAC system.

1. Assign the **Admin role** to a user at the organization level:
    * If you are using the legacy system, you can only do this from the **Django Admin** at `{lms_domain}/admin/student/courseaccessrole`.
    * If you are using the RBAC system, you can do this from the **Admin Console** in **Studio**.
2. Assign the **Staff role** to a user at the organization level. Follow the same instructions as the previous step.
3. Go to the **Instructor Dashboard** of any of the courses that belong to the organization. You should be able to access it without any issues.
4. Go to **Cohorts**, you should be able to enable/disable the feature or create a Cohort without any issues.
5. You can also check using **Dev Tools** > **Network** to verify that all requests are working and not returning a **403** error.

## Screenshots

### Before

<img width="2401" height="1300" alt="image" src="https://github.com/user-attachments/assets/25c90c0c-329d-469b-b02b-8162e170bb09" />

### After

<img width="2401" height="1300" alt="image" src="https://github.com/user-attachments/assets/53544f8b-544d-4ff0-8512-064f472fe0da" />

## Deadline

Verawood
