### PR TITLE
fix: course import when lib block is synced

### DIFF
--- a/xmodule/modulestore/tests/test_xml_importer.py
+++ b/xmodule/modulestore/tests/test_xml_importer.py
@@ -9,6 +9,7 @@ import unittest
 from unittest import mock
 from uuid import uuid4
 
+from django.core.exceptions import ObjectDoesNotExist
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from path import Path as path
@@ -18,7 +19,7 @@ from xblock.runtime import DictKeyValueStore, KvsFieldData, Runtime
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.modulestore.tests.mongo_connection import MONGO_HOST, MONGO_PORT_NUM
-from xmodule.modulestore.xml_importer import StaticContentImporter, _update_block_location
+from xmodule.modulestore.xml_importer import StaticContentImporter, _update_and_import_block, _update_block_location
 from xmodule.tests import DATA_DIR
 from xmodule.x_module import XModuleMixin
 
@@ -257,3 +258,143 @@ class StaticContentImporterTest(unittest.TestCase):  # pylint: disable=missing-c
             )
             mock_file.assert_called_with(full_file_path, 'rb')
             self.mocked_content_store.generate_thumbnail.assert_called_once()
+
+
+class UpdateAndImportBlockLibraryContentTest(unittest.TestCase):
+    """
+    Tests for the library_content special-case handling inside _update_and_import_block.
+
+    Covers the bug where importing a course containing a library_content block into a
+    fresh environment (first import, library exists on dest) failed with:
+        KeyError: BlockKey(type='problem', id='...')
+    because sync_from_library was called on the published block (wrong branch) and with
+    a source-environment library version GUID that does not exist on the destination.
+    """
+
+    def _make_block(self, block_type='library_content', source_library_id='TestOrg+TestLib',
+                    source_library_version='aabbcc112233', has_children=True):
+        """Build a minimal mock block with the attributes _update_and_import_block needs."""
+        block = mock.MagicMock()
+        # block.location must be a MagicMock (not a real OpaqueKey) so its
+        # attributes can be freely set. Real OpaqueKeys are immutable.
+        block.location.block_type = block_type
+        block.location.block_id = 'test_lib_content'
+        block.source_library_id = source_library_id
+        block.source_library_version = source_library_version
+        block.source_library_key = mock.MagicMock()
+        block.fields = {}
+        block.get_asides.return_value = []
+        block.has_children = has_children
+        return block
+
+    def _make_store(self, branch_setting=ModuleStoreEnum.Branch.published_only,
+                    block_already_published=False, library_exists=True):
+        """Build a minimal mock store."""
+        store = mock.MagicMock()
+        store.get_branch_setting.return_value = branch_setting
+        store.branch_setting.return_value.__enter__ = mock.Mock(return_value=None)
+        store.branch_setting.return_value.__exit__ = mock.Mock(return_value=False)
+        store.has_item.return_value = block_already_published
+        store.get_library.return_value = mock.MagicMock() if library_exists else None
+
+        # import_xblock returns the published block (as split_draft does under published_only)
+        published_location = mock.MagicMock()
+        published_location.block_type = 'library_content'
+
+        published_block = mock.MagicMock()
+        published_block.location = published_location
+        published_block.location.block_type = 'library_content'
+        published_block.source_library_id = 'TestOrg+TestLib'
+        published_block.source_library_key = mock.MagicMock()
+        store.import_xblock.return_value = published_block
+
+        # get_item(draft_location) returns a draft block with sync_from_library available
+        draft_block = mock.MagicMock()
+        store.get_item.return_value = draft_block
+
+        return store, published_block, draft_block
+
+    def _call(self, source_block, store):
+        course_key = CourseLocator('TestOrg', 'TestCourse', '2026_T1')
+        return _update_and_import_block(
+            block=source_block,
+            store=store,
+            user_id=1,
+            source_course_id=course_key,
+            dest_course_id=course_key,
+            do_import_static=False,
+            runtime=mock.MagicMock(),
+        )
+
+    def test_first_import_syncs_draft_block_with_upgrade_to_latest(self):
+        """
+        On first import (block not yet published), sync_from_library must be called
+        on the DRAFT block with upgrade_to_latest=True so that copy_from_template
+        creates child blocks in the draft structure before publish() is called.
+        """
+        source_block = self._make_block()
+        store, published_block, draft_block = self._make_store(block_already_published=False)
+
+        self._call(source_block, store)
+
+        # Must fetch the draft block explicitly
+        store.get_item.assert_called_once_with(
+            published_block.location.for_branch(ModuleStoreEnum.BranchName.draft)
+        )
+        # Must call sync with upgrade_to_latest=True (not the source version GUID)
+        draft_block.sync_from_library.assert_called_once_with(upgrade_to_latest=True)
+
+    def test_first_import_publishes_after_sync(self):
+        """
+        After a successful sync on first import, the block must be published.
+        """
+        source_block = self._make_block()
+        store, published_block, _draft_block = self._make_store(block_already_published=False)
+
+        self._call(source_block, store)
+
+        store.publish.assert_called_once_with(published_block.location, 1)
+
+    def test_reimport_skips_sync_when_already_published(self):
+        """
+        When the library_content block already exists in the published branch
+        (re-import scenario), sync_from_library must NOT be called.
+        """
+        source_block = self._make_block()
+        store, _published_block, draft_block = self._make_store(block_already_published=True)
+
+        self._call(source_block, store)
+
+        draft_block.sync_from_library.assert_not_called()
+        store.publish.assert_not_called()
+
+    def test_no_sync_when_library_missing_on_destination(self):
+        """
+        If the library does not exist on the destination, neither sync_from_library
+        nor publish should be called.
+        """
+        source_block = self._make_block()
+        store, _published_block, draft_block = self._make_store(
+            block_already_published=False, library_exists=False
+        )
+
+        self._call(source_block, store)
+
+        draft_block.sync_from_library.assert_not_called()
+        store.publish.assert_not_called()
+
+    def test_object_does_not_exist_during_sync_is_handled(self):
+        """
+        If sync_from_library raises ObjectDoesNotExist, the inner except swallows it.
+        The outer try/except ValueError completes normally, so its else clause runs
+        and publish IS still called. The import must not raise.
+        """
+        source_block = self._make_block()
+        store, published_block, draft_block = self._make_store(block_already_published=False)
+        draft_block.sync_from_library.side_effect = ObjectDoesNotExist("library not found")
+
+        # Should not raise
+        self._call(source_block, store)
+
+        # Outer else runs even though inner sync failed → publish is called
+        store.publish.assert_called_once_with(published_block.location, 1)

