### PR TITLE
feat!: drop DCS_SESSION_COOKIE_SAMESITE legacy setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -245,6 +245,20 @@ Tutor-based deployments satisfy this requirement automatically. For bare-metal
 or custom deployments, verify that ``CACHES['default']`` points at a shared
 Redis or Memcached instance before enabling these features.
 
+Session Cookie SameSite
+=======================
+
+Open edX's LMS <-> Studio SSO flow relies on the session cookie being sent
+on cross-site requests, which requires ``SESSION_COOKIE_SAMESITE = 'None'``.
+This is set automatically when ``lms/envs/production.py`` is loaded.
+
+If you run an LMS *without* loading ``production.py`` (e.g. a stripped-down
+setup that loads only ``lms/envs/common.py``), set ``SESSION_COOKIE_SAMESITE
+= 'None'`` in your settings yourself. ``SameSite=None`` cookies also require
+``SESSION_COOKIE_SECURE = True`` and HTTPS, so over plain HTTP use ``'Lax'``
+instead — in that case some cross-site flows (notably Studio SSO) will not
+work.
+
 .. _lms/djangoapps/lti_provider/README.rst: lms/djangoapps/lti_provider/README.rst
 
 License

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -989,10 +989,6 @@ PYTHON_LIB_FILENAME = 'python_lib.zip'
 
 ############################### DJANGO BUILT-INS ###############################
 
-# django-session-cookie middleware
-DCS_SESSION_COOKIE_SAMESITE = 'None'
-DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL = True
-
 # LMS base
 LMS_BASE = 'localhost:18000'
 

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -474,9 +474,10 @@ if ENABLE_ENTERPRISE_INTEGRATION:
 
 #####################################################################
 
-# django-session-cookie middleware
-DCS_SESSION_COOKIE_SAMESITE = 'Lax'
-DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL = True
+# Override production's 'None' -- devstack runs over plain HTTP, and browsers
+# silently drop SameSite=None cookies that aren't also Secure, which breaks
+# session login.
+SESSION_COOKIE_SAMESITE = 'Lax'
 
 ########################## THEMING  #######################
 # If you want to enable theming in devstack, uncomment this section and add any relevant

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -132,9 +132,10 @@ if STATIC_URL_BASE:  # noqa: F405
 
 DATA_DIR = path(DATA_DIR)  # noqa: F405
 
-# TODO: This was for backwards compatibility back when installed django-cookie-samesite (not since 2022).
-#       The DCS_ version of the setting can be DEPR'd at this point.
-SESSION_COOKIE_SAMESITE = DCS_SESSION_COOKIE_SAMESITE  # noqa: F405
+# Required to be 'None' so the session cookie is sent on cross-site requests
+# (e.g. LMS <-> Studio SSO). Browsers reject SameSite=None unless the cookie
+# is also Secure, so production deployments must serve over HTTPS.
+SESSION_COOKIE_SAMESITE = 'None'
 
 for feature, value in _YAML_TOKENS.get('FEATURES', {}).items():
     FEATURES[feature] = value


### PR DESCRIPTION
## Summary

Removes the `DCS_SESSION_COOKIE_SAMESITE` and `DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL` settings, holdovers from the [`django-cookies-samesite`](https://pypi.org/project/django-cookies-samesite/) library that was removed from `openedx-platform` in [Sept 2021 (commit 708dbb71ec)](https://github.com/openedx/openedx-platform/commit/708dbb71ec450350525a77c400274985756d23a7) when we upgraded to Django 3.2 and its native [`SESSION_COOKIE_SAMESITE`](https://docs.djangoproject.com/en/4.2/ref/settings/#session-cookie-samesite) support. Closes the existing `TODO` in `lms/envs/production.py` line 135.

- `lms/envs/production.py` now sets `SESSION_COOKIE_SAMESITE = 'None'` directly (preserving current production behavior — required for cross-site OAuth/SSO between LMS and Studio).
- `DCS_`-prefixed settings are deleted from `lms/envs/common.py` and `lms/envs/devstack.py`.
- Non-production envs (tests, devstack-without-production-overlay) continue to use Django's `'Lax'` default — same as their prior effective behavior, since the `DCS_` value in `common.py` was only ever read by `production.py`'s aliasing line.
- README's "Security Deployment Requirements" section gains a note for bare-metal operators who load `common.py` directly: they must set `SESSION_COOKIE_SAMESITE = 'None'` themselves for Studio SSO to work.

DEPR ticket: https://github.com/openedx/openedx-platform/issues/38757

## Breaking change

Operators who set `DCS_SESSION_COOKIE_SAMESITE` in their `LMS_CFG` YAML or private settings module must rename the key to `SESSION_COOKIE_SAMESITE`. `DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL` can be deleted; it has been a no-op since 2021.
