### PR TITLE
build: suppress per-shard pytest coverage table in unit-tests CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -121,8 +121,12 @@ jobs:
       - name: run tests
         shell: bash
         run: |
-          python -Wd -m pytest -p no:randomly --ds=${{ env.settings_path }} ${{ env.unit_test_paths }} --cov=. \
-            ${{ env.report_log_arg }}
+          # --cov-report="" suppresses the per-shard terminal coverage table
+          # (~3.7k lines of noise). The .coverage data file is still written and
+          # uploaded as an artifact for the combined `coverage` job below, which
+          # is what reports to codecov.
+          python -Wd -m pytest -p no:randomly --ds=${{ env.settings_path }} ${{ env.unit_test_paths }} \
+            --cov=. --cov-report="" ${{ env.report_log_arg }}
 
       - name: Upload pytest timing report
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Summary

Each unit-test shard was printing a ~3,700-line per-file coverage table at the end of its log (default `--cov=.` behavior is `--cov-report=term`). On a failing run, that table sits between the test progress dots and the end of the log, making it tedious to scroll to the failure summary. The numbers are also misleading per shard, since each shard runs only a subset of the suite.

The dedicated `coverage` job in this same workflow already does the meaningful work: it downloads every shard's `.coverage` artifact, runs `coverage combine` + `coverage report` + `coverage xml`, and pushes the combined result to codecov.

Passing `--cov-report=""` to pytest disables only the terminal coverage report. The `.coverage` data file is still written and uploaded as an artifact, so the `coverage` job and codecov reporting are unaffected.

## What changed

- `.github/workflows/unit-tests.yml`: add `--cov-report=""` to the `pytest` invocation in the `run tests` step, with an inline comment explaining the intent.

## What this does NOT change

- The `.coverage` data file is still produced and uploaded as an artifact.
- The `coverage` job still combines all shard artifacts and uploads to codecov.
- Pytest's own short test summary (the `FAILED ...` lines) is unchanged — it will now sit near the bottom of each shard's log instead of being buried above a 3.7k-line table.

Motivated by trying to debug failures in #38763, where the failing-test lines were drowned out by per-shard coverage tables.