### PR TITLE
chore: remove web_fragments dependency, bump requirements

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -84,5 +84,5 @@ sympy==1.14.0
     # via
     #   -r requirements/edx-sandbox/base.in
     #   openedx-calc
-tqdm==4.68.3
+tqdm==4.68.4
     # via nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -119,7 +119,7 @@ chardet==7.4.3
     # via
     #   encutils
     #   pysrt
-charset-normalizer==3.4.8
+charset-normalizer==3.4.9
     # via
     #   requests
     #   snowflake-connector-python
@@ -173,7 +173,7 @@ defusedxml==0.7.1
     #   python3-openid
     #   social-auth-core
     #   xblocks-contrib
-django==5.2.15
+django==5.2.16
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -834,7 +834,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.20.0
+openedx-authz==1.20.1
     # via -r requirements/edx/kernel.in
 openedx-calc==5.0.0
     # via
@@ -1207,7 +1207,7 @@ tomlkit==0.15.0
     # via
     #   openedx-core
     #   snowflake-connector-python
-tqdm==4.68.3
+tqdm==4.68.4
     # via nltk
 typesense==2.0.0
     # via
@@ -1270,8 +1270,6 @@ wcmatch==10.2.1
     # via pycasbin
 wcwidth==0.8.2
     # via prompt-toolkit
-web-fragments==4.0.0
-    # via -r requirements/edx/kernel.in
 webencodings==0.5.1
     # via
     #   bleach

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -218,7 +218,7 @@ chardet==7.4.3
     #   diff-cover
     #   encutils
     #   pysrt
-charset-normalizer==3.4.8
+charset-normalizer==3.4.9
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -337,7 +337,7 @@ distlib==0.4.3
     # via
     #   -r requirements/edx/testing.txt
     #   virtualenv
-django==5.2.15
+django==5.2.16
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -1374,7 +1374,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.20.0
+openedx-authz==1.20.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2138,7 +2138,7 @@ tomlkit==0.15.0
     #   snowflake-connector-python
 tox==4.56.2
     # via -r requirements/edx/testing.txt
-tqdm==4.68.3
+tqdm==4.68.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
@@ -2261,10 +2261,6 @@ wcwidth==0.8.2
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   prompt-toolkit
-web-fragments==4.0.0
-    # via
-    #   -r requirements/edx/doc.txt
-    #   -r requirements/edx/testing.txt
 webencodings==0.5.1
     # via
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -169,7 +169,7 @@ chardet==7.4.3
     #   -r requirements/edx/base.txt
     #   encutils
     #   pysrt
-charset-normalizer==3.4.8
+charset-normalizer==3.4.9
     # via
     #   -r requirements/edx/base.txt
     #   requests
@@ -237,7 +237,7 @@ defusedxml==0.7.1
     #   python3-openid
     #   social-auth-core
     #   xblocks-contrib
-django==5.2.15
+django==5.2.16
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -1012,7 +1012,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.20.0
+openedx-authz==1.20.1
     # via -r requirements/edx/base.txt
 openedx-calc==5.0.0
     # via
@@ -1522,7 +1522,7 @@ tomlkit==0.15.0
     #   -r requirements/edx/base.txt
     #   openedx-core
     #   snowflake-connector-python
-tqdm==4.68.3
+tqdm==4.68.4
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1606,8 +1606,6 @@ wcwidth==0.8.2
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
-web-fragments==4.0.0
-    # via -r requirements/edx/base.txt
 webencodings==0.5.1
     # via
     #   -r requirements/edx/base.txt

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -153,7 +153,6 @@ sortedcontainers                    # Provides SortedKeyList, used for lists of 
 stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins
 unicodecsv                          # Easier support for CSV files with unicode text
 webob
-web-fragments                       # Provides the ability to render fragments of web pages
 wrapt                               # Better functools.wrapped. TODO: functools has since improved, maybe we can switch?
 XBlock[django]                      # Courseware component architecture
 xss-utils                           # https://github.com/openedx/edx-platform/pull/20633 Fix XSS via Translations

--- a/requirements/edx/semgrep.txt
+++ b/requirements/edx/semgrep.txt
@@ -32,7 +32,7 @@ certifi==2026.6.17
     #   requests
 cffi==2.1.0
     # via cryptography
-charset-normalizer==3.4.8
+charset-normalizer==3.4.9
     # via requests
 click==8.1.8
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -168,7 +168,7 @@ chardet==7.4.3
     #   diff-cover
     #   encutils
     #   pysrt
-charset-normalizer==3.4.8
+charset-normalizer==3.4.9
     # via
     #   -r requirements/edx/base.txt
     #   requests
@@ -258,7 +258,7 @@ dill==0.4.1
     # via pylint
 distlib==0.4.3
     # via virtualenv
-django==5.2.15
+django==5.2.16
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -1052,7 +1052,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.20.0
+openedx-authz==1.20.1
     # via -r requirements/edx/base.txt
 openedx-calc==5.0.0
     # via
@@ -1597,7 +1597,7 @@ tomlkit==0.15.0
     #   snowflake-connector-python
 tox==4.56.2
     # via -r requirements/edx/testing.in
-tqdm==4.68.3
+tqdm==4.68.4
     # via
     #   -r requirements/edx/base.txt
     #   nltk
@@ -1686,8 +1686,6 @@ wcwidth==0.8.2
     # via
     #   -r requirements/edx/base.txt
     #   prompt-toolkit
-web-fragments==4.0.0
-    # via -r requirements/edx/base.txt
 webencodings==0.5.1
     # via
     #   -r requirements/edx/base.txt

--- a/scripts/user_retirement/requirements/base.txt
+++ b/scripts/user_retirement/requirements/base.txt
@@ -22,7 +22,7 @@ cffi==2.1.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.8
+charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via
@@ -32,7 +32,7 @@ cryptography==49.0.0
     # via
     #   google-auth
     #   pyjwt
-django==5.2.15
+django==5.2.16
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt

--- a/scripts/user_retirement/requirements/testing.txt
+++ b/scripts/user_retirement/requirements/testing.txt
@@ -33,7 +33,7 @@ cffi==2.1.0
     #   -r scripts/user_retirement/requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.8
+charset-normalizer==3.4.9
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   requests
@@ -49,7 +49,7 @@ cryptography==49.0.0
     #   pyjwt
 ddt==1.7.2
     # via -r scripts/user_retirement/requirements/testing.in
-django==5.2.15
+django==5.2.16
     # via
     #   -r scripts/user_retirement/requirements/base.txt
     #   django-crum

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -6,7 +6,7 @@
 #
 certifi==2026.6.17
     # via requests
-charset-normalizer==3.4.8
+charset-normalizer==3.4.9
     # via requests
 idna==3.18
     # via requests


### PR DESCRIPTION
## Description

This merge request removes `web_fragments` as a direct dependency and upgrades XBlock. It also upgrades packages generally since the dependencies were recalculated.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

1. Set up a devstack (or wait for the sandbox) with this branch
1. Create the standard blocks in studio and publish them in a course
2. View them in the LMS and verify they render as expected.