### PR TITLE
docs: align studio SSO client-id with SOCIAL_AUTH_EDX_OAUTH2_KEY default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ Set up CMS SSO (for Development)::
       --skip-authorization \
       --redirect-uris 'http://localhost:18010/complete/edx-oauth2/' \
       --scopes user_id  \
-      --client-id 'studio-sso-id' \
+      --client-id 'studio-sso-key' \
       --client-secret 'studio-sso-secret'
 
 Set up CMS SSO (for Production):
@@ -158,17 +158,17 @@ Set up CMS SSO (for Production):
 * Create the CMS user and the OAuth application::
 
     ./manage.py lms manage_user studio_worker <email@yourcompany.com> --unusable-password
-    ./manage.py lms create_dot_application studio-sso-id studio_worker \
+    ./manage.py lms create_dot_application studio-sso-key studio_worker \
         --grant-type authorization-code \
         --skip-authorization \
         --redirect-uris 'http://localhost:18010/complete/edx-oauth2/' \
         --scopes user_id
 
 * Log into Django admin (eg. http://localhost:18000/admin/oauth2_provider/application/),
-  click into the application you created above (``studio-sso-id``), and copy its "Client secret".
+  click into the application you created above (``studio-sso-key``), and copy its "Client secret".
 * In your private LMS_CFG yaml file or your private Django settings module:
 
- * Set ``SOCIAL_AUTH_EDX_OAUTH2_KEY`` to the client ID (``studio-sso-id``).
+ * Set ``SOCIAL_AUTH_EDX_OAUTH2_KEY`` to the client ID (``studio-sso-key``).
  * Set ``SOCIAL_AUTH_EDX_OAUTH2_SECRET`` to the client secret (which you copied).
 
 Run the Platform


### PR DESCRIPTION
## Summary

Renames the example client ID in the README's CMS SSO setup section from `studio-sso-id` to `studio-sso-key`, so that the value matches the current default for `SOCIAL_AUTH_EDX_OAUTH2_KEY` in `cms/envs/devstack.py:277` (`SOCIAL_AUTH_EDX_OAUTH2_KEY = 'studio-sso-key'`).

A first-time bare-metal operator following the README would have ended up with a client ID that doesn't match the CMS's default, so they would have to override `SOCIAL_AUTH_EDX_OAUTH2_KEY` in their settings overrides. After this change, the README's example values work out-of-the-box with the CMS default.