### PR TITLE
fix: clean up deprecation warnings in unit-test output

### DIFF
--- a/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
@@ -724,7 +724,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             created_by=self.user.id,
         )
         child_version_1 = content_api.create_next_component_version(
-            child_component_1.pk,
+            child_component_1.id,
             media_to_replace={},
             created=timezone.now(),
             created_by=self.user.id,
@@ -740,7 +740,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             created_by=self.user.id,
         )
         child_version_2 = content_api.create_next_component_version(
-            child_component_2.pk,
+            child_component_2.id,
             media_to_replace={},
             created=timezone.now(),
             created_by=self.user.id,
@@ -805,7 +805,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
                 self.assertEqual(container_version.title, f"Test {block_type.title()}")  # noqa: PT009
                 # The container is left as a draft; publishing is the caller's
                 # responsibility (handled in _import_structure after bulk_draft_changes_for exits).
-                self.assertTrue(content_api.contains_unpublished_changes(container_version.container.pk))  # noqa: PT009  # pylint: disable=line-too-long
+                self.assertTrue(content_api.contains_unpublished_changes(container_version.container.id))  # noqa: PT009  # pylint: disable=line-too-long
 
     def test_migrate_container_same_title(self):
         """
@@ -913,7 +913,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
                 created_by=self.user.id,
             )
             child_version = content_api.create_next_component_version(
-                child_component.pk,
+                child_component.id,
                 media_to_replace={},
                 created=timezone.now(),
                 created_by=self.user.id,
@@ -953,7 +953,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             created_by=self.user.id,
         )
         problem_version = content_api.create_next_component_version(
-            problem_component.pk,
+            problem_component.id,
             media_to_replace={},
             created=timezone.now(),
             created_by=self.user.id,
@@ -969,7 +969,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             created_by=self.user.id,
         )
         html_version = content_api.create_next_component_version(
-            html_component.pk,
+            html_component.id,
             media_to_replace={},
             created=timezone.now(),
             created_by=self.user.id,
@@ -985,7 +985,7 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
             created_by=self.user.id,
         )
         video_version = content_api.create_next_component_version(
-            video_component.pk,
+            video_component.id,
             media_to_replace={},
             created=timezone.now(),
             created_by=self.user.id,

--- a/cms/lib/xblock/test/test_upstream_sync.py
+++ b/cms/lib/xblock/test/test_upstream_sync.py
@@ -293,7 +293,7 @@ class UpstreamTestCase(ModuleStoreTestCase):
         downstream.attempts_before_showanswer_button = 2
         downstream.due = datetime.datetime(2025, 2, 2, tzinfo=datetime.timezone.utc)  # noqa: UP017
         downstream.force_save_button = True
-        downstream.graceperiod = '2d'
+        downstream.graceperiod = datetime.timedelta(days=2)
         downstream.grading_method = 'last_score'
         downstream.max_attempts = 100
         downstream.show_correctness = 'always'
@@ -321,7 +321,7 @@ class UpstreamTestCase(ModuleStoreTestCase):
         assert downstream.attempts_before_showanswer_button == 2
         assert downstream.due == datetime.datetime(2025, 2, 2, tzinfo=datetime.timezone.utc)  # noqa: UP017
         assert downstream.force_save_button
-        assert downstream.graceperiod == '2d'
+        assert downstream.graceperiod == datetime.timedelta(days=2)
         assert downstream.grading_method == 'last_score'
         assert downstream.max_attempts == 100
         assert downstream.show_correctness == 'always'

--- a/cms/lib/xblock/upstream_sync_block.py
+++ b/cms/lib/xblock/upstream_sync_block.py
@@ -198,8 +198,8 @@ def _update_tags(*, upstream: XBlock, downstream: XBlock) -> None:
     # For any block synced with an upstream, copy the tags as read_only
     # This keeps tags added locally.
     copy_tags_as_read_only(
-        str(upstream.location),
-        str(downstream.location),
+        str(upstream.scope_ids.usage_id),
+        str(downstream.scope_ids.usage_id),
     )
 
 

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -268,7 +268,7 @@ class CourseMode(models.Model):
         if self.id is None:
             # If this model has no primary key at save time, it needs to be force-inserted.
             force_insert = True
-        super().save(force_insert, force_update, using)
+        super().save(force_insert=force_insert, force_update=force_update, using=using)
 
     @property
     def slug(self):

--- a/openedx/core/djangoapps/agreements/models.py
+++ b/openedx/core/djangoapps/agreements/models.py
@@ -125,7 +125,8 @@ class UserAgreement(models.Model):  # noqa: DJ008
         app_label = "agreements"
         constraints = [
             models.CheckConstraint(
-                check=models.Q(text__isnull=False) | models.Q(url__isnull=False), name="agreement_has_text_or_url"
+                condition=models.Q(text__isnull=False) | models.Q(url__isnull=False),
+                name="agreement_has_text_or_url",
             )
         ]
 

--- a/openedx/core/djangoapps/content/block_structure/models.py
+++ b/openedx/core/djangoapps/content/block_structure/models.py
@@ -5,7 +5,7 @@ Models used by the block structure framework.
 
 import errno
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from logging import getLogger
 
 from django.conf import settings
@@ -57,7 +57,7 @@ def _path_name(bs_model, _filename):
     Returns path name to use for the given
     BlockStructureModel instance.
     """
-    filename = datetime.utcnow().strftime('%Y-%m-%d-%H:%M:%S-%f')
+    filename = datetime.now(UTC).strftime('%Y-%m-%d-%H:%M:%S-%f')
     return _create_path(
         _directory_name(bs_model.data_usage_key),
         filename,

--- a/openedx/core/djangoapps/session_inactivity_timeout/middleware.py
+++ b/openedx/core/djangoapps/session_inactivity_timeout/middleware.py
@@ -14,7 +14,7 @@ which defaults to 1209600 (2 weeks, in seconds).
 
 
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from django.conf import settings
 from django.contrib import auth
@@ -45,7 +45,7 @@ class SessionInactivityTimeout(MiddlewareMixin):
         # .. setting_warning:  Keep in sync with SESSION_COOKIE_AGE and must be larger than SESSION_ACTIVITY_SAVE_DELAY_SECONDS.
         timeout_in_seconds = getattr(settings, "SESSION_INACTIVITY_TIMEOUT_IN_SECONDS", None)
 
-        current_time = datetime.utcnow()
+        current_time = datetime.now(UTC)
         # Do we have this feature enabled?
         if timeout_in_seconds:
             # .. setting_name: SESSION_ACTIVITY_SAVE_DELAY_SECONDS

--- a/openedx/core/djangoapps/session_inactivity_timeout/tests/test_middleware.py
+++ b/openedx/core/djangoapps/session_inactivity_timeout/tests/test_middleware.py
@@ -54,7 +54,7 @@ class SessionInactivityTimeoutTestCase(TestCase):
         # else: leave the session without the timestamp key (None case)
 
         mock_now = datetime(2025, 6, 16, 12, 0, 0)
-        mock_datetime.utcnow.return_value = mock_now
+        mock_datetime.now.return_value = mock_now
 
         response = self.middleware.process_request(self.request)  # pylint: disable=assignment-from-none
 
@@ -108,7 +108,7 @@ class SessionInactivityTimeoutTestCase(TestCase):
             last_touch = datetime(2025, 6, 16, 12, 0, 0)
             current_time = last_touch + timedelta(seconds=seconds_elapsed)
             self.request.session[LAST_TOUCH_KEYNAME] = last_touch.isoformat()
-            mock_datetime.utcnow.return_value = current_time
+            mock_datetime.now.return_value = current_time
             mock_datetime.fromisoformat = datetime.fromisoformat
 
             response = self.middleware.process_request(self.request)  # pylint: disable=assignment-from-none
@@ -151,7 +151,7 @@ class SessionInactivityTimeoutTestCase(TestCase):
             last_touch = datetime(2025, 6, 16, 12, 0, 0)
             current_time = last_touch + timedelta(seconds=seconds_elapsed)
             self.request.session[LAST_TOUCH_KEYNAME] = last_touch.isoformat()
-            mock_datetime.utcnow.return_value = current_time
+            mock_datetime.now.return_value = current_time
             mock_datetime.fromisoformat = datetime.fromisoformat
 
             response = self.middleware.process_request(self.request)  # pylint: disable=assignment-from-none
@@ -191,7 +191,7 @@ class SessionInactivityTimeoutTestCase(TestCase):
         last_touch = datetime(2025, 6, 16, 12, 0, 0)
         current_time = last_touch + timedelta(seconds=seconds_elapsed)
         self.request.session[LAST_TOUCH_KEYNAME] = last_touch.isoformat()
-        mock_datetime.utcnow.return_value = current_time
+        mock_datetime.now.return_value = current_time
         mock_datetime.fromisoformat = datetime.fromisoformat
 
         response = self.middleware.process_request(self.request)  # pylint: disable=assignment-from-none

--- a/openedx/core/lib/xblock_serializer/block_serializer.py
+++ b/openedx/core/lib/xblock_serializer/block_serializer.py
@@ -42,10 +42,10 @@ class XBlockSerializer:
 
         self.olx_str = etree.tostring(self.olx_node, encoding="unicode", pretty_print=True)
 
-        course_key = self.orig_block_key.course_key
+        context_key = self.orig_block_key.context_key
         # Search the OLX for references to files stored in the course's
         # "Files & Uploads" (contentstore):
-        self.olx_str = utils.rewrite_absolute_static_urls(self.olx_str, course_key)
+        self.olx_str = utils.rewrite_absolute_static_urls(self.olx_str, context_key)
 
         runtime_supports_explicit_assets = hasattr(block.runtime, 'get_block_assets')
         if runtime_supports_explicit_assets:
@@ -58,17 +58,17 @@ class XBlockSerializer:
             # Otherwise, we have to scan the content to extract associated asset
             # by inference. This is what we have to do for Modulestore-backed
             # courses, which store files a course-global "Files and Uploads".
-            for asset in utils.collect_assets_from_text(self.olx_str, course_key):
+            for asset in utils.collect_assets_from_text(self.olx_str, context_key):
                 path = asset['path']
                 if path not in [sf.name for sf in self.static_files]:
                     self.static_files.append(StaticFile(name=path, url=asset['url'], data=None))
 
             if block.scope_ids.usage_id.block_type in ['problem', 'vertical']:
-                py_lib_zip_file = utils.get_python_lib_zip_if_using(self.olx_str, course_key)
+                py_lib_zip_file = utils.get_python_lib_zip_if_using(self.olx_str, context_key)
                 if py_lib_zip_file:
                     self.static_files.append(py_lib_zip_file)
 
-                js_input_files = utils.get_js_input_files_if_using(self.olx_str, course_key)
+                js_input_files = utils.get_js_input_files_if_using(self.olx_str, context_key)
                 for js_input_file in js_input_files:
                     self.static_files.append(js_input_file)
 


### PR DESCRIPTION
First pass at cleaning up the deprecation warnings flooding the pytest "warnings summary" in CI. One commit per warning class.

Covered: `datetime.utcnow()`, `block.location`, opaque-key `.course_key`, `CheckConstraint(check=)`, positional `save()` args, `.pk` on TypedBigAutoField models, and a `graceperiod = '2d'` test value.

Not in this PR (separate follow-ups):
- `FEATURES as a dict is deprecated` — 96% of in-repo volume; ~252 call sites to migrate.
- `LibraryLocator.run` (7 sites) and `Runtime.user_id` (2 sites) — need case-by-case analysis.
- `ContentLibraryPermission … deprecated` — intentional migration, tracked in #37409.