--- a/xmodule/modulestore/xml_importer.py
+++ b/xmodule/modulestore/xml_importer.py
@@ -952,7 +952,10 @@ def _update_and_import_block(  # pylint: disable=too-many-statements
                 # Update library content block's children on draft branch
                 with store.branch_setting(branch_setting=ModuleStoreEnum.Branch.draft_preferred):
                     try:
-                        block.sync_from_library()
+                        draft_block = store.get_item(
+                            block.location.for_branch(ModuleStoreEnum.BranchName.draft)
+                            )
+                        draft_block.sync_from_library(upgrade_to_latest=True)
                     except ObjectDoesNotExist:
                         # If the source library does not exist, that's OK, the library content will still kinda work.
                         # Unfortunately, any setting defaults that are set in the library will be missing.


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Fixes a crash when importing a course containing a `library_content` block into an environment where that course does not yet exist, but the referenced v1 library does.

## Problem

When exporting a course from one environment (e.g. production) and importing it into another (e.g. RC/staging) **for the first time**, the import fails with:

```
KeyError: BlockKey(type='problem', id='...')
BlockFailedToImport: Failed to import block: <name> at location: i4x://.../library_content/...
```


This only occurs when all three conditions are met simultaneously:

1. The `library_content` block had its children synced from the library **before export** (so the exported XML contains child problem block IDs)
2. This is the **first import** of the course to the destination (the `library_content` block has never been published there)
3. The referenced v1 library **exists** on the destination

## Root Cause

The `_update_and_import_block` function in `xml_importer.py` has special-case handling for `library_content` blocks. During a course import, children are imported under the `published_only` branch setting. `split_draft.import_xblock` under this setting imports the block to the **draft** branch and then immediately publishes it with `blacklist=EXCLUDE_ALL` (no children). It returns the **published** block.

Two bugs compounded:

**Bug 1 — sync called on wrong branch:**
`sync_from_library()` was called on the returned published block. The `trigger_library_sync` Celery task calls `store.get_item(dest_block.scope_ids.usage_id)` — since the usage ID already carries `branch=published`, `_map_revision_to_branch` ignores the surrounding `draft_preferred` branch setting and fetches the published block. `copy_from_template` then creates child blocks only in the **published** structure. When `store.publish()` subsequently copies from draft → published, the draft structure has a dangling child reference (from the XML import) but no actual block entry for it, causing the `KeyError`.

**Bug 2 — stale library version GUID:**
Even after fixing Bug 1 (calling `sync_from_library` on the draft block), the sync still silently failed. `sync_from_library()` without `upgrade_to_latest=True` passes `source_library_version` — a MongoDB ObjectId from the **source** environment's database — to `trigger_library_sync`. That version GUID does not exist in the destination's MongoDB, so `get_library(...for_version(source_version_guid))` raises `ItemNotFoundError` → `ObjectDoesNotExist`, which is swallowed by the inner `except ObjectDoesNotExist: pass`. The `else` block then proceeds to call `store.publish()` on a draft structure that still has only dangling child references — same crash.

## Fix

Two changes to `_update_and_import_block` in `xmodule/modulestore/xml_importer.py`:

1. Explicitly fetch the **draft** block and call `sync_from_library` on it, so `copy_from_template` populates child blocks in the draft structure (not the published structure).
2. Pass `upgrade_to_latest=True` so the library is resolved against the **destination** environment's current library head, rather than attempting to look up a version GUID from the source environment that will never exist on the destination.

```python
# Before
with store.branch_setting(branch_setting=ModuleStoreEnum.Branch.draft_preferred):
    try:
        block.sync_from_library()
    except ObjectDoesNotExist:
        pass

# After
with store.branch_setting(branch_setting=ModuleStoreEnum.Branch.draft_preferred):
    try:
        draft_block = store.get_item(
            block.location.for_branch(ModuleStoreEnum.BranchName.draft)
        )
        draft_block.sync_from_library(upgrade_to_latest=True)
    except ObjectDoesNotExist:
        pass
```

After these fixes, `copy_from_template` correctly creates child problem blocks in the draft structure, and the subsequent `store.publish()` can recursively copy them from draft → published without a KeyError.

Notes
- The upgrade_to_latest=True behaviour on first import is safe and intentional: the existing guard if lib_content_block_already_published: return block ensures subsequent re-imports skip the sync entirely, preserving student state.
- This is a first-import-only code path. Re-imports of a course that already has a published library_content block are completely unaffected.

## Testing instructions
To reproduce the bug (before the fix), we need to have 2 open edx instances:

- Create a v1 legacy library with at least one problem block
- Create a course with a library_content unit pointing to that library
- Click "Update Now" in Studio to sync the library content block (this populates children in the draft structure)
- Export the course as a .tar.gz
- Export the library and import on the second instance
- Import the course .tar.gz on second instance → import fails with BlockFailedToImport
- To verify the fix:
  - Repeat the steps above with the fix applied → import succeeds
  - Verify the library_content block is visible and functional in Studio after import
  - Re-importing the same course a second time should also succeed.
