### PR TITLE
feat: migrate callers off FEATURES-as-dict access

### DIFF
--- a/cms/djangoapps/cms_user_tasks/tests.py
+++ b/cms/djangoapps/cms_user_tasks/tests.py
@@ -4,7 +4,6 @@ Unit tests for integration of the django-user-tasks app and its REST API.
 import json
 import logging
 from unittest import mock
-from unittest.mock import patch
 from uuid import uuid4
 
 import botocore
@@ -254,7 +253,7 @@ class TestUserTaskStopped(APITestCase):
             *self.olx_validations['warnings']
         ]
 
-        with patch.dict(settings.FEATURES, ENABLE_COURSE_OLX_VALIDATION=True):
+        with override_settings(ENABLE_COURSE_OLX_VALIDATION=True):
             user_task_stopped.send(sender=UserTaskStatus, status=self.status)
             msg = mail.outbox[0]
 
@@ -277,12 +276,12 @@ class TestUserTaskStopped(APITestCase):
         msg = mail.outbox[0]
 
         # Verify olx validation is not enabled out of the box.
-        self.assertFalse(settings.FEATURES.get('ENABLE_COURSE_OLX_VALIDATION'))  # noqa: PT009
+        self.assertFalse(settings.ENABLE_COURSE_OLX_VALIDATION)  # noqa: PT009
         self.assertEqual(len(mail.outbox), 1)  # noqa: PT009
         self.assert_msg_subject(msg)
         self.assert_msg_body_fragments(msg, body_fragments)
 
-    @patch.dict(settings.FEATURES, ENABLE_COURSE_OLX_VALIDATION=True)
+    @override_settings(ENABLE_COURSE_OLX_VALIDATION=True)
     @override_waffle_flag(BYPASS_OLX_FAILURE, active=True)
     def test_email_sent_with_olx_validations_with_bypass_flag(self):
         """

--- a/cms/djangoapps/contentstore/api/tests/test_validation.py
+++ b/cms/djangoapps/contentstore/api/tests/test_validation.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 
 import ddt
 import factory
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -106,8 +105,7 @@ class CourseValidationViewTest(SharedModuleStoreTestCase, APITestCase):
     )
     @ddt.unpack
     def test_staff_succeeds(self, certs_html_view, with_modes):
-        features = dict(settings.FEATURES, CERTIFICATES_HTML_VIEW=certs_html_view)
-        with override_settings(FEATURES=features):
+        with override_settings(CERTIFICATES_HTML_VIEW=certs_html_view):
             if with_modes:
                 CourseModeFactory.create_batch(
                     2,

--- a/cms/djangoapps/contentstore/exams.py
+++ b/cms/djangoapps/contentstore/exams.py
@@ -27,7 +27,7 @@ def register_exams(course_key):
     Likewise, if formerly registered exams are not included in the payload they will
     be marked inactive by the exam service.
     """
-    if not settings.FEATURES.get('ENABLE_SPECIAL_EXAMS') or not exams_ida_enabled(course_key):
+    if not settings.ENABLE_SPECIAL_EXAMS or not exams_ida_enabled(course_key):
         # if feature is not enabled then do a quick exit
         return
 

--- a/cms/djangoapps/contentstore/proctoring.py
+++ b/cms/djangoapps/contentstore/proctoring.py
@@ -35,7 +35,7 @@ def register_special_exams(course_key):
     subsystem. Likewise, if formerly registered exams are unmarked, then those
     registered exams are marked as inactive
     """
-    if not settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+    if not settings.ENABLE_SPECIAL_EXAMS:
         # if feature is not enabled then do a quick exit
         return
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/home.py
@@ -90,7 +90,7 @@ class HomePageView(APIView):
             ),
             'studio_name': settings.STUDIO_NAME,
             'studio_short_name': settings.STUDIO_SHORT_NAME,
-            'studio_request_email': settings.FEATURES.get('STUDIO_REQUEST_EMAIL', ''),
+            'studio_request_email': settings.STUDIO_REQUEST_EMAIL,
             'tech_support_email': settings.TECH_SUPPORT_EMAIL,
             'platform_name': settings.PLATFORM_NAME,
             'user_is_active': request.user.is_active,

--- a/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/settings.py
@@ -117,7 +117,7 @@ class CourseSettingsView(DeveloperErrorViewMixin, APIView):
                 'course_display_name': course_block.display_name,
                 'course_display_name_with_default': course_block.display_name_with_default,
                 'platform_name': settings.PLATFORM_NAME,
-                'licensing_enabled': settings.FEATURES.get("LICENSING", False),
+                'licensing_enabled': settings.LICENSING,
             })
 
             serializer = CourseSettingsSerializer(settings_context)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_proctoring.py
@@ -4,7 +4,6 @@ Unit tests for Contentstore Proctored Exam Settings.
 from unittest.mock import patch
 
 import ddt
-from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
@@ -272,9 +271,7 @@ class ProctoringExamSettingsPostTests(
     )
     def test_update_exam_settings_invalid_value(self):
         self.client.login(username=self.global_staff.username, password=self.password)
-        PROCTORED_EXAMS_ENABLED_FEATURES = settings.FEATURES
-        PROCTORED_EXAMS_ENABLED_FEATURES["ENABLE_PROCTORED_EXAMS"] = True
-        with override_settings(FEATURES=PROCTORED_EXAMS_ENABLED_FEATURES):
+        with override_settings(ENABLE_PROCTORED_EXAMS=True):
             data = self.get_request_data(
                 enable_proctored_exams=True,
                 proctoring_provider="notvalidprovider",
@@ -366,42 +363,38 @@ class ProctoringExamSettingsPostTests(
     @override_waffle_flag(EXAMS_IDA, active=True)
     def test_200_for_lti_provider(self):
         self.client.login(username=self.global_staff.username, password=self.password)
-        PROCTORED_EXAMS_ENABLED_FEATURES = settings.FEATURES
-        PROCTORED_EXAMS_ENABLED_FEATURES["ENABLE_PROCTORED_EXAMS"] = True
-        with override_settings(FEATURES=PROCTORED_EXAMS_ENABLED_FEATURES):
+        with override_settings(ENABLE_PROCTORED_EXAMS=True):
             data = self.get_request_data(
                 enable_proctored_exams=True,
                 proctoring_provider="lti_external",
             )
             response = self.make_request(data=data)
 
-        # response is correct
-        assert response.status_code == status.HTTP_200_OK
+            # response is correct
+            assert response.status_code == status.HTTP_200_OK
 
-        self.assertDictEqual(  # noqa: PT009
-            response.data,
-            {
-                "proctored_exam_settings": {
-                    "enable_proctored_exams": True,
-                    "allow_proctoring_opt_out": True,
-                    "proctoring_provider": "lti_external",
-                    "proctoring_escalation_email": None,
-                    "create_zendesk_tickets": True,
-                }
-            },
-        )
+            self.assertDictEqual(  # noqa: PT009
+                response.data,
+                {
+                    "proctored_exam_settings": {
+                        "enable_proctored_exams": True,
+                        "allow_proctoring_opt_out": True,
+                        "proctoring_provider": "lti_external",
+                        "proctoring_escalation_email": None,
+                        "create_zendesk_tickets": True,
+                    }
+                },
+            )
 
-        # course settings have been updated
-        updated = modulestore().get_item(self.course.location)
-        assert updated.enable_proctored_exams is True
-        assert updated.proctoring_provider == "lti_external"
+            # course settings have been updated
+            updated = modulestore().get_item(self.course.location)
+            assert updated.enable_proctored_exams is True
+            assert updated.proctoring_provider == "lti_external"
 
     @override_waffle_flag(EXAMS_IDA, active=False)
     def test_400_for_disabled_lti(self):
         self.client.login(username=self.global_staff.username, password=self.password)
-        PROCTORED_EXAMS_ENABLED_FEATURES = settings.FEATURES
-        PROCTORED_EXAMS_ENABLED_FEATURES["ENABLE_PROCTORED_EXAMS"] = True
-        with override_settings(FEATURES=PROCTORED_EXAMS_ENABLED_FEATURES):
+        with override_settings(ENABLE_PROCTORED_EXAMS=True):
             data = self.get_request_data(
                 enable_proctored_exams=True,
                 proctoring_provider="lti_external",

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1333,17 +1333,17 @@ class ContentStoreTest(ContentStoreTestCase):
         self.course_data['org'] = 'University of California, Berkeley'
         self.assert_course_creation_failed(r"(?s)Unable to create course 'Robot Super Course'.*")
 
+    @override_settings(DISABLE_COURSE_CREATION=True)
     def test_create_course_with_course_creation_disabled_staff(self):
         """Test new course creation -- course creation disabled, but staff access."""
-        with mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': True}):
-            self.assert_created_course()
+        self.assert_created_course()
 
+    @override_settings(DISABLE_COURSE_CREATION=True)
     def test_create_course_with_course_creation_disabled_not_staff(self):
         """Test new course creation -- error path for course creation disabled, not staff access."""
-        with mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': True}):
-            self.user.is_staff = False
-            self.user.save()
-            self.assert_course_permission_denied()
+        self.user.is_staff = False
+        self.user.save()
+        self.assert_course_permission_denied()
 
     @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_create_course_no_course_creators_staff(self):

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1363,20 +1363,20 @@ class ContentStoreTest(ContentStoreTestCase):
         auth.add_users(self.user, CourseCreatorRole(), self.user)
         self.assert_created_course()
 
+    @override_settings(ALLOW_UNICODE_COURSE_ID=False)
     def test_create_course_with_unicode_in_id_disabled(self):
         """
         Test new course creation with feature setting: ALLOW_UNICODE_COURSE_ID disabled.
         """
-        with mock.patch.dict('django.conf.settings.FEATURES', {'ALLOW_UNICODE_COURSE_ID': False}):
-            error_message = "Special characters not allowed in organization, course number, and course run."
-            self.course_data['org'] = '��������������'
-            self.assert_create_course_failed(error_message)
+        error_message = "Special characters not allowed in organization, course number, and course run."
+        self.course_data['org'] = '��������������'
+        self.assert_create_course_failed(error_message)
 
-            self.course_data['number'] = '��chantillon'
-            self.assert_create_course_failed(error_message)
+        self.course_data['number'] = '��chantillon'
+        self.assert_create_course_failed(error_message)
 
-            self.course_data['run'] = '����������'
-            self.assert_create_course_failed(error_message)
+        self.course_data['run'] = '����������'
+        self.assert_create_course_failed(error_message)
 
     def assert_course_permission_denied(self):
         """

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1345,23 +1345,23 @@ class ContentStoreTest(ContentStoreTestCase):
             self.user.save()
             self.assert_course_permission_denied()
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_create_course_no_course_creators_staff(self):
         """Test new course creation -- course creation group enabled, staff, group is empty."""
-        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': True}):
-            self.assert_created_course()
+        self.assert_created_course()
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_create_course_no_course_creators_not_staff(self):
         """Test new course creation -- error path for course creator group enabled, not staff, group is empty."""
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
-            self.user.is_staff = False
-            self.user.save()
-            self.assert_course_permission_denied()
+        self.user.is_staff = False
+        self.user.save()
+        self.assert_course_permission_denied()
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_create_course_with_course_creator(self):
         """Test new course creation -- use course creator group"""
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
-            auth.add_users(self.user, CourseCreatorRole(), self.user)
-            self.assert_created_course()
+        auth.add_users(self.user, CourseCreatorRole(), self.user)
+        self.assert_created_course()
 
     def test_create_course_with_unicode_in_id_disabled(self):
         """
@@ -2014,13 +2014,13 @@ class RerunCourseTest(ContentStoreTestCase):
         # Verify that the existing course continues to be in the course listing
         self.assertInCourseListing(existent_course_key)
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_rerun_with_permission_denied(self):
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
-            source_course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
-            auth.add_users(self.user, CourseCreatorRole(), self.user)
-            self.user.is_staff = False
-            self.user.save()
-            self.post_rerun_request(source_course.id, response_code=403, expect_error=True)
+        source_course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
+        auth.add_users(self.user, CourseCreatorRole(), self.user)
+        self.user.is_staff = False
+        self.user.save()
+        self.post_rerun_request(source_course.id, response_code=403, expect_error=True)
 
     def test_rerun_error(self):
         error_message = "Mock Error Message"

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -202,7 +202,7 @@ class TestCourseListing(ModuleStoreTestCase):
             self.assertEqual(len(course_orgs), 1)  # noqa: PT009
             self.assertEqual(course_orgs[0]['short_name'], 'orgX')  # noqa: PT009
 
-    @override_settings(FEATURES={'ENABLE_CREATOR_GROUP': True})
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_course_creation_when_user_not_in_org(self):
         """
         Tests course creation when user doesn't have the required role.
@@ -215,7 +215,7 @@ class TestCourseListing(ModuleStoreTestCase):
         })
         self.assertEqual(response.status_code, 403)  # noqa: PT009
 
-    @override_settings(FEATURES={'ENABLE_CREATOR_GROUP': True})
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     @mock.patch(
         'cms.djangoapps.course_creators.admin.render_to_string',
         mock.Mock(side_effect=mock_render_to_string, autospec=True)
@@ -242,7 +242,7 @@ class TestCourseListing(ModuleStoreTestCase):
         })
         self.assertEqual(response.status_code, 200)  # noqa: PT009
 
-    @override_settings(FEATURES={'ENABLE_CREATOR_GROUP': True})
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     @mock.patch(
         'cms.djangoapps.course_creators.admin.render_to_string',
         mock.Mock(side_effect=mock_render_to_string, autospec=True)
@@ -269,7 +269,7 @@ class TestCourseListing(ModuleStoreTestCase):
         })
         self.assertEqual(response.status_code, 200)  # noqa: PT009
 
-    @override_settings(FEATURES={'ENABLE_CREATOR_GROUP': True})
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     @mock.patch(
         'cms.djangoapps.course_creators.admin.render_to_string',
         mock.Mock(side_effect=mock_render_to_string, autospec=True)
@@ -298,7 +298,7 @@ class TestCourseListing(ModuleStoreTestCase):
         })
         self.assertEqual(response.status_code, 200)  # noqa: PT009
 
-    @override_settings(FEATURES={'ENABLE_CREATOR_GROUP': True})
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     @mock.patch(
         'cms.djangoapps.course_creators.admin.render_to_string',
         mock.Mock(side_effect=mock_render_to_string, autospec=True)

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -427,7 +427,7 @@ class TestCourseHandlerAuthz(
     # ------------------------------------------------------------
     # CREATE COURSE -- Non-staff users and existing Organization
     # ------------------------------------------------------------
-    @override_settings(FEATURES={"DISABLE_COURSE_CREATION": False})
+    @override_settings(DISABLE_COURSE_CREATION=False)
     def test_create_course_unauthorized(self):
         """
         User without role cannot create course.
@@ -442,7 +442,7 @@ class TestCourseHandlerAuthz(
 
         assert response.status_code == 403
 
-    @override_settings(FEATURES={"DISABLE_COURSE_CREATION": False})
+    @override_settings(DISABLE_COURSE_CREATION=False)
     def test_create_course_unauthorized_with_role(self):
         """
         User with role but without required permission cannot create course.
@@ -484,7 +484,7 @@ class TestCourseHandlerAuthz(
     # ------------------------------------------------------------
     # FEATURE FLAG
     # ------------------------------------------------------------
-    @override_settings(FEATURES={"DISABLE_COURSE_CREATION": True})
+    @override_settings(DISABLE_COURSE_CREATION=True)
     def test_create_course_disabled_by_flag(self):
         """
         Even authorized users cannot create course if feature flag is off.

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -337,7 +337,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         response = self.client.ajax_post(url, course_detail_json)
         self.assertEqual(400, response.status_code)  # noqa: PT009
 
-    @unittest.skipUnless(settings.FEATURES.get('ENTRANCE_EXAMS', False), True)
+    @unittest.skipUnless(settings.ENTRANCE_EXAMS, True)
     def test_entrance_exam_created_updated_and_deleted_successfully(self):
         """
         This tests both of the entrance exam settings and the `any_unfulfilled_milestones` helper.
@@ -396,7 +396,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         self.assertFalse(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),  # noqa: PT009
                          msg='The entrance exam should not be required anymore')
 
-    @unittest.skipUnless(settings.FEATURES.get('ENTRANCE_EXAMS', False), True)
+    @unittest.skipUnless(settings.ENTRANCE_EXAMS, True)
     def test_entrance_exam_store_default_min_score(self):
         """
         test that creating an entrance exam should store the default value, if key missing in json request
@@ -435,7 +435,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         self.assertTrue(course.entrance_exam_enabled)  # noqa: PT009
         self.assertEqual(course.entrance_exam_minimum_score_pct, .5)  # noqa: PT009
 
-    @unittest.skipUnless(settings.FEATURES.get('ENTRANCE_EXAMS', False), True)
+    @unittest.skipUnless(settings.ENTRANCE_EXAMS, True)
     @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
     def test_entrance_after_changing_other_setting(self):
         """

--- a/cms/djangoapps/contentstore/tests/test_exams.py
+++ b/cms/djangoapps/contentstore/tests/test_exams.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import ddt
 from django.conf import settings
+from django.test.utils import override_settings
 from edx_toggles.toggles.testutils import override_waffle_flag
 from freezegun import freeze_time
 from pytz import utc
@@ -19,7 +20,7 @@ from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 
 @ddt.ddt
 @override_waffle_flag(EXAMS_IDA, active=True)
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_PROCTORED_EXAMS': True})
+@override_settings(ENABLE_PROCTORED_EXAMS=True)
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
 @patch('cms.djangoapps.contentstore.exams._patch_course_exams')
 @patch('cms.djangoapps.contentstore.signals.handlers.transaction.on_commit',

--- a/cms/djangoapps/contentstore/tests/test_exams.py
+++ b/cms/djangoapps/contentstore/tests/test_exams.py
@@ -20,8 +20,7 @@ from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 
 @ddt.ddt
 @override_waffle_flag(EXAMS_IDA, active=True)
-@override_settings(ENABLE_PROCTORED_EXAMS=True)
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_PROCTORED_EXAMS=True, ENABLE_SPECIAL_EXAMS=True)
 @patch('cms.djangoapps.contentstore.exams._patch_course_exams')
 @patch('cms.djangoapps.contentstore.signals.handlers.transaction.on_commit',
        new=Mock(side_effect=lambda func: func()),)  # run right away
@@ -161,7 +160,7 @@ class TestExamService(ModuleStoreTestCase):
         listen_for_course_publish(self, self.course.id)
         mock_patch_course_exams.assert_called_once_with([], self.course_key)
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': False})
+    @override_settings(ENABLE_SPECIAL_EXAMS=False)
     def test_feature_flag_off(self, mock_patch_course_exams):
         """
         Make sure the feature flag is honored

--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -574,12 +574,12 @@ class TestLibraryAccess(LibraryTestCase):
 
         # Now check that logged-in users without CourseCreator role cannot create libraries
         self._login_as_non_staff_user(logout_first=False)
-        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': True}):
+        with override_settings(ENABLE_CREATOR_GROUP=True):
             self._assert_cannot_create_library(expected_code=403)  # 403 user is not CourseCreator
 
         # Now check that logged-in users with CourseCreator role can create libraries
         add_user_with_status_granted(self.user, self.non_staff_user)
-        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': True}):
+        with override_settings(ENABLE_CREATOR_GROUP=True):
             lib_key2 = self._create_library(library="lib2", display_name="Test Library 2")
             library2 = modulestore().get_library(lib_key2)
             self.assertIsNotNone(library2)  # noqa: PT009

--- a/cms/djangoapps/contentstore/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/tests/test_proctoring.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 
 import ddt
 from django.conf import settings
+from django.test import override_settings
 from edx_proctoring.api import get_all_exams_for_course, get_review_policy_by_exam_id
 from pytz import UTC
 
@@ -19,7 +20,7 @@ from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 
 
 @ddt.ddt
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 @patch('cms.djangoapps.contentstore.signals.handlers.transaction.on_commit',
        new=Mock(side_effect=lambda func: func()),)  # run right away
 class TestProctoredExams(ModuleStoreTestCase):
@@ -220,7 +221,7 @@ class TestProctoredExams(ModuleStoreTestCase):
         exam = exams[0]
         self.assertEqual(exam['is_active'], False)  # noqa: PT009
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': False})
+    @override_settings(ENABLE_SPECIAL_EXAMS=False)
     def test_feature_flag_off(self):
         """
         Make sure the feature flag is honored

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import ddt
-from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 from opaque_keys.edx.keys import CourseKey
@@ -641,7 +640,7 @@ class GetUserPartitionInfoTest(ModuleStoreTestCase):
         return utils.get_user_partition_info(self.block, schemes=schemes)
 
 
-@patch.dict(settings.FEATURES, ENABLE_COURSE_OLX_VALIDATION=True)
+@override_settings(ENABLE_COURSE_OLX_VALIDATION=True)
 @mock.patch('olxcleaner.validate')
 @ddt.ddt
 class ValidateCourseOlxTests(CourseTestCase):
@@ -668,7 +667,7 @@ class ValidateCourseOlxTests(CourseTestCase):
         """
         Tests olx validation with config setting is disabled.
         """
-        with patch.dict(settings.FEATURES, ENABLE_COURSE_OLX_VALIDATION=False):
+        with override_settings(ENABLE_COURSE_OLX_VALIDATION=False):
             self.assertTrue(validate_course_olx(self.course.id, self.toy_course_path, self.status))  # noqa: PT009
             self.assertFalse(mock_olxcleaner_validate.called)  # noqa: PT009
 
@@ -676,7 +675,7 @@ class ValidateCourseOlxTests(CourseTestCase):
         """
         Tests olx validation with config setting is enabled.
         """
-        with patch.dict(settings.FEATURES, ENABLE_COURSE_OLX_VALIDATION=True):
+        with override_settings(ENABLE_COURSE_OLX_VALIDATION=True):
             self.assertTrue(validate_course_olx(self.course.id, self.toy_course_path, self.status))  # noqa: PT009
             self.assertTrue(mock_olxcleaner_validate.called)  # noqa: PT009
 

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -539,7 +539,7 @@ def course_import_olx_validation_is_enabled():
     """
     Check if course olx validation is enabled on course import.
     """
-    return settings.FEATURES.get('ENABLE_COURSE_OLX_VALIDATION', False)
+    return settings.ENABLE_COURSE_OLX_VALIDATION
 
 
 # pylint: disable=invalid-name

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1587,7 +1587,7 @@ def get_library_context(request, request_is_json=False):
             'user': request.user,
             'request_course_creator_url': reverse('request_course_creator'),
             'course_creator_status': _get_course_creator_status(request.user),
-            'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False),
+            'allow_unicode_course_id': settings.ALLOW_UNICODE_COURSE_ID,
             'archived_courses': True,
             'allow_course_reruns': settings.FEATURES.get('ALLOW_COURSE_RERUNS', True),
             'rerun_creator_status': GlobalStaff().has_user(request.user),
@@ -1718,7 +1718,7 @@ def get_home_context(request, no_course=False):
         'request_course_creator_url': reverse('request_course_creator'),
         'course_creator_status': _get_course_creator_status(user),
         'rerun_creator_status': GlobalStaff().has_user(user),
-        'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False),
+        'allow_unicode_course_id': settings.ALLOW_UNICODE_COURSE_ID,
         'allow_course_reruns': settings.FEATURES.get('ALLOW_COURSE_RERUNS', True),
         'active_tab': 'courses',
         'allowed_organizations': get_allowed_organizations(user),
@@ -1743,7 +1743,7 @@ def get_course_rerun_context(course_key, course_block, user):
         'display_name': course_block.display_name,
         'user': user,
         'course_creator_status': _get_course_creator_status(user),
-        'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False)
+        'allow_unicode_course_id': settings.ALLOW_UNICODE_COURSE_ID
     }
 
     return course_rerun_context

--- a/cms/djangoapps/contentstore/views/certificate_manager.py
+++ b/cms/djangoapps/contentstore/views/certificate_manager.py
@@ -121,7 +121,7 @@ class CertificateManager:
         """
         is_active = False
         certificates = []
-        if settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+        if settings.CERTIFICATES_HTML_VIEW:
             certificates = CertificateManager.get_certificates(course)
             # we are assuming only one certificate in certificates collection.
             for certificate in certificates:

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -2113,7 +2113,7 @@ def _get_course_creator_status(user):
         course_creator_status = 'granted'
     elif settings.FEATURES.get('DISABLE_COURSE_CREATION', False):
         course_creator_status = 'disallowed_for_this_site'
-    elif settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+    elif getattr(settings, 'ENABLE_CREATOR_GROUP', False):
         course_creator_status = get_course_creator_status(user)
         if course_creator_status is None:
             # User not grandfathered in as an existing user, has not previously visited the dashboard page.
@@ -2130,7 +2130,7 @@ def get_allowed_organizations(user):
     """
     Helper method for returning the list of organizations for which the user is allowed to create courses.
     """
-    if settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+    if getattr(settings, 'ENABLE_CREATOR_GROUP', False):
         return get_organizations(user)
     else:
         return []
@@ -2150,7 +2150,7 @@ def get_allowed_organizations_for_libraries(user):
 
     # This allows people in the course creator group for an org to create
     # libraries, which mimics course behavior.
-    if settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+    if getattr(settings, 'ENABLE_CREATOR_GROUP', False):
         organizations_set.update(get_organizations(user))
 
     return sorted(organizations_set)
@@ -2160,7 +2160,7 @@ def user_can_create_organizations(user):
     """
     Returns True if the user can create organizations.
     """
-    return user.is_staff or not settings.FEATURES.get('ENABLE_CREATOR_GROUP', False)
+    return user.is_staff or not getattr(settings, 'ENABLE_CREATOR_GROUP', False)
 
 
 def get_organizations_for_non_course_creators(user):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1184,7 +1184,7 @@ def _create_or_rerun_course(request):
             raise PermissionDenied()
 
         # allow/disable unicode characters in course_id according to settings
-        if not settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID'):
+        if not settings.ALLOW_UNICODE_COURSE_ID:
             if _has_non_ascii_characters(org) or _has_non_ascii_characters(course) or _has_non_ascii_characters(run):
                 return JsonResponse(
                     {'error': _('Special characters not allowed in organization, course number, and course run.')},

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -2111,7 +2111,7 @@ def _get_course_creator_status(user):
 
     if user.is_staff:
         course_creator_status = 'granted'
-    elif settings.FEATURES.get('DISABLE_COURSE_CREATION', False):
+    elif getattr(settings, 'DISABLE_COURSE_CREATION', False):
         course_creator_status = 'disallowed_for_this_site'
     elif getattr(settings, 'ENABLE_CREATOR_GROUP', False):
         course_creator_status = get_course_creator_status(user)

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -88,7 +88,7 @@ def _user_can_create_library_for_org(user, org=None):
     else:
         # EDUCATOR-1924: DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION, if present.
         disable_library_creation = settings.FEATURES.get('DISABLE_LIBRARY_CREATION', None)
-        disable_course_creation = settings.FEATURES.get('DISABLE_COURSE_CREATION', False)
+        disable_course_creation = getattr(settings, 'DISABLE_COURSE_CREATION', False)
         if disable_library_creation is not None:
             return not disable_library_creation
         else:

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -67,7 +67,7 @@ def _user_can_create_library_for_org(user, org=None):
         return False
     elif user.is_staff:
         return True
-    elif settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+    elif getattr(settings, 'ENABLE_CREATOR_GROUP', False):
         is_course_creator = get_course_creator_status(user) == 'granted'
         if is_course_creator:
             return True

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -186,7 +186,7 @@ def _prepare_runtime_for_preview(request, block):
     ]
 
     mako_service = MakoService(namespace_prefix='lms.')
-    if settings.FEATURES.get("LICENSING", False):
+    if settings.LICENSING:
         # stick the license wrapper in front
         wrappers.insert(0, partial(wrap_with_license, mako_service=mako_service))
 

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -38,11 +38,7 @@ TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 
 MAX_FILE_SIZE = settings.MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB * 1000 ** 2
 
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
-
-
-@override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+@override_settings(CERTIFICATES_HTML_VIEW=True)
 class AssetsTestCase(CourseTestCase):
     """
     Parent class for all asset tests.

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -3705,7 +3705,7 @@ class TestGetMetadataWithProblemDefaults(ModuleStoreTestCase):
         assert 'weight' not in metadata_result
 
 
-@patch.dict("django.conf.settings.FEATURES", {"ENABLE_SPECIAL_EXAMS": True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 @ddt.ddt
 class TestSpecialExamXBlockInfo(ItemTest):
     """

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -7,7 +7,6 @@ import itertools
 import json
 
 import ddt
-from django.conf import settings
 from django.test.utils import override_settings
 from opaque_keys.edx.keys import AssetKey
 
@@ -23,9 +22,6 @@ from xmodule.contentstore.django import contentstore  # pylint: disable=wrong-im
 from xmodule.exceptions import NotFoundError  # pylint: disable=wrong-import-order
 
 from ..certificate_manager import CERTIFICATE_SCHEMA_VERSION, CertificateManager
-
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
 
 CERTIFICATE_JSON = {
     'name': 'Test certificate',
@@ -195,7 +191,7 @@ class CertificatesBaseTestCase:
 
 
 @ddt.ddt
-@override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+@override_settings(CERTIFICATES_HTML_VIEW=True)
 class CertificatesListHandlerTestCase(
         EventTestMixin, CourseTestCase, HelperMethods, UrlResetMixin
 ):
@@ -350,7 +346,7 @@ class CertificatesListHandlerTestCase(
 
 
 @ddt.ddt
-@override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+@override_settings(CERTIFICATES_HTML_VIEW=True)
 class CertificatesDetailHandlerTestCase(
         EventTestMixin, CourseTestCase, CertificatesBaseTestCase, HelperMethods, UrlResetMixin
 ):

--- a/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
+++ b/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
@@ -10,9 +10,9 @@ from common.djangoapps.util.testing import UrlResetMixin
 
 
 @override_settings(
+    CERTIFICATES_HTML_VIEW=True,
     FEATURES={
         **settings.FEATURES,
-        "CERTIFICATES_HTML_VIEW": True,
         "ENABLE_PROCTORED_EXAMS": True,
     },
 )

--- a/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
+++ b/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
@@ -1,7 +1,6 @@
 """
 Exam Settings View Tests
 """
-from django.conf import settings
 from django.test.utils import override_settings
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
@@ -11,10 +10,7 @@ from common.djangoapps.util.testing import UrlResetMixin
 
 @override_settings(
     CERTIFICATES_HTML_VIEW=True,
-    FEATURES={
-        **settings.FEATURES,
-        "ENABLE_PROCTORED_EXAMS": True,
-    },
+    ENABLE_PROCTORED_EXAMS=True,
 )
 @override_settings(COURSE_AUTHORING_MICROFRONTEND_URL='https://mfe.example')
 class TestExamSettingsView(CourseTestCase, UrlResetMixin):

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -665,7 +665,7 @@ class ImportTestCase(CourseTestCase):
             Mock(), Mock(errors=errors, return_error=Mock(return_value=True)), Mock()
         ]
         expected_error_mesg = f'{self.log_prefix} CourseOlx validation failed.'
-        with patch.dict(settings.FEATURES, ENABLE_COURSE_OLX_VALIDATION=True):
+        with override_settings(ENABLE_COURSE_OLX_VALIDATION=True):
             response = self.import_file_in_course(good_file)
 
         self.assertEqual(response.status_code, 200)  # noqa: PT009

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -38,7 +38,7 @@ def make_url_for_lib(key):
 
 
 @ddt.ddt
-@mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': False})
+@override_settings(DISABLE_COURSE_CREATION=False)
 class UnitTestLibraries(CourseTestCase):
     """
     Unit tests for library views
@@ -133,16 +133,14 @@ class UnitTestLibraries(CourseTestCase):
         """
         _, nostaff_user = self.create_non_staff_authed_user_client()
         with mock.patch("cms.djangoapps.contentstore.toggles.libraries_v1_enabled", True):
-            with mock.patch.dict(
-                "django.conf.settings.FEATURES",
-                {
-                    "DISABLE_COURSE_CREATION": disable_course,
-                    "DISABLE_LIBRARY_CREATION": disable_library
-                }
-            ):
-                self.assertEqual(user_can_create_library(nostaff_user, 'SomEOrg'), expected_status)  # noqa: PT009
+            with override_settings(DISABLE_COURSE_CREATION=disable_course):
+                with mock.patch.dict(
+                    "django.conf.settings.FEATURES",
+                    {"DISABLE_LIBRARY_CREATION": disable_library}
+                ):
+                    self.assertEqual(user_can_create_library(nostaff_user, 'SomEOrg'), expected_status)  # noqa: PT009
 
-    @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': True})
+    @override_settings(DISABLE_COURSE_CREATION=True)
     @mock.patch("cms.djangoapps.contentstore.toggles.libraries_v1_enabled", True)
     def test_library_creator_status_with_no_course_creator_role_and_disabled_nonstaff_course_creation(self):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -69,7 +69,7 @@ class UnitTestLibraries(CourseTestCase):
     @mock.patch("cms.djangoapps.contentstore.toggles.libraries_v1_enabled", True)
     def test_library_creator_status_for_enabled_creator_group_setting_for_non_staff_users(self):
         _, nostaff_user = self.create_non_staff_authed_user_client()
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
+        with override_settings(ENABLE_CREATOR_GROUP=True):
             self.assertEqual(user_can_create_library(nostaff_user, None), False)  # noqa: PT009
 
     # Global staff can create libraries for any org, even ones that don't exist.
@@ -87,14 +87,14 @@ class UnitTestLibraries(CourseTestCase):
     # When creator groups are enabled, global staff can create libraries in any org
     @mock.patch("cms.djangoapps.contentstore.toggles.libraries_v1_enabled", True)
     def test_library_creator_status_for_enabled_creator_group_setting_with_is_staff_user(self):
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
+        with override_settings(ENABLE_CREATOR_GROUP=True):
             self.assertEqual(user_can_create_library(self.user, 'RandomOrg'), True)  # noqa: PT009
 
     # When creator groups are enabled, course creators can create libraries in any org.
     @mock.patch("cms.djangoapps.contentstore.toggles.libraries_v1_enabled", True)
     def test_library_creator_status_with_course_creator_role_for_enabled_creator_group_setting(self):
         _, nostaff_user = self.create_non_staff_authed_user_client()
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
+        with override_settings(ENABLE_CREATOR_GROUP=True):
             grant_course_creator_status(self.user, nostaff_user)
             self.assertEqual(user_can_create_library(nostaff_user, 'soMeRandOmoRg'), True)  # noqa: PT009
 
@@ -103,7 +103,7 @@ class UnitTestLibraries(CourseTestCase):
     @mock.patch("cms.djangoapps.contentstore.toggles.libraries_v1_enabled", True)
     def test_library_creator_status_with_course_staff_role_for_enabled_creator_group_setting(self):
         _, nostaff_user = self.create_non_staff_authed_user_client()
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
+        with override_settings(ENABLE_CREATOR_GROUP=True):
             auth.add_users(self.user, CourseStaffRole(self.course.id), nostaff_user)
             self.assertEqual(user_can_create_library(nostaff_user, self.course.org), True)  # noqa: PT009
             self.assertEqual(user_can_create_library(nostaff_user, 'SomEOtherOrg'), False)  # noqa: PT009
@@ -113,7 +113,7 @@ class UnitTestLibraries(CourseTestCase):
     @mock.patch("cms.djangoapps.contentstore.toggles.libraries_v1_enabled", True)
     def test_library_creator_status_with_course_instructor_role_for_enabled_creator_group_setting(self):
         _, nostaff_user = self.create_non_staff_authed_user_client()
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
+        with override_settings(ENABLE_CREATOR_GROUP=True):
             auth.add_users(self.user, CourseInstructorRole(self.course.id), nostaff_user)
             self.assertEqual(user_can_create_library(nostaff_user, self.course.org), True)  # noqa: PT009
             self.assertEqual(user_can_create_library(nostaff_user, 'SomEOtherOrg'), False)  # noqa: PT009
@@ -205,7 +205,7 @@ class UnitTestLibraries(CourseTestCase):
         self.assertEqual(response.status_code, 200)  # noqa: PT009
         # That's all we check. More detailed tests are in contentstore.tests.test_libraries...
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': True})
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_lib_create_permission(self):
         """
         Users who are given course creator roles should be able to create libraries.
@@ -219,7 +219,7 @@ class UnitTestLibraries(CourseTestCase):
         })
         self.assertEqual(response.status_code, 200)  # noqa: PT009
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': False})
+    @override_settings(ENABLE_CREATOR_GROUP=False)
     def test_lib_create_permission_no_course_creator_role_and_no_course_creator_group(self):
         """
         Users who are not given course creator roles should still be able to create libraries
@@ -233,7 +233,7 @@ class UnitTestLibraries(CourseTestCase):
         })
         self.assertEqual(response.status_code, 200)  # noqa: PT009
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': True})
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_lib_create_permission_no_course_creator_role_and_no_course_creator_group_and_no_course_staff_role(self):
         """
         Users who are not given course creator roles or course staff role should not be able to create libraries
@@ -247,7 +247,7 @@ class UnitTestLibraries(CourseTestCase):
         })
         self.assertEqual(response.status_code, 403)  # noqa: PT009
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': True})
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_lib_create_permission_course_staff_role(self):
         """
         Users who are staff on any existing course should able to create libraries
@@ -464,14 +464,11 @@ class UnitTestLibraries(CourseTestCase):
                         'django.conf.settings.FEATURES',
                         {"ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES": False}
                     ):
-                        with mock.patch.dict(
-                            'django.conf.settings.FEATURES',
-                            {"ENABLE_CREATOR_GROUP": False}
-                        ):
+                        with override_settings(ENABLE_CREATOR_GROUP=False):
                             organizations = get_allowed_organizations_for_libraries(self.user)
                             # Assert that the method returned the expected value
                             self.assertEqual(organizations, [])  # noqa: PT009
-                        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
+                        with override_settings(ENABLE_CREATOR_GROUP=True):
                             # Assert that correct org values are returned based on course creator state
                             for course_creator_state in CourseCreator.STATES:
                                 course_creator.state = course_creator_state

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -89,44 +89,44 @@ class TestOrganizationsForLibraries(TestCase):
         )
 
     @override_settings(
+        ENABLE_CREATOR_GROUP=False,
         FEATURES={
             **settings.FEATURES,
             'ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES': False,
-            'ENABLE_CREATOR_GROUP': False,
-        }
+        },
     )
     def test_both_toggles_disabled(self):
         allowed_orgs = get_allowed_organizations_for_libraries(self.library_author)
         assert allowed_orgs == []
 
     @override_settings(
+        ENABLE_CREATOR_GROUP=True,
         FEATURES={
             **settings.FEATURES,
             'ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES': True,
-            'ENABLE_CREATOR_GROUP': True,
-        }
+        },
     )
     def test_both_toggles_enabled(self):
         allowed_orgs = get_allowed_organizations_for_libraries(self.library_author)
         assert allowed_orgs == ["CreatorOrg", "OrgStaffOrg"]
 
     @override_settings(
+        ENABLE_CREATOR_GROUP=False,
         FEATURES={
             **settings.FEATURES,
             'ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES': True,
-            'ENABLE_CREATOR_GROUP': False,
-        }
+        },
     )
     def test_org_staff_enabled(self):
         allowed_orgs = get_allowed_organizations_for_libraries(self.library_author)
         assert allowed_orgs == ["OrgStaffOrg"]
 
     @override_settings(
+        ENABLE_CREATOR_GROUP=True,
         FEATURES={
             **settings.FEATURES,
             'ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES': False,
-            'ENABLE_CREATOR_GROUP': True,
-        }
+        },
     )
     def test_creator_group_enabled(self):
         allowed_orgs = get_allowed_organizations_for_libraries(self.library_author)

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1385,7 +1385,7 @@ def create_xblock_info(  # pylint: disable=too-many-statements
             )
 
         # update xblock_info with special exam information if the feature flag is enabled
-        if settings.FEATURES.get("ENABLE_SPECIAL_EXAMS"):
+        if settings.ENABLE_SPECIAL_EXAMS:
             if xblock.category == "course":
                 xblock_info.update(
                     {

--- a/cms/djangoapps/course_creators/admin.py
+++ b/cms/djangoapps/course_creators/admin.py
@@ -137,7 +137,7 @@ def update_creator_group_callback(sender, **kwargs):  # pylint: disable=unused-a
 
 def course_creator_notification_context(subject):
     return {
-        'studio_request_email': settings.FEATURES.get('STUDIO_REQUEST_EMAIL', ''),
+        'studio_request_email': settings.STUDIO_REQUEST_EMAIL,
         'is_secure': (settings.CMS_ROOT_URL or '').split(':')[0].lower() == 'https',
         'site': str(get_current_site() or settings.CMS_BASE),
         'user_name': subject.username,

--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -9,6 +9,7 @@ from django.contrib.admin.sites import AdminSite
 from django.core import mail
 from django.http import HttpRequest
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from cms.djangoapps.course_creators.admin import CourseCreatorAdmin
 from cms.djangoapps.course_creators.models import CourseCreator
@@ -48,8 +49,7 @@ class CourseCreatorAdminTest(TestCase):
 
         self.studio_request_email = 'mark@marky.mark'
         self.enable_creator_group_patch = {
-            "ENABLE_CREATOR_GROUP": True,
-            "STUDIO_REQUEST_EMAIL": self.studio_request_email
+            "STUDIO_REQUEST_EMAIL": self.studio_request_email,
         }
         self.context = {
             'studio_request_email': self.studio_request_email,
@@ -59,6 +59,7 @@ class CourseCreatorAdminTest(TestCase):
             'user_email': 'test_user+courses@edx.org',
         }
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     @mock.patch('django.contrib.auth.models.User.email_user')
     def test_change_status(self, email_user):
         """
@@ -101,6 +102,7 @@ class CourseCreatorAdminTest(TestCase):
 
             change_state_and_verify_email(CourseCreator.DENIED, False)
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_mail_admin_on_pending(self):
         """
         Tests that the admin account is notified when a user is in the 'pending' state.

--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -48,9 +48,6 @@ class CourseCreatorAdminTest(TestCase):
         self.creator_admin = CourseCreatorAdmin(self.table_entry, AdminSite())
 
         self.studio_request_email = 'mark@marky.mark'
-        self.enable_creator_group_patch = {
-            "STUDIO_REQUEST_EMAIL": self.studio_request_email,
-        }
         self.context = {
             'studio_request_email': self.studio_request_email,
             'is_secure': False,
@@ -59,7 +56,7 @@ class CourseCreatorAdminTest(TestCase):
             'user_email': 'test_user+courses@edx.org',
         }
 
-    @override_settings(ENABLE_CREATOR_GROUP=True)
+    @override_settings(ENABLE_CREATOR_GROUP=True, STUDIO_REQUEST_EMAIL='mark@marky.mark')
     @mock.patch('django.contrib.auth.models.User.email_user')
     def test_change_status(self, email_user):
         """
@@ -83,26 +80,24 @@ class CourseCreatorAdminTest(TestCase):
                 self.studio_request_email
             )
 
-        with mock.patch.dict('django.conf.settings.FEATURES', self.enable_creator_group_patch):
+        # User is initially unrequested.
+        self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
 
-            # User is initially unrequested.
-            self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
+        change_state_and_verify_email(CourseCreator.GRANTED, True)
 
-            change_state_and_verify_email(CourseCreator.GRANTED, True)
+        change_state_and_verify_email(CourseCreator.DENIED, False)
 
-            change_state_and_verify_email(CourseCreator.DENIED, False)
+        change_state_and_verify_email(CourseCreator.GRANTED, True)
 
-            change_state_and_verify_email(CourseCreator.GRANTED, True)
+        change_state_and_verify_email(CourseCreator.PENDING, False)
 
-            change_state_and_verify_email(CourseCreator.PENDING, False)
+        change_state_and_verify_email(CourseCreator.GRANTED, True)
 
-            change_state_and_verify_email(CourseCreator.GRANTED, True)
+        change_state_and_verify_email(CourseCreator.UNREQUESTED, False)
 
-            change_state_and_verify_email(CourseCreator.UNREQUESTED, False)
+        change_state_and_verify_email(CourseCreator.DENIED, False)
 
-            change_state_and_verify_email(CourseCreator.DENIED, False)
-
-    @override_settings(ENABLE_CREATOR_GROUP=True)
+    @override_settings(ENABLE_CREATOR_GROUP=True, STUDIO_REQUEST_EMAIL='mark@marky.mark')
     def test_mail_admin_on_pending(self):
         """
         Tests that the admin account is notified when a user is in the 'pending' state.
@@ -133,18 +128,17 @@ class CourseCreatorAdminTest(TestCase):
             else:
                 self.assertEqual(base_num_emails, len(mail.outbox))  # noqa: PT009
 
-        with mock.patch.dict('django.conf.settings.FEATURES', self.enable_creator_group_patch):
-            # E-mail message should be sent to admin only when new state is PENDING, regardless of what
-            # previous state was (unless previous state was already PENDING).
-            # E-mail message sent to user only on transition into and out of GRANTED state.
-            check_admin_message_state(CourseCreator.UNREQUESTED, expect_sent_to_admin=False, expect_sent_to_user=False)
-            check_admin_message_state(CourseCreator.PENDING, expect_sent_to_admin=True, expect_sent_to_user=False)
-            check_admin_message_state(CourseCreator.GRANTED, expect_sent_to_admin=False, expect_sent_to_user=True)
-            check_admin_message_state(CourseCreator.DENIED, expect_sent_to_admin=False, expect_sent_to_user=True)
-            check_admin_message_state(CourseCreator.GRANTED, expect_sent_to_admin=False, expect_sent_to_user=True)
-            check_admin_message_state(CourseCreator.PENDING, expect_sent_to_admin=True, expect_sent_to_user=True)
-            check_admin_message_state(CourseCreator.PENDING, expect_sent_to_admin=False, expect_sent_to_user=False)
-            check_admin_message_state(CourseCreator.DENIED, expect_sent_to_admin=False, expect_sent_to_user=True)
+        # E-mail message should be sent to admin only when new state is PENDING, regardless of what
+        # previous state was (unless previous state was already PENDING).
+        # E-mail message sent to user only on transition into and out of GRANTED state.
+        check_admin_message_state(CourseCreator.UNREQUESTED, expect_sent_to_admin=False, expect_sent_to_user=False)
+        check_admin_message_state(CourseCreator.PENDING, expect_sent_to_admin=True, expect_sent_to_user=False)
+        check_admin_message_state(CourseCreator.GRANTED, expect_sent_to_admin=False, expect_sent_to_user=True)
+        check_admin_message_state(CourseCreator.DENIED, expect_sent_to_admin=False, expect_sent_to_user=True)
+        check_admin_message_state(CourseCreator.GRANTED, expect_sent_to_admin=False, expect_sent_to_user=True)
+        check_admin_message_state(CourseCreator.PENDING, expect_sent_to_admin=True, expect_sent_to_user=True)
+        check_admin_message_state(CourseCreator.PENDING, expect_sent_to_admin=False, expect_sent_to_user=False)
+        check_admin_message_state(CourseCreator.DENIED, expect_sent_to_admin=False, expect_sent_to_user=True)
 
     def _change_state(self, state):
         """ Helper method for changing state """

--- a/cms/djangoapps/course_creators/tests/test_views.py
+++ b/cms/djangoapps/course_creators/tests/test_views.py
@@ -3,10 +3,9 @@ Tests course_creators.views.py.
 """
 
 
-from unittest import mock
-
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from cms.djangoapps.course_creators.views import (
@@ -64,35 +63,35 @@ class CourseCreatorView(TestCase):
         add_user_with_status_granted(self.admin, self.user)
         self.assertEqual('unrequested', get_course_creator_status(self.user))  # noqa: PT009
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_add_granted(self):
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
-            # Calling add_user_with_status_granted impacts is_user_in_course_group_role.
-            self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
+        # Calling add_user_with_status_granted impacts is_user_in_course_group_role.
+        self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
 
-            add_user_with_status_granted(self.admin, self.user)
-            self.assertEqual('granted', get_course_creator_status(self.user))  # noqa: PT009
+        add_user_with_status_granted(self.admin, self.user)
+        self.assertEqual('granted', get_course_creator_status(self.user))  # noqa: PT009
 
-            # Calling add again will be a no-op (even if state is different).
-            add_user_with_status_unrequested(self.user)
-            self.assertEqual('granted', get_course_creator_status(self.user))  # noqa: PT009
+        # Calling add again will be a no-op (even if state is different).
+        add_user_with_status_unrequested(self.user)
+        self.assertEqual('granted', get_course_creator_status(self.user))  # noqa: PT009
 
-            self.assertTrue(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
+        self.assertTrue(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_update_creator_group(self):
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
-            self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
-            update_course_creator_group(self.admin, self.user, True)
-            self.assertTrue(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
-            update_course_creator_group(self.admin, self.user, False)
-            self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
+        self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
+        update_course_creator_group(self.admin, self.user, True)
+        self.assertTrue(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
+        update_course_creator_group(self.admin, self.user, False)
+        self.assertFalse(auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_update_org_content_creator_role(self):
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
-            self.assertFalse(auth.user_has_role(self.user, OrgContentCreatorRole(self.org)))  # noqa: PT009
-            update_org_content_creator_role(self.admin, self.user, [self.org])
-            self.assertTrue(auth.user_has_role(self.user, OrgContentCreatorRole(self.org)))  # noqa: PT009
-            update_org_content_creator_role(self.admin, self.user, [])
-            self.assertFalse(auth.user_has_role(self.user, OrgContentCreatorRole(self.org)))  # noqa: PT009
+        self.assertFalse(auth.user_has_role(self.user, OrgContentCreatorRole(self.org)))  # noqa: PT009
+        update_org_content_creator_role(self.admin, self.user, [self.org])
+        self.assertTrue(auth.user_has_role(self.user, OrgContentCreatorRole(self.org)))  # noqa: PT009
+        update_org_content_creator_role(self.admin, self.user, [])
+        self.assertFalse(auth.user_has_role(self.user, OrgContentCreatorRole(self.org)))  # noqa: PT009
 
     def test_user_requested_access(self):
         add_user_with_status_unrequested(self.user)

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -131,7 +131,7 @@ class CourseMetadata:
             exclude_list.append('video_bumper')
 
         # Do not show enable_ccx if feature is not enabled.
-        if not settings.FEATURES.get('CUSTOM_COURSES_EDX'):
+        if not settings.CUSTOM_COURSES_EDX:
             exclude_list.append('enable_ccx')
             exclude_list.append('ccx_connector')
 

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -124,7 +124,7 @@ class CourseMetadata:
             exclude_list.append('social_sharing_url')
 
         # Do not show teams configuration if feature is disabled.
-        if not settings.FEATURES.get('ENABLE_TEAMS'):
+        if not settings.ENABLE_TEAMS:
             exclude_list.append('teams_configuration')
 
         if not settings.FEATURES.get('ENABLE_VIDEO_BUMPER'):

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -265,7 +265,7 @@ if core_toggles.ENTRANCE_EXAMS.is_enabled():
                        contentstore_views.entrance_exam))
 
 # Enable Web/HTML Certificates
-if settings.FEATURES.get('CERTIFICATES_HTML_VIEW'):
+if settings.CERTIFICATES_HTML_VIEW:
     from cms.djangoapps.contentstore.views.certificates import (  # noqa: I001 - conditional import inside if block
         CertificateActivationAPIView,
         CertificateDetailAPIView,

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -642,7 +642,7 @@ class TrackSelectionEmbargoTest(UrlResetMixin, ModuleStoreTestCase):
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def setUp(self):
         super().setUp()
 
@@ -658,7 +658,7 @@ class TrackSelectionEmbargoTest(UrlResetMixin, ModuleStoreTestCase):
         # Construct the URL for the track selection page
         self.url = reverse('course_modes_choose', args=[str(self.course.id)])
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_embargo_restrict(self):
         with restrict_course(self.course.id) as redirect_url:
             response = self.client.get(self.url)

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -61,7 +61,7 @@ def user_has_role(user, role):
     # CourseCreator is odd b/c it can be disabled via config
     if isinstance(role, CourseCreatorRole):
         # completely shut down course creation setting
-        if settings.FEATURES.get('DISABLE_COURSE_CREATION', False):
+        if getattr(settings, 'DISABLE_COURSE_CREATION', False):
             return False
         # wide open course creation setting
         if not getattr(settings, 'ENABLE_CREATOR_GROUP', False):
@@ -257,7 +257,7 @@ def _has_content_creator_access(user, org):
     Returns:
         bool: True if the user has platform-wide or org-scoped course creation permission.
     """
-    if settings.FEATURES.get("DISABLE_COURSE_CREATION", False):
+    if getattr(settings, 'DISABLE_COURSE_CREATION', False):
         return False
 
     scope_keys = (

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -64,7 +64,7 @@ def user_has_role(user, role):
         if settings.FEATURES.get('DISABLE_COURSE_CREATION', False):
             return False
         # wide open course creation setting
-        if not settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+        if not getattr(settings, 'ENABLE_CREATOR_GROUP', False):
             return True
 
     if role.has_user(user):

--- a/common/djangoapps/student/email_helpers.py
+++ b/common/djangoapps/student/email_helpers.py
@@ -57,7 +57,7 @@ def generate_proctoring_requirements_email_context(user, course_id):
         'course_name': course_block.display_name,
         'proctoring_provider': capwords(course_block.proctoring_provider.replace('_', ' ')),
         'proctoring_requirements_url': settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('faq', ''),
-        'idv_required': not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE'),
+        'idv_required': not settings.ENABLE_INTEGRITY_SIGNATURE,
         'id_verification_url': IDVerificationService.get_verify_location(),
     }
 

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -122,7 +122,7 @@ def check_verify_status_by_course(user, course_enrollments):
     status_by_course = {}
 
     # If integrity signature is enabled, this is a no-op because IDV is not required
-    if settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE'):
+    if settings.ENABLE_INTEGRITY_SIGNATURE:
         return status_by_course
 
     # Retrieve all verifications for the user, sorted in descending

--- a/common/djangoapps/student/management/tests/test_recover_account.py
+++ b/common/djangoapps/student/management/tests/test_recover_account.py
@@ -18,8 +18,6 @@ from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 LOGGER_NAME = 'common.djangoapps.student.management.commands.recover_account'
-FEATURES_WITH_AUTHN_MFE_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_AUTHN_MFE_ENABLED['ENABLE_AUTHN_MICROFRONTEND'] = True
 
 
 class RecoverAccountTests(TestCase):
@@ -67,7 +65,7 @@ class RecoverAccountTests(TestCase):
         # try to login with previous password
         assert not self.client.login(username=self.user.username, password='password')
 
-    @override_settings(FEATURES=FEATURES_WITH_AUTHN_MFE_ENABLED)
+    @override_settings(ENABLE_AUTHN_MICROFRONTEND=True)
     @skip_unless_lms
     def test_authn_mfe_url_in_reset_link(self):
         """

--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -199,7 +199,7 @@ class CourseEnrollmentManager(models.Manager):
 
         'course_id' is the course_id to return enrollments
         """
-        max_enrollments = settings.FEATURES.get("MAX_ENROLLMENT_INSTR_BUTTONS")
+        max_enrollments = settings.MAX_ENROLLMENT_INSTR_BUTTONS
 
         enrollment_number = super().get_queryset().filter(
             course_id=course_id,

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -1284,7 +1284,7 @@ def add_user_to_default_group(user, group):  # pylint: disable=missing-function-
 
 
 def create_comments_service_user(user):  # pylint: disable=missing-function-docstring
-    if not settings.FEATURES['ENABLE_DISCUSSION_SERVICE']:
+    if not settings.ENABLE_DISCUSSION_SERVICE:
         # Don't try--it won't work, and it will fill the logs with lots of errors
         return
     try:

--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -17,9 +17,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from openedx.features.enterprise_support.tests.factories import EnterpriseCustomerUserFactory
 
-FEATURES_WITH_AUTHN_MFE_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_AUTHN_MFE_ENABLED['ENABLE_AUTHN_MICROFRONTEND'] = True
-
 
 @skip_unless_lms
 class TestActivateAccount(TestCase):
@@ -180,7 +177,7 @@ class TestActivateAccount(TestCase):
         self.assertContains(response, 'Your email could not be confirmed')
 
     @override_settings(LOGIN_REDIRECT_WHITELIST=['localhost:1991'])
-    @override_settings(FEATURES={**FEATURES_WITH_AUTHN_MFE_ENABLED, 'ENABLE_ENTERPRISE_INTEGRATION': True})
+    @override_settings(ENABLE_AUTHN_MICROFRONTEND=True, ENABLE_ENTERPRISE_INTEGRATION=True)
     def test_authenticated_account_activation_with_valid_next_url(self):
         """
         Verify that an activation link with a valid next URL will redirect
@@ -234,7 +231,7 @@ class TestActivateAccount(TestCase):
         self.assertRedirects(response, expected_destination)
         self._assert_user_active_state(expected_active_state=True)
 
-    @override_settings(FEATURES=FEATURES_WITH_AUTHN_MFE_ENABLED)
+    @override_settings(ENABLE_AUTHN_MICROFRONTEND=True)
     def test_unauthenticated_user_redirects_to_mfe(self):
         """
         Verify that if Authn MFE is enabled then authenticated user redirects to
@@ -259,7 +256,7 @@ class TestActivateAccount(TestCase):
         assert response.url == (login_page_url + 'error')
 
     @override_settings(LOGIN_REDIRECT_WHITELIST=['localhost:1991'])
-    @override_settings(FEATURES=FEATURES_WITH_AUTHN_MFE_ENABLED)
+    @override_settings(ENABLE_AUTHN_MICROFRONTEND=True)
     def test_unauthenticated_user_redirects_to_mfe_with_valid_next_url(self):
         """
         Verify that if Authn MFE is enabled then authenticated user redirects to

--- a/common/djangoapps/student/tests/test_authz.py
+++ b/common/djangoapps/student/tests/test_authz.py
@@ -76,44 +76,41 @@ class CreatorGroupTest(TestCase):
         remove_users(self.admin, CourseCreatorRole(), self.user)
         assert not user_has_role(self.user, CourseCreatorRole())
 
-    @override_settings(ENABLE_CREATOR_GROUP=True)
+    @override_settings(ENABLE_CREATOR_GROUP=True, DISABLE_COURSE_CREATION=True)
     def test_course_creation_disabled(self):
         """ Tests that the COURSE_CREATION_DISABLED flag overrides course creator group settings. """
-        with mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': True}):
-            # Add user to creator group.
-            add_users(self.admin, CourseCreatorRole(), self.user)
+        # Add user to creator group.
+        add_users(self.admin, CourseCreatorRole(), self.user)
 
-            # DISABLE_COURSE_CREATION overrides (user is not marked as staff).
-            assert not user_has_role(self.user, CourseCreatorRole())
+        # DISABLE_COURSE_CREATION overrides (user is not marked as staff).
+        assert not user_has_role(self.user, CourseCreatorRole())
 
-            # Mark as staff. Now CourseCreatorRole().has_user returns true.
-            self.user.is_staff = True
-            assert user_has_role(self.user, CourseCreatorRole())
+        # Mark as staff. Now CourseCreatorRole().has_user returns true.
+        self.user.is_staff = True
+        assert user_has_role(self.user, CourseCreatorRole())
 
-            # Remove user from creator group. CourseCreatorRole().has_user still returns true because is_staff=True
-            remove_users(self.admin, CourseCreatorRole(), self.user)
-            assert user_has_role(self.user, CourseCreatorRole())
+        # Remove user from creator group. CourseCreatorRole().has_user still returns true because is_staff=True
+        remove_users(self.admin, CourseCreatorRole(), self.user)
+        assert user_has_role(self.user, CourseCreatorRole())
 
-    @override_settings(ENABLE_CREATOR_GROUP=True)
+    @override_settings(ENABLE_CREATOR_GROUP=True, DISABLE_COURSE_CREATION=False)
     def test_add_user_not_authenticated(self):
         """
         Tests that adding to creator group fails if user is not authenticated
         """
-        with mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': False}):
-            anonymous_user = AnonymousUser()
-            role = CourseCreatorRole()
-            add_users(self.admin, role, anonymous_user)
-            assert not user_has_role(anonymous_user, role)
+        anonymous_user = AnonymousUser()
+        role = CourseCreatorRole()
+        add_users(self.admin, role, anonymous_user)
+        assert not user_has_role(anonymous_user, role)
 
-    @override_settings(ENABLE_CREATOR_GROUP=True)
+    @override_settings(ENABLE_CREATOR_GROUP=True, DISABLE_COURSE_CREATION=False)
     def test_add_user_not_active(self):
         """
         Tests that adding to creator group fails if user is not active
         """
-        with mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': False}):
-            self.user.is_active = False
-            add_users(self.admin, CourseCreatorRole(), self.user)
-            assert not user_has_role(self.user, CourseCreatorRole())
+        self.user.is_active = False
+        add_users(self.admin, CourseCreatorRole(), self.user)
+        assert not user_has_role(self.user, CourseCreatorRole())
 
     def test_add_user_to_group_requires_staff_access(self):
         with pytest.raises(PermissionDenied):  # noqa: PT012

--- a/common/djangoapps/student/tests/test_authz.py
+++ b/common/djangoapps/student/tests/test_authz.py
@@ -53,33 +53,33 @@ class CreatorGroupTest(TestCase):
         """
         assert user_has_role(self.user, CourseCreatorRole())
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_creator_group_enabled_but_empty(self):
         """ Tests creator group feature on, but group empty. """
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
-            assert not user_has_role(self.user, CourseCreatorRole())
+        assert not user_has_role(self.user, CourseCreatorRole())
 
-            # Make user staff. This will cause CourseCreatorRole().has_user to return True.
-            self.user.is_staff = True
-            assert user_has_role(self.user, CourseCreatorRole())
+        # Make user staff. This will cause CourseCreatorRole().has_user to return True.
+        self.user.is_staff = True
+        assert user_has_role(self.user, CourseCreatorRole())
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_creator_group_enabled_nonempty(self):
         """ Tests creator group feature on, user added. """
-        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
-            add_users(self.admin, CourseCreatorRole(), self.user)
-            assert user_has_role(self.user, CourseCreatorRole())
+        add_users(self.admin, CourseCreatorRole(), self.user)
+        assert user_has_role(self.user, CourseCreatorRole())
 
-            # check that a user who has not been added to the group still returns false
-            user_not_added = UserFactory.create(username='testuser2', email='test+courses2@edx.org', password='foo2')
-            assert not user_has_role(user_not_added, CourseCreatorRole())
+        # check that a user who has not been added to the group still returns false
+        user_not_added = UserFactory.create(username='testuser2', email='test+courses2@edx.org', password='foo2')
+        assert not user_has_role(user_not_added, CourseCreatorRole())
 
-            # remove first user from the group and verify that CourseCreatorRole().has_user now returns false
-            remove_users(self.admin, CourseCreatorRole(), self.user)
-            assert not user_has_role(self.user, CourseCreatorRole())
+        # remove first user from the group and verify that CourseCreatorRole().has_user now returns false
+        remove_users(self.admin, CourseCreatorRole(), self.user)
+        assert not user_has_role(self.user, CourseCreatorRole())
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_course_creation_disabled(self):
         """ Tests that the COURSE_CREATION_DISABLED flag overrides course creator group settings. """
-        with mock.patch.dict('django.conf.settings.FEATURES',
-                             {'DISABLE_COURSE_CREATION': True, "ENABLE_CREATOR_GROUP": True}):
+        with mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': True}):
             # Add user to creator group.
             add_users(self.admin, CourseCreatorRole(), self.user)
 
@@ -94,27 +94,23 @@ class CreatorGroupTest(TestCase):
             remove_users(self.admin, CourseCreatorRole(), self.user)
             assert user_has_role(self.user, CourseCreatorRole())
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_add_user_not_authenticated(self):
         """
         Tests that adding to creator group fails if user is not authenticated
         """
-        with mock.patch.dict(
-            'django.conf.settings.FEATURES',
-            {'DISABLE_COURSE_CREATION': False, "ENABLE_CREATOR_GROUP": True}
-        ):
+        with mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': False}):
             anonymous_user = AnonymousUser()
             role = CourseCreatorRole()
             add_users(self.admin, role, anonymous_user)
             assert not user_has_role(anonymous_user, role)
 
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_add_user_not_active(self):
         """
         Tests that adding to creator group fails if user is not active
         """
-        with mock.patch.dict(
-            'django.conf.settings.FEATURES',
-            {'DISABLE_COURSE_CREATION': False, "ENABLE_CREATOR_GROUP": True}
-        ):
+        with mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': False}):
             self.user.is_active = False
             add_users(self.admin, CourseCreatorRole(), self.user)
             assert not user_has_role(self.user, CourseCreatorRole())

--- a/common/djangoapps/student/tests/test_certificates.py
+++ b/common/djangoapps/student/tests/test_certificates.py
@@ -1,7 +1,6 @@
 """Tests for display of certificates on the student dashboard. """
 
 import datetime
-from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import ddt
@@ -206,8 +205,7 @@ class CertificateDisplayTestLinkedHtmlView(CertificateDisplayTestBase):
         cls.store.update_item(cls.course, cls.USERNAME)
 
     @ddt.data('verified')
-    @override_settings(CERT_NAME_SHORT='Test_Certificate')
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERT_NAME_SHORT='Test_Certificate', CERTIFICATES_HTML_VIEW=True)
     def test_linked_student_to_web_view_credential(self, enrollment_mode):
 
         cert = self._create_certificate(enrollment_mode)

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -232,8 +232,7 @@ class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
 
 
 @ddt.ddt
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
-@override_settings(ACCOUNT_MICROFRONTEND_URL='http://account-mfe')
+@override_settings(ACCOUNT_MICROFRONTEND_URL='http://account-mfe', ENABLE_SPECIAL_EXAMS=True)
 @skip_unless_lms
 class ProctoringRequirementsEmailTests(EmailTemplateTagMixin, ModuleStoreTestCase):
     """

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import ddt
 import pytest
 from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 from openedx_events.testing import OpenEdxEventsTestMixin
 
@@ -274,7 +275,7 @@ class EnrollmentTest(OpenEdxEventsTestMixin, UrlResetMixin, ModuleStoreTestCase)
     @patch.dict(
         'django.conf.settings.PROCTORING_BACKENDS', {'test_provider_honor_mode': {'allow_honor_mode': True}}
     )
-    @patch.dict(settings.FEATURES, {'ENABLE_PROCTORED_EXAMS': True})
+    @override_settings(ENABLE_PROCTORED_EXAMS=True)
     def test_enroll_in_proctored_course_honor_mode_allowed(self):
         """
         If the proctoring provider allows honor mode, send proctoring requirements email when learners

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -29,7 +29,7 @@ from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory
 
 
 @ddt.ddt
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 @skip_unless_lms
 class EnrollmentTest(OpenEdxEventsTestMixin, UrlResetMixin, ModuleStoreTestCase):
     """

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -43,7 +43,7 @@ class EnrollmentTest(OpenEdxEventsTestMixin, UrlResetMixin, ModuleStoreTestCase)
     PASSWORD = "edx"
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def setUp(self):
         """ Create a course and user, then log in. """
         super().setUp()
@@ -294,7 +294,7 @@ class EnrollmentTest(OpenEdxEventsTestMixin, UrlResetMixin, ModuleStoreTestCase)
             CourseEnrollment.enroll(self.user, course_honor_mode.id, 'honor')  # pylint: disable=no-member
             assert mock_send_email.called
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_embargo_restrict(self):
         # When accessing the course from an embargoed country,
         # we should be blocked.
@@ -307,7 +307,7 @@ class EnrollmentTest(OpenEdxEventsTestMixin, UrlResetMixin, ModuleStoreTestCase)
         is_enrolled = CourseEnrollment.is_enrolled(self.user, self.course.id)
         assert not is_enrolled
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_embargo_allow(self):
         response = self._change_enrollment('enroll')
         assert response.status_code == 200

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -80,7 +80,7 @@ class CourseEndingTest(ModuleStoreTestCase):
         link2_expected = f"http://www.mysurvey.com?unique={user_id}"
         assert process_survey_link(link2, user) == link2_expected
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': False})
+    @override_settings(CERTIFICATES_HTML_VIEW=False)
     def test_cert_info(self):
         user = UserFactory.create()
         survey_url = "http://a_survey.com"
@@ -477,7 +477,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
         self.assertNotContains(response, escape(response_url))
 
     @skip_unless_lms
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': False})
+    @override_settings(CERTIFICATES_HTML_VIEW=False)
     def test_linked_in_add_to_profile_btn_with_certificate(self):
         # If user has a certificate with valid linked-in config then Add Certificate to LinkedIn button
         # should be visible. and it has URL value with valid parameters.

--- a/common/djangoapps/third_party_auth/__init__.py
+++ b/common/djangoapps/third_party_auth/__init__.py
@@ -12,5 +12,5 @@ def is_enabled():
 
     return configuration_helpers.get_value(
         "ENABLE_THIRD_PARTY_AUTH",
-        settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH")
+        getattr(settings, 'ENABLE_THIRD_PARTY_AUTH', False)
     )

--- a/common/djangoapps/third_party_auth/decorators.py
+++ b/common/djangoapps/third_party_auth/decorators.py
@@ -21,7 +21,7 @@ def xframe_allow_whitelisted(view_func):
         """ Modify the response with the correct X-Frame-Options. """
         resp = view_func(request, *args, **kwargs)
         x_frame_option = settings.X_FRAME_OPTIONS
-        if settings.FEATURES['ENABLE_THIRD_PARTY_AUTH']:
+        if getattr(settings, 'ENABLE_THIRD_PARTY_AUTH', False):
             referer = request.META.get('HTTP_REFERER')
             if referer is not None:
                 parsed_url = urlparse(referer)

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -70,7 +70,7 @@ def clean_username(username=''):
     """
     Simple helper method to ensure a username is compatible with our system requirements.
     """
-    if settings.FEATURES.get("ENABLE_UNICODE_USERNAME"):
+    if getattr(settings, 'ENABLE_UNICODE_USERNAME', False):
         return ('_').join(re.findall(settings.USERNAME_REGEX_PARTIAL, username))[:USERNAME_MAX_LENGTH]
     else:
         return ('_').join(re.findall(r'[a-zA-Z0-9\-]+', username))[:USERNAME_MAX_LENGTH]

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -149,12 +149,12 @@ class HelperMixin:
         partial_unicode_username = unicode_username + ascii_substring
         pipeline_kwargs = pipeline.get(request)["kwargs"]
 
-        assert settings.FEATURES["ENABLE_UNICODE_USERNAME"] is False
+        assert settings.ENABLE_UNICODE_USERNAME is False
 
         self._check_registration_form_username(pipeline_kwargs, unicode_username, "")
         self._check_registration_form_username(pipeline_kwargs, partial_unicode_username, ascii_substring)
 
-        with mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_UNICODE_USERNAME": True}):
+        with django_utils.override_settings(ENABLE_UNICODE_USERNAME=True):
             self._check_registration_form_username(pipeline_kwargs, unicode_username, unicode_username)
 
     def assert_exception_redirect_looks_correct(self, expected_uri, auth_entry=None):

--- a/common/djangoapps/third_party_auth/tests/test_decorators.py
+++ b/common/djangoapps/third_party_auth/tests/test_decorators.py
@@ -48,7 +48,7 @@ class TestXFrameWhitelistDecorator(TestCase):
 
     @ddt.data('http://localhost/login', 'http://not-a-real-domain.com', None)
     def test_feature_flag_off(self, url):
-        with self.settings(FEATURES={'ENABLE_THIRD_PARTY_AUTH': False}):
+        with self.settings(ENABLE_THIRD_PARTY_AUTH=False):
             request = self.construct_request(url)
             response = mock_view(request)
             assert response['X-Frame-Options'] == 'DENY'

--- a/common/djangoapps/third_party_auth/tests/test_models.py
+++ b/common/djangoapps/third_party_auth/tests/test_models.py
@@ -41,14 +41,14 @@ class TestSamlProviderConfigModel(TestCase, unittest.TestCase):
             bad_config.save()
         assert ctx.records[0].msg == f'Entity ID: {self.saml_provider_config.entity_id} already in use'
 
-    @override_settings(FEATURES={'ENABLE_UNICODE_USERNAME': False})
+    @override_settings(ENABLE_UNICODE_USERNAME=False)
     def test_clean_username_unicode_disabled(self):
         """
         Test the username cleaner function with unicode disabled
         """
         assert clean_username('ItJüstWòrks™') == 'ItJ_stW_rks'
 
-    @override_settings(FEATURES={'ENABLE_UNICODE_USERNAME': True})
+    @override_settings(ENABLE_UNICODE_USERNAME=True)
     def test_clean_username_unicode_enabled(self):
         """
         Test the username cleaner function with unicode enabled

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -62,7 +62,7 @@ class SettingsUnitTest(TestCase):
         assert 'social_django.context_processors.backends' in context_processors
         assert 'social_django.context_processors.login_redirect' in context_processors
 
-    @override_settings(FEATURES={'ENABLE_UNICODE_USERNAME': False})
+    @override_settings(ENABLE_UNICODE_USERNAME=False)
     def test_social_auth_clean_usernames_default(self):
         """Verify SOCIAL_AUTH_CLEAN_USERNAMES is True when unicode usernames disabled."""
         # Note: SOCIAL_AUTH_CLEAN_USERNAMES is a Derived setting, computed at settings load time.

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -27,7 +27,7 @@ from openedx.core.djangolib.testing.utils import CacheIsolationMixin
 from openedx.core.storage import OverwriteStorage
 
 AUTH_FEATURES_KEY = 'ENABLE_THIRD_PARTY_AUTH'
-AUTH_FEATURE_ENABLED = AUTH_FEATURES_KEY in settings.FEATURES
+AUTH_FEATURE_ENABLED = hasattr(settings, AUTH_FEATURES_KEY)
 
 
 def patch_mako_templates():

--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -80,7 +80,7 @@ def has_certificates_enabled(course):
         course: This can be either a course overview object or a course block.
     Returns a boolean if the course has enabled certificates
     """
-    if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+    if not settings.CERTIFICATES_HTML_VIEW:
         return False
     return course.cert_html_view_enabled
 

--- a/lms/djangoapps/ccx/plugins.py
+++ b/lms/djangoapps/ccx/plugins.py
@@ -28,7 +28,7 @@ class CcxCourseTab(CourseTab):
         """
         Returns true if CCX has been enabled and the specified user is a coach
         """
-        if not settings.FEATURES.get('CUSTOM_COURSES_EDX', False) or not course.enable_ccx:
+        if not settings.CUSTOM_COURSES_EDX or not course.enable_ccx:
             # If ccx is not enable do not show ccx coach tab.
             return False
 

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -230,7 +230,7 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
 
     @patch('lms.djangoapps.ccx.views.render_to_response', intercept_renderer)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', intercept_renderer)
-    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    @override_settings(CUSTOM_COURSES_EDX=True)
     def test_edit_schedule(self):
         """
         Get CCX schedule, modify it, save it.
@@ -1119,7 +1119,7 @@ class CCXCoachTabTestCase(CcxTestCase):
         """
         Test ccx coach tab state (visible or hidden) depending on the value of enable_ccx flag, ccx feature flag.
         """
-        with self.settings(FEATURES={'CUSTOM_COURSES_EDX': ccx_feature_flag}):
+        with override_settings(CUSTOM_COURSES_EDX=ccx_feature_flag):
             course = self.ccx_enabled_course if enable_ccx else self.ccx_disabled_course
             assert expected_result == self.check_ccx_tab(course, self.user)
 

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -6,7 +6,7 @@ Tests for the Certificate REST APIs.
 from unittest.mock import patch
 
 import ddt
-from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -382,7 +382,7 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
             assert resp.status_code == status.HTTP_200_OK
             assert len(resp.data) == 2
 
-    @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_with_no_certificate_configuration(self):
         """
         Verify that certificates are not returned until there is an active

--- a/lms/djangoapps/certificates/apps.py
+++ b/lms/djangoapps/certificates/apps.py
@@ -23,6 +23,6 @@ class CertificatesConfig(AppConfig):
         # Can't import models at module level in AppConfigs, and models get
         # included from the signal handlers
         from lms.djangoapps.certificates import signals  # pylint: disable=unused-import  # noqa: F401
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from lms.djangoapps.certificates.services import CertificateService
             set_runtime_service('certificates', CertificateService())

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -76,10 +76,6 @@ CAN_GENERATE_METHOD = "lms.djangoapps.certificates.generation_handler._can_gener
 BETA_TESTER_METHOD = "lms.djangoapps.certificates.api.access.is_beta_tester"
 CERTS_VIEWABLE_METHOD = "lms.djangoapps.certificates.api.certificates_viewable_for_course"
 PASSED_OR_ALLOWLISTED_METHOD = "lms.djangoapps.certificates.api._has_passed_or_is_allowlisted"
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED["CERTIFICATES_HTML_VIEW"] = True
-
-
 class WebCertificateTestMixin:
     """
     Mixin with helpers for testing Web Certificates.
@@ -191,14 +187,14 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
             "uuid": cert.verify_uuid,
         }
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_pdf_cert_with_html_enabled(self):
         self.verify_downloadable_pdf_cert()
 
     def test_pdf_cert_with_html_disabled(self):
         self.verify_downloadable_pdf_cert()
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_with_downloadable_web_cert(self):
         cert_status = certificate_status_for_student(self.student, self.course.id)
         assert certificate_downloadable_status(self.student, self.course.id) == {
@@ -221,7 +217,7 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
         (False, timedelta(days=2), CertificatesDisplayBehaviors.END_WITH_DATE, False, None, True),
     )
     @ddt.unpack
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_cert_api_return(
         self,
         self_paced,
@@ -476,7 +472,7 @@ class CertificateGetTests(SharedModuleStoreTestCase):
         """
         assert not get_certificates_for_user(self.student_no_cert.username)
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_get_web_certificate_url(self):
         """
         Test the get_certificate_url with a web cert course
@@ -490,7 +486,7 @@ class CertificateGetTests(SharedModuleStoreTestCase):
         cert_url = get_certificate_url(user_id=self.student.id, course_id=self.web_cert_course.id, uuid=self.uuid)
         assert expected_url == cert_url
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_get_pdf_certificate_url(self):
         """
         Test the get_certificate_url with a pdf cert course
@@ -522,7 +518,7 @@ class GenerateUserCertificatesTest(ModuleStoreTestCase):
             mode=CourseMode.VERIFIED,
         )
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": False})
+    @override_settings(CERTIFICATES_HTML_VIEW=False)
     def test_cert_url_empty_with_invalid_certificate(self):
         """
         Test certificate url is empty if html view is not enabled and certificate is not yet generated
@@ -530,7 +526,7 @@ class GenerateUserCertificatesTest(ModuleStoreTestCase):
         url = get_certificate_url(self.user.id, self.course_run_key)
         assert url == ""
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_generation(self):
         """
         Test that a cert is successfully generated
@@ -546,7 +542,7 @@ class GenerateUserCertificatesTest(ModuleStoreTestCase):
                 assert cert.status == CertificateStatuses.downloadable
                 assert cert.mode == CourseMode.VERIFIED
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @ddt.data(True, False)
     def test_generation_unverified(self, enable_idv_requirement):
         """
@@ -567,7 +563,7 @@ class GenerateUserCertificatesTest(ModuleStoreTestCase):
                     else:
                         assert cert.status == CertificateStatuses.downloadable
 
-    @patch.dict(settings.FEATURES, {"CERTIFICATES_HTML_VIEW": True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_generation_notpassing(self):
         """
         Test that a cert is successfully generated with a status of notpassing
@@ -652,7 +648,7 @@ class CertificateGenerationEnabledTest(EventTestMixin, TestCase):
         assert expect_enabled == actual_enabled
 
 
-@override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+@override_settings(CERTIFICATES_HTML_VIEW=True)
 class CertificatesBrandingTest(ModuleStoreTestCase):
     """Test certificates branding."""
 

--- a/lms/djangoapps/certificates/tests/test_support_views.py
+++ b/lms/djangoapps/certificates/tests/test_support_views.py
@@ -8,7 +8,6 @@ from unittest import mock
 from uuid import uuid4
 
 import ddt
-from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
@@ -25,8 +24,6 @@ from xmodule.modulestore.tests.django_utils import (
 from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable=wrong-import-order
 
 CAN_GENERATE_METHOD = 'lms.djangoapps.certificates.generation_handler._can_generate_regular_certificate'
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
 
 
 class CertificateSupportTestCase(ModuleStoreTestCase):
@@ -213,7 +210,7 @@ class CertificateSearchTests(CertificateSupportTestCase):
         assert retrieved_cert['download_url'] == self.CERT_DOWNLOAD_URL
         assert not retrieved_cert['regenerate']
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_download_link(self):
         self.cert.course_id = self.course_key
         self.cert.download_url = ''

--- a/lms/djangoapps/certificates/tests/test_utils.py
+++ b/lms/djangoapps/certificates/tests/test_utils.py
@@ -2,10 +2,10 @@
 Tests for Certificates app utility functions
 """
 from datetime import datetime, timedelta
-from unittest.mock import patch
 
 import ddt
 from django.test import TestCase
+from django.test.utils import override_settings
 from pytz import utc
 
 from lms.djangoapps.certificates.utils import has_html_certificates_enabled, should_certificate_be_visible
@@ -27,14 +27,14 @@ class CertificateUtilityTests(TestCase):
         super().setUp()
         self.course_overview = CourseOverviewFactory.create()
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': False})
+    @override_settings(CERTIFICATES_HTML_VIEW=False)
     def test_has_html_certificates_enabled_from_course_overview_cert_html_view_disabled(self):
         """
         Test to ensure we return the correct value when the `CERTIFICATES_HTML_VIEW` setting is disabled.
         """
         assert not has_html_certificates_enabled(self.course_overview)
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_has_html_certificates_enabled_from_course_overview_enabled(self):
         """
         Test to ensure we return the correct value when the HTML certificates are enabled in a course-run.
@@ -44,7 +44,7 @@ class CertificateUtilityTests(TestCase):
 
         assert has_html_certificates_enabled(self.course_overview)
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_has_html_certificates_enabled_from_course_overview_disabled(self):
         """
         Test to ensure we return the correct value when the HTML certificates are disabled in a course-run.

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -4,7 +4,6 @@
 import datetime
 from uuid import uuid4
 
-from django.conf import settings
 from django.test.client import Client
 from django.test.utils import override_settings
 
@@ -18,17 +17,6 @@ from xmodule.modulestore.tests.django_utils import (
     ModuleStoreTestCase,  # pylint: disable=wrong-import-order
 )
 from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable=wrong-import-order
-
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
-
-FEATURES_WITH_CERTS_DISABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_DISABLED['CERTIFICATES_HTML_VIEW'] = False
-
-FEATURES_WITH_CUSTOM_CERTS_ENABLED = {
-    "CUSTOM_CERTIFICATE_TEMPLATES_ENABLED": True
-}
-FEATURES_WITH_CUSTOM_CERTS_ENABLED.update(FEATURES_WITH_CERTS_ENABLED)
 
 
 class CertificatesViewsSiteTests(ModuleStoreTestCase):
@@ -129,7 +117,7 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
         self.course.save()
         self.store.update_item(self.course, self.user.id)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @with_site_configuration(configuration={'platform_name': 'My Platform Site'})
     def test_html_view_for_site(self):
         test_url = get_certificate_url(
@@ -149,7 +137,7 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
         )
         self.assertContains(response, 'About My Platform Site')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_html_view_site_configuration_missing(self):
         test_url = get_certificate_url(
             user_id=self.user.id,
@@ -165,7 +153,7 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
             'This should not survive being overwritten by static content',
         )
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED, GOOGLE_ANALYTICS_4_ID='GA-abc')
+    @override_settings(CERTIFICATES_HTML_VIEW=True, GOOGLE_ANALYTICS_4_ID='GA-abc')
     @with_site_configuration(configuration={'platform_name': 'My Platform Site'})
     def test_html_view_with_g4(self):
         test_url = get_certificate_url(

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -51,9 +51,6 @@ from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-FEATURES_WITH_CUSTOM_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CUSTOM_CERTS_ENABLED['CUSTOM_CERTIFICATE_TEMPLATES_ENABLED'] = True
-
 name_affirmation_service = get_name_affirmation_service()
 
 
@@ -1081,7 +1078,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, "Invalid Certificate")
 
     # TEMPLATES WITHOUT LANGUAGE TESTS
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @override_settings(LANGUAGE_CODE='fr')
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_org_mode_and_course_key(self, mock_get_course_run_details):
@@ -1116,7 +1113,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertContains(response, 'lang: fr')
             self.assertContains(response, 'course name: test_template_3_course')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_org_and_mode(self, mock_get_course_run_details):
         """
@@ -1151,7 +1148,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             assert response.status_code == 200
             self.assertContains(response, 'course name: test_template_1_course')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_org(self, mock_get_course_run_details):
         """
@@ -1175,7 +1172,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             assert response.status_code == 200
             self.assertContains(response, 'course name: test_template_1_course')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_mode(self, mock_get_course_run_details):
         """
@@ -1203,7 +1200,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
     # Templates With Language tests
     # 1
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @override_settings(LANGUAGE_CODE='fr')
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
@@ -1288,7 +1285,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 2
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_org_and_mode(self, mock_get_org_id, mock_get_course_run_details):
@@ -1348,7 +1345,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 3
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_org(self, mock_get_org_id, mock_get_course_run_details):
@@ -1406,7 +1403,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 4
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_mode(self, mock_get_org_id, mock_get_course_run_details):
@@ -1464,7 +1461,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         assert response.status_code == 200
         self.assertContains(response, 'course name: test_right_lang_template')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_locale_language_from_catalogue(
@@ -1526,7 +1523,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         assert response.status_code == 200
         self.assertContains(response, 'course name: test_right_lang_template')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @ddt.data(True, False)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
@@ -1572,10 +1569,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         mode = 'honor'
         self._add_course_certificates(count=1, signatory_count=2)
         self._create_custom_template(mode=mode)
-        with override_settings(CERTIFICATES_HTML_VIEW=True), patch.dict(
-            "django.conf.settings.FEATURES",
-            {"CUSTOM_CERTIFICATE_TEMPLATES_ENABLED": custom_certs_enabled},
-        ):
+        with override_settings(CERTIFICATES_HTML_VIEW=True, CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=custom_certs_enabled):
             test_url = get_certificate_url(
                 user_id=self.user.id,
                 course_id=str(self.course.id),
@@ -1597,7 +1591,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
                             self.assertContains(response, "Tweet this Accomplishment")
                         self.assertContains(response, 'https://twitter.com/intent/tweet')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_asset_by_slug(self, mock_get_course_run_details):
         """
@@ -1673,7 +1667,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertContains(response, self.user.profile.name)
             self.assertNotContains(response, verified_name)
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
+    @override_settings(CUSTOM_CERTIFICATE_TEMPLATES_ENABLED=True, CERTIFICATES_HTML_VIEW=True)
     @ddt.data(
         True,
         False

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -51,13 +51,7 @@ from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
-
-FEATURES_WITH_CERTS_DISABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_DISABLED['CERTIFICATES_HTML_VIEW'] = False
-
-FEATURES_WITH_CUSTOM_CERTS_ENABLED = FEATURES_WITH_CERTS_ENABLED.copy()
+FEATURES_WITH_CUSTOM_CERTS_ENABLED = settings.FEATURES.copy()
 FEATURES_WITH_CUSTOM_CERTS_ENABLED['CUSTOM_CERTIFICATE_TEMPLATES_ENABLED'] = True
 
 name_affirmation_service = get_name_affirmation_service()
@@ -289,7 +283,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             'max_effort': '10'
         }
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_linkedin_share_url(self):
         """
         Test: LinkedIn share URL.
@@ -314,7 +308,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             js_escaped_string(self.linkedin_url.format(params=urlencode(params))),
         )
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @with_site_configuration(
         configuration={
             'platform_name': 'My Platform Site', 'LINKEDIN_COMPANY_ID': 2448,
@@ -348,7 +342,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         "CERTIFICATE_FACEBOOK": True,
         "CERTIFICATE_FACEBOOK_TEXT": "test FB text"
     })
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_certificate_html_view_with_facebook_meta_tags(self):
         """
         Test view html certificate if share to FB is enabled.
@@ -381,7 +375,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
     @patch.dict("django.conf.settings.SOCIAL_SHARING_SETTINGS", {
         "CERTIFICATE_FACEBOOK": False,
     })
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_certificate_html_view_without_facebook_meta_tags(self):
         """
         Test view html certificate if share to FB is disabled.
@@ -408,7 +402,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertNotContains(response, '<meta property="og:image" ')
         self.assertNotContains(response, '<meta property="og:description" ')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @patch.dict("django.conf.settings.SOCIAL_SHARING_SETTINGS", {"CERTIFICATE_FACEBOOK": True})
     @with_site_configuration(
         configuration={'FACEBOOK_APP_ID': 'test_facebook_my_site'},
@@ -424,7 +418,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, "Post on Facebook")
         self.assertContains(response, 'test_facebook_my_site')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @ddt.data(
         (False, False, False),
         (False, False, True),
@@ -456,7 +450,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             assert ('Share on Twitter' in response.content.decode('utf-8')) == twitter_sharing
             assert ('Add to LinkedIn Profile' in response.content.decode('utf-8')) == linkedin_sharing
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_facebook_default_text_site(self):
         """
         Test: Facebook sharing default text for sites.
@@ -476,7 +470,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             response = self.client.get(test_url, HTTP_HOST='test.localhost')
             self.assertContains(response, facebook_text)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_twitter_default_text_site(self):
         """
         Test: Twitter sharing default text for sites.
@@ -496,7 +490,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             response = self.client.get(test_url, HTTP_HOST='test.localhost')
             self.assertContains(response, twitter_text)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_rendering_course_organization_data(self):
         """
         Test: organization data should render on certificate web view if course has organization.
@@ -525,7 +519,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, f'<title>test_organization {self.course.number} Certificate |')
         self.assertContains(response, 'logo_test1.png')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @patch.dict("django.conf.settings.SOCIAL_SHARING_SETTINGS", {
         "CERTIFICATE_TWITTER": True,
         "CERTIFICATE_FACEBOOK": True,
@@ -597,7 +591,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         # Test course overrides
         self.assertContains(response, "/static/certificates/images/course_override_logo.png")
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_valid_certificate(self):
         self._add_course_certificates(count=1, signatory_count=2)
         test_url = get_certificate_url(
@@ -620,7 +614,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         self.assertContains(response, str(self.cert.verify_uuid))
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_certificate_only_for_downloadable_status(self):
         """
         Tests that Certificate HTML Web View returns Certificate only if certificate status is 'downloadable',
@@ -649,7 +643,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         (CertificateStatuses.audit_notpassing, False),
     )
     @ddt.unpack
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_audit_certificate_display(self, status, eligible_for_certificate):
         """
         Ensure that audit-mode certs are only shown in the web view if they
@@ -672,7 +666,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         else:
             assert response.status_code == 404
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_html_view_returns_404_for_invalid_certificate(self):
         """
         Tests that Certificate HTML Web View successfully retrieves certificate only
@@ -694,7 +688,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         assert response.status_code == 404
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_html_lang_attribute_is_dynamic_for_certificate_html_view(self):
         """
         Tests that Certificate HTML Web View's lang attribute is based on user language.
@@ -717,7 +711,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, '<html class="no-js" lang="ar">')
 
     @ddt.data(False, True)
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_html_view_for_non_viewable_certificate_and_for_student_user(self, date_override):
         """
         Tests that Certificate HTML Web View returns "Cannot Find Certificate"
@@ -755,7 +749,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, "Cannot Find Certificate")
         self.assertContains(response, "We cannot find a certificate with this URL or ID number.")
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_with_valid_signatories(self):
         self._add_course_certificates(count=1, signatory_count=2)
         test_url = get_certificate_url(
@@ -771,7 +765,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'Signatory_Organization 0')
         self.assertContains(response, '/static/certificates/images/demo-sig0.png')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_course_display_name_not_override_with_course_title(self):
         # if certificate in block has not course_title then course name should not be overridden with this title.
         test_certificates = [
@@ -798,7 +792,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertNotContains(response, 'test_course_title_0')
         self.assertContains(response, 'refundable course')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_course_display_overrides(self):
         """
         Tests if `Course Number Display String` or `Course Organization Display` is set for a course
@@ -821,7 +815,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'overridden_number')
         self.assertContains(response, 'overridden_org')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_certificate_view_without_org_logo(self):
         test_certificates = [
             {
@@ -846,7 +840,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         # make sure response html has only one organization logo container for edX
         self.assertContains(response, "<li class=\"wrapper-organization\">", 1)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_without_signatories(self):
         self._add_course_certificates(count=1, signatory_count=0)
         test_url = get_certificate_url(
@@ -858,7 +852,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertNotContains(response, 'Signatory_Name 0')
         self.assertNotContains(response, 'Signatory_Title 0')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_is_html_escaped(self):
         test_certificates = [
             {
@@ -887,7 +881,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertNotContains(response, '<script>')
         self.assertContains(response, '&lt;script&gt;course_title&lt;/script&gt;')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_DISABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=False)
     def test_render_html_view_disabled_feature_flag_returns_static_url(self):
         test_url = get_certificate_url(
             user_id=self.user.id,
@@ -896,7 +890,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         )
         assert str(self.cert.download_url) in test_url
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_invalid_course(self):
         test_url = "/certificates/user/{user_id}/course/{course_id}".format(
             user_id=self.user.id,
@@ -905,7 +899,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         self.assertContains(response, 'invalid')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_invalid_user_certificate(self):
         self._add_course_certificates(count=1, signatory_count=0)
         test_url = get_certificate_url(
@@ -919,7 +913,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         assert response.status_code == 404
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED, PLATFORM_NAME='Űńíćődé Űńívéŕśítӳ')
+    @override_settings(CERTIFICATES_HTML_VIEW=True, PLATFORM_NAME='Űńíćődé Űńívéŕśítӳ')
     def test_render_html_view_with_unicode_platform_name(self):
         self._add_course_certificates(count=1, signatory_count=0)
 
@@ -931,7 +925,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         assert response.status_code == 200
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_user_id_cert_url_not_supported(self):
         """
         tests the user id based certificate url is no longer supported
@@ -944,7 +938,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         # staff or instructor access should show invalid certificate
         self.assertContains(response, 'URL Not Supported')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_with_preview_mode(self):
         """
         test certificate web view should render properly along with its signatories information when accessing it in
@@ -967,7 +961,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course_title_0')
         self.assertContains(response, 'Signatory_Title 0')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_with_preview_mode_when_user_already_has_cert(self):
         """
         test certificate web view should render properly in
@@ -989,7 +983,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course_title_0')
         self.assertContains(response, 'Signatory_Title 0')
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @ddt.data(
         (-2, True),
         (-2, False)
@@ -1024,7 +1018,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         )
         self.assertContains(response, date)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @ddt.data(
         (True, False),
         (False, False),
@@ -1072,7 +1066,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
         self.assertContains(response, date)
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_render_html_view_invalid_certificate_configuration(self):
         self.course.cert_html_view_enabled = True
         self.course.save()
@@ -1087,7 +1081,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, "Invalid Certificate")
 
     # TEMPLATES WITHOUT LANGUAGE TESTS
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @override_settings(LANGUAGE_CODE='fr')
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_org_mode_and_course_key(self, mock_get_course_run_details):
@@ -1122,7 +1116,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertContains(response, 'lang: fr')
             self.assertContains(response, 'course name: test_template_3_course')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_org_and_mode(self, mock_get_course_run_details):
         """
@@ -1157,7 +1151,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             assert response.status_code == 200
             self.assertContains(response, 'course name: test_template_1_course')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_org(self, mock_get_course_run_details):
         """
@@ -1181,7 +1175,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             assert response.status_code == 200
             self.assertContains(response, 'course name: test_template_1_course')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_custom_template_with_mode(self, mock_get_course_run_details):
         """
@@ -1209,7 +1203,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
     # Templates With Language tests
     # 1
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @override_settings(LANGUAGE_CODE='fr')
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
@@ -1294,7 +1288,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 2
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_org_and_mode(self, mock_get_org_id, mock_get_course_run_details):
@@ -1354,7 +1348,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 3
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_org(self, mock_get_org_id, mock_get_course_run_details):
@@ -1412,7 +1406,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertContains(response, 'course name: test_right_lang_template')
 
     # 4
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_mode(self, mock_get_org_id, mock_get_course_run_details):
@@ -1470,7 +1464,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         assert response.status_code == 200
         self.assertContains(response, 'course name: test_right_lang_template')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
     def test_certificate_custom_language_template_with_locale_language_from_catalogue(
@@ -1532,7 +1526,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         assert response.status_code == 200
         self.assertContains(response, 'course name: test_right_lang_template')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @ddt.data(True, False)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     @patch('lms.djangoapps.certificates.api.get_course_organization_id')
@@ -1578,10 +1572,10 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         mode = 'honor'
         self._add_course_certificates(count=1, signatory_count=2)
         self._create_custom_template(mode=mode)
-        with patch.dict("django.conf.settings.FEATURES", {
-            "CERTIFICATES_HTML_VIEW": True,
-            "CUSTOM_CERTIFICATE_TEMPLATES_ENABLED": custom_certs_enabled
-        }):
+        with override_settings(CERTIFICATES_HTML_VIEW=True), patch.dict(
+            "django.conf.settings.FEATURES",
+            {"CUSTOM_CERTIFICATE_TEMPLATES_ENABLED": custom_certs_enabled},
+        ):
             test_url = get_certificate_url(
                 user_id=self.user.id,
                 course_id=str(self.course.id),
@@ -1603,7 +1597,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
                             self.assertContains(response, "Tweet this Accomplishment")
                         self.assertContains(response, 'https://twitter.com/intent/tweet')
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
     def test_certificate_asset_by_slug(self, mock_get_course_run_details):
         """
@@ -1642,7 +1636,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             )
 
     @skipUnless(name_affirmation_service is not None, 'Requires Name Affirmation')
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     @ddt.data((True, 'approved'),
               (True, 'denied'),
               (False, 'pending'))
@@ -1679,7 +1673,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertContains(response, self.user.profile.name)
             self.assertNotContains(response, verified_name)
 
-    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED, CERTIFICATES_HTML_VIEW=True)
     @ddt.data(
         True,
         False
@@ -1823,7 +1817,7 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
     Test events emitted by certificate handling.
     """
 
-    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_certificate_evidence_event_emitted(self):
         self.client.logout()
         self._add_course_certificates(count=1, signatory_count=2)

--- a/lms/djangoapps/certificates/utils.py
+++ b/lms/djangoapps/certificates/utils.py
@@ -87,7 +87,7 @@ def has_html_certificates_enabled(course_overview):
     """
     Returns True if HTML certificates are enabled in a course run.
     """
-    if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+    if not settings.CERTIFICATES_HTML_VIEW:
         return False
     return course_overview.cert_html_view_enabled
 

--- a/lms/djangoapps/certificates/views/tests/test_filters.py
+++ b/lms/djangoapps/certificates/views/tests/test_filters.py
@@ -1,7 +1,6 @@
 """
 Test that various filters are fired for views in the certificates app.
 """
-from django.conf import settings
 from django.http import HttpResponse
 from django.test import override_settings
 from openedx_filters import PipelineStep
@@ -14,9 +13,6 @@ from lms.djangoapps.certificates.utils import get_certificate_url
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-
-FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
 
 
 class TestStopCertificateRenderStep(PipelineStep):
@@ -120,7 +116,7 @@ class CertificateFiltersTest(CommonCertificatesTestCase, SharedModuleStoreTestCa
                 "fail_silently": False,
             },
         },
-        FEATURES=FEATURES_WITH_CERTS_ENABLED,
+        CERTIFICATES_HTML_VIEW=True,
     )
     def test_certificate_render_filter_executed(self):
         """
@@ -154,7 +150,7 @@ class CertificateFiltersTest(CommonCertificatesTestCase, SharedModuleStoreTestCa
                 "fail_silently": False,
             },
         },
-        FEATURES=FEATURES_WITH_CERTS_ENABLED,
+        CERTIFICATES_HTML_VIEW=True,
     )
     def test_certificate_render_invalid(self):
         """
@@ -186,7 +182,7 @@ class CertificateFiltersTest(CommonCertificatesTestCase, SharedModuleStoreTestCa
                 "fail_silently": False,
             },
         },
-        FEATURES=FEATURES_WITH_CERTS_ENABLED,
+        CERTIFICATES_HTML_VIEW=True,
     )
     def test_certificate_redirect(self):
         """
@@ -217,7 +213,7 @@ class CertificateFiltersTest(CommonCertificatesTestCase, SharedModuleStoreTestCa
                 "fail_silently": False,
             },
         },
-        FEATURES=FEATURES_WITH_CERTS_ENABLED,
+        CERTIFICATES_HTML_VIEW=True,
     )
     def test_certificate_render_custom_response(self):
         """
@@ -240,7 +236,7 @@ class CertificateFiltersTest(CommonCertificatesTestCase, SharedModuleStoreTestCa
 
     @override_settings(
         OPEN_EDX_FILTERS_CONFIG={},
-        FEATURES=FEATURES_WITH_CERTS_ENABLED,
+        CERTIFICATES_HTML_VIEW=True,
     )
     @with_site_configuration(
         configuration={

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -475,7 +475,7 @@ def render_html_view(request, course_id, certificate=None):  # pylint: disable=t
     configuration = CertificateHtmlViewConfiguration.get_config()
 
     # Kick the user back to the "Invalid" screen if the feature is disabled globally
-    if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+    if not settings.CERTIFICATES_HTML_VIEW:
         return _render_invalid_certificate(request, course_id, platform_name, configuration)
 
     # Load the course and user objects

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -531,7 +531,7 @@ def render_html_view(request, course_id, certificate=None):  # pylint: disable=t
     # Determine whether to use the standard or custom template to render the certificate.
     custom_template = None
     custom_template_language = None
-    if settings.FEATURES.get('CUSTOM_CERTIFICATE_TEMPLATES_ENABLED', False):
+    if settings.CUSTOM_CERTIFICATE_TEMPLATES_ENABLED:
         log.info("Custom certificate for course %s", course_id)
         custom_template, custom_template_language = _get_custom_template_and_language(
             course.id,

--- a/lms/djangoapps/commerce/api/v0/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v0/tests/test_views.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 
 import ddt
 import pytz
-from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse, reverse_lazy
@@ -88,7 +87,7 @@ class BasketsViewTests(UserMixin, ModuleStoreTestCase):
                 bulk_sku=f'BULK-{sku_string}'
             )
 
-    @mock.patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_embargo_restriction(self):
         """
         The view should return HTTP 403 status if the course is embargoed.

--- a/lms/djangoapps/course_api/blocks/transformers/milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/milestones.py
@@ -73,7 +73,7 @@ class MilestonesAndSpecialExamsTransformer(BlockStructureTransformer):
                 return True
             elif not self.include_gated_sections and self.has_pending_milestones_for_user(block_key, usage_info):
                 return True
-            elif (settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
+            elif (settings.ENABLE_SPECIAL_EXAMS and
                   (self.is_special_exam(block_key, block_structure) and
                    not self.include_special_exams)):
                 return True

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
@@ -6,6 +6,7 @@ Tests for ProctoredExamTransformer.
 from unittest.mock import Mock, patch
 
 import ddt
+from django.test import override_settings
 from edx_toggles.toggles.testutils import override_waffle_flag
 from milestones.tests.utils import MilestonesTestCaseMixin
 
@@ -26,7 +27,7 @@ QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES + AUTHZ_TABLES
 
 
 @ddt.ddt
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseMixin):
     """
     Test behavior of ProctoredExamTransformer

--- a/lms/djangoapps/course_goals/tests/test_user_activity.py
+++ b/lms/djangoapps/course_goals/tests/test_user_activity.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import ddt
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 from edx_django_utils.cache import TieredCache
@@ -27,11 +28,11 @@ User = get_user_model()
 
 @ddt.ddt
 @override_waffle_flag(ENABLE_COURSE_GOALS, active=True)
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class UserActivityTests(UrlResetMixin, ModuleStoreTestCase):
     """
     Testing Course Goals User Activity
     """
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(
@@ -168,7 +169,7 @@ class UserActivityTests(UrlResetMixin, ModuleStoreTestCase):
     def test_mobile_app_user_activity_calls(self, url):
         url = url.replace('{COURSE_ID}', str(self.course.id))
         with patch.object(UserActivity, 'record_user_activity') as record_user_activity_mock:
-            with patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}):
+            with override_settings(ENABLE_DISCUSSION_SERVICE=True):
                 self.client.get(url)
                 record_user_activity_mock.assert_called_once()
 

--- a/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
@@ -241,7 +241,7 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
 
         self._assert_course_access_response(response, expect_course_access, error_code)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     @ddt.data(True, False)
     def test_discussion_tab_visible(self, visible):
         """

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -251,7 +251,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         }
         assert course_goals == expected_course_goals
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     @patch('lms.djangoapps.course_api.blocks.transformers.milestones.get_attempt_status_summary')
     def test_proctored_exam(self, mock_summary):
         course = CourseFactory.create(
@@ -620,7 +620,7 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         response = self.client.get(url)
         assert response.status_code == 404
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     @patch('lms.djangoapps.course_api.blocks.transformers.milestones.get_attempt_status_summary')
     def test_proctored_exam(self, mock_summary):
         """

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -556,7 +556,7 @@ def prepare_runtime_for_user(
         block_wrappers.append(filter_displayed_blocks)
 
     mako_service = MakoService()
-    if settings.FEATURES.get("LICENSING", False):
+    if settings.LICENSING:
         block_wrappers.append(partial(wrap_with_license, mako_service=mako_service))
 
     # Wrap the output display in a single div to allow for the XBlock

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -260,7 +260,7 @@ def _add_timed_exam_info(user, course, section, section_context):
     """
     section_is_time_limited = (
         getattr(section, 'is_time_limited', False) and
-        settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False)
+        settings.ENABLE_SPECIAL_EXAMS
     )
     if section_is_time_limited:
         # call into edx_proctoring subsystem

--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -591,7 +591,7 @@ class VerificationDeadlineDate(DateSummary):
             is_active and
             mode == 'verified' and
             self.verification_status in ('expired', 'none', 'must_reverify') and
-            not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE')
+            not settings.ENABLE_INTEGRITY_SIGNATURE
         )
 
     @lazy

--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -235,7 +235,7 @@ class ProctoringCourseApp(CourseApp):
         """
         Returns true if the proctoring app is available for all courses.
         """
-        return settings.FEATURES.get('ENABLE_PROCTORED_EXAMS')
+        return settings.ENABLE_PROCTORED_EXAMS
 
     @classmethod
     def is_enabled(cls, course_key: CourseKey) -> bool:

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -1141,7 +1141,7 @@ class TestTOC(ModuleStoreTestCase):
 
 
 @ddt.ddt
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 class TestProctoringRendering(ModuleStoreTestCase):
     """Check the Table of Contents for a course"""
     def setUp(self):

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -3,12 +3,10 @@
 
 
 from datetime import datetime, timedelta
-from unittest.mock import patch
 
 import crum
 import ddt
-from django.conf import settings
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 from freezegun import freeze_time
 from pytz import utc
@@ -570,7 +568,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         block = VerificationDeadlineDate(course, user)
         assert not block.is_allowed
 
-    @patch.dict(settings.FEATURES, {'ENABLE_INTEGRITY_SIGNATURE': True})
+    @override_settings(ENABLE_INTEGRITY_SIGNATURE=True)
     def test_verification_deadline_with_integrity_signature(self):
         course = create_course_run(days_till_start=-1)
         user = create_user()

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -13,7 +13,6 @@ from unittest import mock
 from unittest.mock import patch
 
 import ddt
-from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
@@ -171,7 +170,7 @@ class TestViews(TestDiscussionXBlock):
             'is_visible': True,
         }
 
-    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     @ddt.data(
         (False, False, False),
         (True, False, False),
@@ -242,7 +241,7 @@ class TestTemplates(TestDiscussionXBlock):
         fragment = self.block.author_view({})
         assert f'data-discussion-id="{self.discussion_id}"' in fragment.content
 
-    @override_settings(FEATURES=dict(settings.FEATURES, ENABLE_DISCUSSION_SERVICE='True'))
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     @ddt.data(
         (True, False, False),
         (False, True, False),

--- a/lms/djangoapps/courseware/tests/test_rules.py
+++ b/lms/djangoapps/courseware/tests/test_rules.py
@@ -6,6 +6,7 @@ Tests for permissions defined in courseware.rules
 from unittest.mock import patch
 
 import ddt
+from django.test.utils import override_settings
 
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.student.models import CourseEnrollment
@@ -17,13 +18,8 @@ from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable
 
 
 @ddt.ddt
-@patch.dict(
-    'django.conf.settings.FEATURES',
-    {
-        'ENABLE_SPECIAL_EXAMS': True,
-        'ENABLE_PROCTORED_EXAMS': True,
-    }
-)
+@override_settings(ENABLE_PROCTORED_EXAMS=True)
+@patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
 class PermissionTests(ModuleStoreTestCase):
     """
     Tests for permissions defined in courseware.rules

--- a/lms/djangoapps/courseware/tests/test_rules.py
+++ b/lms/djangoapps/courseware/tests/test_rules.py
@@ -18,8 +18,7 @@ from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable
 
 
 @ddt.ddt
-@override_settings(ENABLE_PROCTORED_EXAMS=True)
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_PROCTORED_EXAMS=True, ENABLE_SPECIAL_EXAMS=True)
 class PermissionTests(ModuleStoreTestCase):
     """
     Tests for permissions defined in courseware.rules

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -615,9 +615,9 @@ class CourseTabListTestCase(TabListTestCase):
         assert not self.has_tab(self.course.tabs, 'external_discussion')
         assert self.has_tab(self.course.tabs, 'discussion')
 
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     @patch.dict("django.conf.settings.FEATURES", {
         "ENABLE_TEXTBOOK": True,
-        "ENABLE_DISCUSSION_SERVICE": True,
         "ENABLE_EDXNOTES": True,
     })
     def test_iterate_displayable(self):
@@ -775,7 +775,7 @@ class DiscussionLinkTestCase(TabTestCase):
                     (discussion_tab.link_func(self.course, reverse)
                      == expected_discussion_link)) == expected_can_display_value
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": False})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=False)
     def test_explicit_discussion_link(self):
         """Test that setting discussion_link overrides everything else"""
         self.check_discussion(
@@ -785,7 +785,7 @@ class DiscussionLinkTestCase(TabTestCase):
             expected_can_display_value=True,
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": False})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=False)
     def test_discussions_disabled(self):
         """Test that other cases return None with discussions disabled"""
         for tab_list in [[], self.tabs_with_discussion, self.tabs_without_discussion]:
@@ -795,7 +795,7 @@ class DiscussionLinkTestCase(TabTestCase):
                 expected_can_display_value=False,
             )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_tabs_with_discussion(self):
         """Test a course with a discussion tab configured"""
         self.check_discussion(
@@ -804,7 +804,7 @@ class DiscussionLinkTestCase(TabTestCase):
             expected_can_display_value=True,
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_tabs_without_discussion(self):
         """Test a course with tabs configured but without a discussion tab"""
         self.check_discussion(
@@ -813,7 +813,7 @@ class DiscussionLinkTestCase(TabTestCase):
             expected_can_display_value=False,
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_tabs_enrolled_or_staff(self):
         for is_enrolled, is_staff in [(True, False), (False, True)]:
             self.check_discussion(
@@ -824,7 +824,7 @@ class DiscussionLinkTestCase(TabTestCase):
                 is_staff=is_staff
             )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_tabs_not_enrolled_or_staff(self):
         is_enrolled = is_staff = False
         self.check_discussion(
@@ -842,7 +842,7 @@ class DiscussionLinkTestCase(TabTestCase):
         else:
             expected_link = reverse("forum_form_discussion", args=[str(self.course.id)])
 
-        with self.settings(FEATURES={'ENABLE_DISCUSSION_SERVICE': True}):
+        with override_settings(ENABLE_DISCUSSION_SERVICE=True):
             with override_waffle_flag(ENABLE_DISCUSSIONS_MFE, toggle_enabled):
                 self.check_discussion(
                     tab_list=self.tabs_with_discussion,

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2505,7 +2505,7 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
         }
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PROCTORED_EXAMS': True})
+    @override_settings(ENABLE_PROCTORED_EXAMS=True)
     @patch('lms.djangoapps.courseware.views.views.unpack_jwt')
     def test_render_descendant_of_exam_gated_by_access_token(self, exam_access_token,
                                                              expected_response, _mock_unpack_jwt):  # noqa: PT019

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1181,7 +1181,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         resp = self._get_progress_page()
         self.assertNotContains(resp, 'Request Certificate')
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_view_certificate_for_unverified_student(self):
         """
         If user has already generated a certificate, it should be visible in case of user being
@@ -1212,7 +1212,7 @@ class ProgressPageTests(ProgressPageBaseTests):
             self.assertNotContains(resp, "Certificate unavailable")
             self.assertContains(resp, "Your certificate is available")
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_view_certificate_link(self):
         """
         If certificate web view is enabled then certificate web view button should appear for user who certificate is
@@ -1337,7 +1337,7 @@ class ProgressPageTests(ProgressPageBaseTests):
 
                 assert cert_button_hidden == ('Request Certificate' not in resp.content.decode('utf-8'))
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_page_with_invalidated_certificate_with_html_view(self):
         """
         Verify that for html certs if certificate is marked as invalidated than
@@ -1373,7 +1373,7 @@ class ProgressPageTests(ProgressPageBaseTests):
             self.assertContains(resp, "View Certificate")
             self.assert_invalidate_certificate(generated_certificate)
 
-    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_page_with_allowlisted_certificate_with_html_view(self):
         """
         Verify that view certificate appears for an allowlisted user

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1706,7 +1706,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True, disable_sta
                 'enable_completion_on_view_service': enable_completion_on_view_service,
                 'edx_notes_enabled': is_feature_enabled(course, request.user),
                 'staff_access': staff_access,
-                'xqa_server': settings.FEATURES.get('XQA_SERVER', 'http://your_xqa_server.com'),
+                'xqa_server': settings.XQA_SERVER,
                 'missed_deadlines': missed_deadlines,
                 'missed_gated_content': missed_gated_content,
                 'has_ended': course.has_ended(),

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -833,7 +833,7 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
         show_courseware_link = bool(
             (
                 request.user.has_perm(VIEW_COURSEWARE, course)
-            ) or settings.FEATURES.get('ENABLE_LMS_MIGRATION')
+            ) or settings.ENABLE_LMS_MIGRATION
         )
 
         # If the ecommerce checkout flow is enabled and the mode of the course is

--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -10,15 +10,7 @@ WAFFLE_NAMESPACE = 'discussion'
 
 def is_forum_daily_digest_enabled():
     """Returns whether forum notification features should be visible"""
-    # .. toggle_name: FEATURES['ENABLE_FORUM_DAILY_DIGEST']
-    # .. toggle_implementation: DjangoSetting
-    # .. toggle_default: False
-    # .. toggle_description: Settings for forums/discussions to on/off daily digest
-    #   feature. Set this to True if you want to enable users to subscribe and unsubscribe
-    #   for daily digest. This setting enables deprecation of daily digest.
-    # .. toggle_use_cases: open_edx
-    # .. toggle_creation_date: 2020-03-09
-    return settings.FEATURES.get('ENABLE_FORUM_DAILY_DIGEST', False)
+    return settings.ENABLE_FORUM_DAILY_DIGEST
 
 # .. toggle_name: discussion.enable_captcha
 # .. toggle_implementation: CourseWaffleFlag

--- a/lms/djangoapps/discussion/django_comment_client/base/tests_v2.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests_v2.py
@@ -11,6 +11,7 @@ import ddt
 import pytest
 from django.contrib.auth.models import User
 from django.core.management import call_command
+from django.test import override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 from eventtracking.processors.exceptions import EventEmissionExit
@@ -369,6 +370,7 @@ class ViewsTestCaseMixin:
 @ddt.ddt
 @disable_signal(views, "comment_flagged")
 @disable_signal(views, "thread_flagged")
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ViewsTestCase(
     MockForumApiMixin,
     UrlResetMixin,
@@ -404,11 +406,10 @@ class ViewsTestCase(
         # seed the forums permissions and roles
         call_command("seed_permissions_roles", str(cls.course_id))
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
-        # Patching the ENABLE_DISCUSSION_SERVICE value affects the contents of urls.py,
-        # so we need to call super.setUp() which reloads urls.py (because
-        # of the UrlResetMixin)
+        # The class-level @override_settings(ENABLE_DISCUSSION_SERVICE=True) above
+        # affects the contents of urls.py, so we need to call super.setUp() which
+        # reloads urls.py (because of the UrlResetMixin).
         super().setUp()
         # Patch the comment client user save method so it does not try
         # to create a new cc user when creating a django user
@@ -995,6 +996,7 @@ class ViewsTestCase(
 
 
 @disable_signal(views, "comment_endorsed")
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ViewPermissionsTestCase(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -1034,7 +1036,6 @@ class ViewPermissionsTestCase(
             Role.objects.get(name="Moderator", course_id=cls.course.id)
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         """Set up the test case."""
         super().setUp()
@@ -1210,6 +1211,7 @@ class CommentActionTestCase(CohortedTestCase, MockForumApiMixin):
 @disable_signal(views, "comment_deleted")
 @disable_signal(views, "comment_flagged")
 @disable_signal(views, "thread_flagged")
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class TeamsPermissionsTestCase(
     UrlResetMixin, SharedModuleStoreTestCase, MockForumApiMixin
 ):
@@ -1328,9 +1330,6 @@ class TeamsPermissionsTestCase(
             users=[cls.group_moderator, cls.cohorted],
         )
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUp(self):
         super().setUp()
 
@@ -2444,6 +2443,7 @@ def _create_and_transform_event(**kwargs):
 
 
 @ddt.ddt
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ForumThreadViewedEventTransformerTestCase(UrlResetMixin, ModuleStoreTestCase):
     """
     Test that the ForumThreadViewedEventTransformer transforms events correctly
@@ -2466,7 +2466,6 @@ class ForumThreadViewedEventTransformerTestCase(UrlResetMixin, ModuleStoreTestCa
     DUMMY_CATEGORY_ID = 'i4x-edx-dummy-commentable-id'
     DUMMY_THREAD_ID = 'dummy_thread_id'
 
-    @mock.patch.dict("common.djangoapps.student.models.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import ddt
 import pytest
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.keys import CourseKey
@@ -1165,7 +1165,7 @@ class DiscussionTabTestCase(ModuleStoreTestCase):
         return any(tab.type == 'discussion' for tab in all_tabs)
 
     def test_tab_access(self):
-        with self.settings(FEATURES={'ENABLE_DISCUSSION_SERVICE': True}):
+        with override_settings(ENABLE_DISCUSSION_SERVICE=True):
             assert self.discussion_tab_present(self.staff_user)
             assert self.discussion_tab_present(self.enrolled_user)
             assert not self.discussion_tab_present(self.unenrolled_user)
@@ -1173,7 +1173,7 @@ class DiscussionTabTestCase(ModuleStoreTestCase):
     @mock.patch('lms.djangoapps.ccx.overrides.get_current_ccx')
     def test_tab_settings(self, mock_get_ccx):
         mock_get_ccx.return_value = True
-        with self.settings(FEATURES={'ENABLE_DISCUSSION_SERVICE': False}):
+        with override_settings(ENABLE_DISCUSSION_SERVICE=False):
             assert not self.discussion_tab_present(self.enrolled_user)
 
         with self.settings(FEATURES={'CUSTOM_COURSES_EDX': True}):

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
@@ -1176,7 +1176,7 @@ class DiscussionTabTestCase(ModuleStoreTestCase):
         with override_settings(ENABLE_DISCUSSION_SERVICE=False):
             assert not self.discussion_tab_present(self.enrolled_user)
 
-        with self.settings(FEATURES={'CUSTOM_COURSES_EDX': True}):
+        with override_settings(CUSTOM_COURSES_EDX=True):
             assert not self.discussion_tab_present(self.enrolled_user)
 
 

--- a/lms/djangoapps/discussion/django_comment_client/tests/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/utils.py
@@ -3,7 +3,7 @@ Utilities for tests within the django_comment_client module.
 """
 
 
-from unittest.mock import patch
+from django.test import override_settings
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from common.djangoapps.util.testing import UrlResetMixin
@@ -17,12 +17,12 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class CohortedTestCase(UrlResetMixin, SharedModuleStoreTestCase):
     """
     Sets up a course with a student, a moderator and their cohorts.
     """
     @classmethod
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create(
@@ -43,7 +43,6 @@ class CohortedTestCase(UrlResetMixin, SharedModuleStoreTestCase):
         fake_user_id = 1
         cls.store.update_item(cls.course, fake_user_id)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super().setUp()
 

--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -1016,7 +1016,7 @@ def is_discussion_enabled(course_id):
     """
     Return True if discussions are enabled; else False
     """
-    return settings.FEATURES.get('ENABLE_DISCUSSION_SERVICE')
+    return settings.ENABLE_DISCUSSION_SERVICE
 
 
 def is_content_authored_by(content, user):

--- a/lms/djangoapps/discussion/notification_prefs/tests.py
+++ b/lms/djangoapps/discussion/notification_prefs/tests.py
@@ -23,11 +23,10 @@ from lms.djangoapps.discussion.notification_prefs.views import (
 from openedx.core.djangoapps.user_api.models import UserPreference
 
 
-@override_settings(SECRET_KEY="test secret key")
+@override_settings(SECRET_KEY="test secret key", ENABLE_DISCUSSION_SERVICE=True)
 class NotificationPrefViewTest(UrlResetMixin, TestCase):  # pylint: disable=missing-class-docstring
     INITIALIZATION_VECTOR = b"\x00" * 16
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_FORUM_DAILY_DIGEST": True})
     def setUp(self):
         super().setUp()

--- a/lms/djangoapps/discussion/notification_prefs/tests.py
+++ b/lms/djangoapps/discussion/notification_prefs/tests.py
@@ -23,11 +23,10 @@ from lms.djangoapps.discussion.notification_prefs.views import (
 from openedx.core.djangoapps.user_api.models import UserPreference
 
 
-@override_settings(SECRET_KEY="test secret key", ENABLE_DISCUSSION_SERVICE=True)
+@override_settings(SECRET_KEY="test secret key", ENABLE_DISCUSSION_SERVICE=True, ENABLE_FORUM_DAILY_DIGEST=True)
 class NotificationPrefViewTest(UrlResetMixin, TestCase):  # pylint: disable=missing-class-docstring
     INITIALIZATION_VECTOR = b"\x00" * 16
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_FORUM_DAILY_DIGEST": True})
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create(username="testuser")

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -2,11 +2,11 @@
 Tests for Discussion API internal interface
 """
 
-from unittest import mock
 
 import ddt
 import pytest
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from django.test.client import RequestFactory
 from opaque_keys.edx.keys import CourseKey
 
@@ -21,7 +21,7 @@ User = get_user_model()
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class GetUserCommentsTest(ForumMockUtilsMixin, SharedModuleStoreTestCase):
     """
     Tests for get_user_comments.
@@ -37,7 +37,6 @@ class GetUserCommentsTest(ForumMockUtilsMixin, SharedModuleStoreTestCase):
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super().setUp()
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
@@ -169,7 +169,7 @@ def _set_course_discussion_blackout(course, user_id):
 @ddt.ddt
 @disable_signal(api, "thread_created")
 @disable_signal(api, "thread_voted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class CreateThreadTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -228,9 +228,6 @@ class CreateThreadTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create()
@@ -585,7 +582,7 @@ class CreateThreadTest(
 @ddt.ddt
 @disable_signal(api, "comment_created")
 @disable_signal(api, "comment_voted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 @mock.patch(
     "lms.djangoapps.discussion.signals.handlers.send_response_notifications",
     new=mock.Mock(),
@@ -610,9 +607,6 @@ class CreateCommentTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -1028,7 +1022,7 @@ class CreateCommentTest(
 @ddt.ddt
 @disable_signal(api, "thread_edited")
 @disable_signal(api, "thread_voted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class UpdateThreadTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -1049,9 +1043,6 @@ class UpdateThreadTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUp(self):
         super().setUp()
 
@@ -1688,7 +1679,7 @@ class UpdateThreadTest(
 @ddt.ddt
 @disable_signal(api, "comment_edited")
 @disable_signal(api, "comment_voted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class UpdateCommentTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -1709,9 +1700,6 @@ class UpdateCommentTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUp(self):
         super().setUp()
 
@@ -2293,7 +2281,7 @@ class UpdateCommentTest(
 
 @ddt.ddt
 @disable_signal(api, "thread_deleted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class DeleteThreadTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -2314,9 +2302,6 @@ class DeleteThreadTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -2472,7 +2457,7 @@ class DeleteThreadTest(
 
 @ddt.ddt
 @disable_signal(api, "comment_deleted")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class DeleteCommentTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -2493,9 +2478,6 @@ class DeleteCommentTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -2662,7 +2644,7 @@ class DeleteCommentTest(
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class RetrieveThreadTest(
     UrlResetMixin,
     SharedModuleStoreTestCase,
@@ -2682,9 +2664,6 @@ class RetrieveThreadTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -2818,7 +2797,7 @@ class RetrieveThreadTest(
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class GetThreadListTest(
         ForumMockUtilsMixin, UrlResetMixin, SharedModuleStoreTestCase
 ):
@@ -2836,9 +2815,6 @@ class GetThreadListTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -3453,7 +3429,7 @@ class GetThreadListTest(
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class GetCommentListTest(
         SharedModuleStoreTestCase, ForumMockUtilsMixin
 ):
@@ -3471,9 +3447,6 @@ class GetCommentListTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -4225,10 +4198,9 @@ class CourseTopicsV2Test(ModuleStoreTestCase):
 
 
 @mock.patch.dict("django.conf.settings.FEATURES", {"DISABLE_START_DATES": False})
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class GetCourseTopicsTest(ForumMockUtilsMixin, UrlResetMixin, ModuleStoreTestCase):
     """Test for get_course_topics"""
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         httpretty.reset()
         httpretty.enable()
@@ -4660,7 +4632,7 @@ class GetCourseTopicsTest(ForumMockUtilsMixin, UrlResetMixin, ModuleStoreTestCas
         }
 
 
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 @override_settings(DISCUSSION_MODERATION_EDIT_REASON_CODES={"test-edit-reason": "Test Edit Reason"})
 @override_settings(DISCUSSION_MODERATION_CLOSE_REASON_CODES={"test-close-reason": "Test Close Reason"})
 @ddt.ddt
@@ -4671,7 +4643,6 @@ class GetCourseTest(UrlResetMixin, SharedModuleStoreTestCase):
         super().setUpClass()
         cls.course = CourseFactory.create(org="x", course="y", run="z")
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create()
@@ -4744,12 +4715,11 @@ class GetCourseTest(UrlResetMixin, SharedModuleStoreTestCase):
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class GetCourseTestBlackouts(UrlResetMixin, ModuleStoreTestCase):
     """
     Tests of get_course for courses that have blackout dates.
     """
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(org="x", course="y", run="z")

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers_v2.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import ddt
 import httpretty
+from django.test import override_settings
 from django.test.client import RequestFactory
 
 from common.djangoapps.student.tests.factories import UserFactory
@@ -385,6 +386,7 @@ class CommentSerializerDeserializationTest(ForumMockUtilsMixin, SharedModuleStor
 
 
 @ddt.ddt
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ThreadSerializerDeserializationTest(
         ForumMockUtilsMixin,
         UrlResetMixin,
@@ -392,7 +394,6 @@ class ThreadSerializerDeserializationTest(
 ):
     """Tests for ThreadSerializer deserialization."""
     @classmethod
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create()
@@ -404,7 +405,6 @@ class ThreadSerializerDeserializationTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -538,7 +538,6 @@ class SerializerTestMixin(UrlResetMixin, ForumMockUtilsMixin):
     Test Mixin for Serializer tests
     """
     @classmethod
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUpClass(cls):
         super().setUpClass()
         cls.course = CourseFactory.create()
@@ -550,7 +549,6 @@ class SerializerTestMixin(UrlResetMixin, ForumMockUtilsMixin):
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super().setUp()
         httpretty.reset()
@@ -658,6 +656,7 @@ class SerializerTestMixin(UrlResetMixin, ForumMockUtilsMixin):
 
 
 @ddt.ddt
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
     """Tests for CommentSerializer."""
 
@@ -844,6 +843,7 @@ class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
 
 
 @ddt.ddt
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTestCase, ForumMockUtilsMixin):
     """Tests for ThreadSerializer serialization."""
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks_v2.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import ddt
 import httpretty
 from django.conf import settings
+from django.test import override_settings
 from openedx_events.learning.signals import COURSE_NOTIFICATION_REQUESTED, USER_NOTIFICATION_REQUESTED
 
 from common.djangoapps.student.models import CourseEnrollment
@@ -492,7 +493,7 @@ class TestSendCommentNotification(DiscussionAPIViewTestMixin, ModuleStoreTestCas
 
 @ddt.ddt
 @httpretty.activate
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class TestNewThreadCreatedNotification(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """
     Test cases related to new_discussion_post and new_question_post notification types

--- a/lms/djangoapps/discussion/rest_api/tests/test_views.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views.py
@@ -4,10 +4,10 @@ Tests for Discussion API views
 
 import json
 from datetime import datetime
-from unittest import mock
 from urllib.parse import urlencode
 
 import ddt
+from django.test import override_settings
 from django.urls import reverse
 from pytz import UTC
 from rest_framework import status
@@ -25,7 +25,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class CommentViewSetListByUserTest(
     ForumMockUtilsMixin,
     UrlResetMixin,
@@ -45,7 +45,6 @@ class CommentViewSetListByUserTest(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super().setUp()
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
@@ -74,9 +74,6 @@ class DiscussionAPIViewTestMixin(ForumMockUtilsMixin, UrlResetMixin):
 
     client_class = APIClient
 
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUp(self):
         super().setUp()
         self.maxDiff = None  # pylint: disable=invalid-name
@@ -169,7 +166,7 @@ class DiscussionAPIViewTestMixin(ForumMockUtilsMixin, UrlResetMixin):
 @ddt.ddt
 @httpretty.activate
 @disable_signal(api, "thread_edited")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ThreadViewSetPartialUpdateTest(
     DiscussionAPIViewTestMixin, ModuleStoreTestCase, PatchMediaTypeMixin
 ):
@@ -352,7 +349,7 @@ class ThreadViewSetPartialUpdateTest(
 
 @ddt.ddt
 @disable_signal(api, "comment_edited")
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class CommentViewSetPartialUpdateTest(
     DiscussionAPIViewTestMixin, ModuleStoreTestCase, PatchMediaTypeMixin
 ):
@@ -486,7 +483,7 @@ class CommentViewSetPartialUpdateTest(
 
 @ddt.ddt
 @httpretty.activate
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ThreadViewSetListTest(
     DiscussionAPIViewTestMixin, ModuleStoreTestCase, ProfileImageTestMixin
 ):
@@ -883,7 +880,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     Tests for the BulkDeleteUserPostsViewSet
     """
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self) -> None:
         super().setUp()
         self.course = CourseFactory.create()
@@ -928,7 +925,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_regular_user(self):
         """
         Tests that for a regular user stats are returned without flag counts
@@ -938,7 +935,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         data = response.json()
         assert data["results"] == self.stats_without_flags
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_moderator_user(self):
         """
         Tests that for a moderator user stats are returned with flag counts
@@ -958,7 +955,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         ("user", "recency", "recency"),
     )
     @ddt.unpack
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_sorting(self, username, ordering_requested, ordering_performed):
         """
         Test valid sorting options and defaults
@@ -973,7 +970,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         assert params["sort_key"] == ordering_performed
 
     @ddt.data("flagged", "xyz")
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_sorting_error_regular_user(self, order_by):
         """
         Test for invalid sorting options for regular users.
@@ -987,7 +984,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         ('moderator', 'moderator'),
     )
     @ddt.unpack
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param(self, username_search_string, comma_separated_usernames):
         """
         Test for endpoint with username param.
@@ -999,7 +996,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         params = self.get_mock_func_calls("get_user_course_stats")[-1][1]
         assert params["usernames"] == comma_separated_usernames
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param_with_no_matches(self):
         """
         Test for endpoint with username param with no matches.
@@ -1017,7 +1014,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         'User-2',
         'UsEr-3'
     )
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param_case(self, username_search_string):
         """
         Test user search function is case-insensitive.
@@ -1037,7 +1034,7 @@ class BulkDeleteUserPostsTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
 
 
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 @override_settings(DISCUSSION_MODERATION_EDIT_REASON_CODES={"test-edit-reason": "Test Edit Reason"})
 @override_settings(DISCUSSION_MODERATION_CLOSE_REASON_CODES={"test-close-reason": "Test Close Reason"})
 class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
@@ -1098,7 +1095,7 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 @ddt.ddt
 @httpretty.activate
 @mock.patch('django.conf.settings.USERNAME_REPLACEMENT_WORKER', 'test_replace_username_service_worker')
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ReplaceUsernamesViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for ReplaceUsernamesView"""
 
@@ -1192,7 +1189,7 @@ class ReplaceUsernamesViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 
 
 @ddt.ddt
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class CourseTopicsViewTest(DiscussionAPIViewTestMixin, CommentsServiceMockMixin, ModuleStoreTestCase):
     """
     Tests for CourseTopicsView
@@ -1402,7 +1399,7 @@ class CourseTopicsViewTest(DiscussionAPIViewTestMixin, CommentsServiceMockMixin,
 
 @ddt.ddt
 @mock.patch('lms.djangoapps.discussion.rest_api.api._get_course', mock.Mock())
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 @override_waffle_flag(ENABLE_NEW_STRUCTURE_DISCUSSIONS, True)
 class CourseTopicsViewV3Test(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """
@@ -1494,7 +1491,7 @@ class CourseTopicsViewV3Test(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 
 @ddt.ddt
 @httpretty.activate
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class LearnerThreadViewAPITest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for LearnerThreadView list"""
 
@@ -1806,13 +1803,13 @@ class LearnerThreadViewAPITest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 @ddt.ddt
 @httpretty.activate
 @override_waffle_flag(ENABLE_DISCUSSIONS_MFE, True)
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
                               SharedModuleStoreTestCase):
     """
     Tests for the course stats endpoint
     """
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self) -> None:
         super().setUp()
         self.course = CourseFactory.create()
@@ -1857,7 +1854,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_regular_user(self):
         """
         Tests that for a regular user stats are returned without flag counts
@@ -1867,7 +1864,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         data = response.json()
         assert data["results"] == self.stats_without_flags
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_moderator_user(self):
         """
         Tests that for a moderator user stats are returned with flag counts
@@ -1887,7 +1884,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         ("user", "recency", "recency"),
     )
     @ddt.unpack
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_sorting(self, username, ordering_requested, ordering_performed):
         """
         Test valid sorting options and defaults
@@ -1902,7 +1899,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         assert params["sort_key"] == ordering_performed
 
     @ddt.data("flagged", "xyz")
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_sorting_error_regular_user(self, order_by):
         """
         Test for invalid sorting options for regular users.
@@ -1916,7 +1913,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         ('moderator', 'moderator'),
     )
     @ddt.unpack
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param(self, username_search_string, comma_separated_usernames):
         """
         Test for endpoint with username param.
@@ -1928,7 +1925,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         params = self.get_mock_func_calls("get_user_course_stats")[-1][1]
         assert params["usernames"] == comma_separated_usernames
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param_with_no_matches(self):
         """
         Test for endpoint with username param with no matches.
@@ -1946,7 +1943,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
         'User-2',
         'UsEr-3'
     )
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_DISCUSSION_SERVICE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_with_username_param_case(self, username_search_string):
         """
         Test user search function is case-insensitive.
@@ -1956,7 +1953,7 @@ class CourseActivityStatsTest(UrlResetMixin, ForumMockUtilsMixin, APITestCase,
 
 
 @httpretty.activate
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for CourseView"""
 
@@ -2019,13 +2016,13 @@ class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         pass  # pylint: disable=unnecessary-pass
 
 
-@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class UploadFileViewTest(ForumMockUtilsMixin, UrlResetMixin, ModuleStoreTestCase):
     """
     Tests for UploadFileView.
     """
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.valid_file = {
@@ -2181,7 +2178,7 @@ class CourseDiscussionSettingsAPIViewTest(APITestCase, UrlResetMixin, ModuleStor
     """
     Test the course discussion settings handler API endpoint.
     """
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(
@@ -2480,7 +2477,7 @@ class CourseDiscussionRolesAPIViewTest(APITestCase, UrlResetMixin, ModuleStoreTe
     """
     Test the course discussion roles management endpoint.
     """
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create(
@@ -2494,7 +2491,7 @@ class CourseDiscussionRolesAPIViewTest(APITestCase, UrlResetMixin, ModuleStoreTe
         course_key = CourseKey.from_string('course-v1:x+y+z')
         seed_permissions_roles(course_key)
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def path(self, course_id=None, role=None):
         """Return the URL path to the endpoint based on the provided arguments."""
         course_id = str(self.course.id) if course_id is None else course_id

--- a/lms/djangoapps/discussion/tests/test_tasks_v2.py
+++ b/lms/djangoapps/discussion/tests/test_tasks_v2.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import ddt
 from django.contrib.sites.models import Site
+from django.test import override_settings
 from edx_ace.channel import ChannelType, get_channel_for_message
 from edx_ace.recipient import Recipient
 from edx_ace.renderers import EmailRenderer
@@ -56,14 +57,12 @@ def make_subscribed_threads_callback(subscribed_thread_ids, per_page=1):
 
 
 @ddt.ddt
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class TaskTestCase(
     ModuleStoreTestCase, MockForumApiMixin
 ):  # pylint: disable=missing-class-docstring
 
     @classmethod
-    @mock.patch.dict(
-        "django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}
-    )
     def setUpClass(cls):
         super().setUpClass()
         super().setUpClassAndForumMock()

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -38,9 +38,9 @@ log = logging.getLogger(__name__)
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES
 
 
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):  # pylint: disable=missing-class-docstring
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
 
         # Patching the ENABLE_DISCUSSION_SERVICE value affects the contents of urls.py,
@@ -305,7 +305,7 @@ class CommentsServiceRequestHeadersTestCase(UrlResetMixin, ModuleStoreTestCase):
 
     CREATE_USER = False
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         patcher = mock.patch(
@@ -381,13 +381,13 @@ class EnrollmentTestCase(ModuleStoreTestCase):
     in the course
     """
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create()
         self.student = UserFactory.create()
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     @patch('openedx.core.djangoapps.django_comment_common.comment_client.utils.requests.request', autospec=True)
     def test_unenrolled(self, mock_request):
         mock_request.side_effect = make_mock_request_impl(course=self.course, text='dummy')

--- a/lms/djangoapps/discussion/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/tests/test_views_v2.py
@@ -700,11 +700,8 @@ class SingleThreadGroupIdTestCase(CohortedTestCase, GroupIdAssertionMixinV2, For
         )
 
 
+@override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class SingleThreadContentGroupTestCase(UrlResetMixin, ContentGroupTestCase, ForumViewsUtilsMixin):  # pylint: disable=missing-class-docstring
-
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
-    def setUp(self):
-        super().setUp()
 
     @classmethod
     def setUpClass(cls):
@@ -916,7 +913,7 @@ class ForumFormDiscussionContentGroupTestCase(
     beta_block => beta_group_discussion => beta_cohort => beta_user
     """
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
         self.thread_list = [
@@ -1360,7 +1357,7 @@ class ForumDiscussionXSSTestCase(
         UrlResetMixin, ModuleStoreTestCase, ForumViewsUtilsMixin
 ):  # pylint: disable=missing-class-docstring
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
 
@@ -1651,7 +1648,7 @@ class UserProfileTestCase(
     TEST_THREAD_TEXT = "userprofile-test-text"
     TEST_THREAD_ID = "userprofile-test-thread-id"
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):
         super().setUp()
 
@@ -1798,7 +1795,7 @@ class ThreadViewedEventTestCase(
     DUMMY_TITLE = 'Dummy title'
     DUMMY_URL = 'https://example.com/dummy/url/'
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp('lms.djangoapps.discussion.django_comment_client.base.views.tracker')
         self.course = CourseFactory.create(
@@ -1845,7 +1842,7 @@ class ThreadViewedEventTestCase(
         super().tearDownClass()
         super().disposeForumMocks()
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     def test_thread_viewed_event(self):
         self._configure_mock_responses(
             course=self.course,

--- a/lms/djangoapps/grades/apps.py
+++ b/lms/djangoapps/grades/apps.py
@@ -43,6 +43,6 @@ class GradesConfig(AppConfig):
         # Can't import models at module level in AppConfigs, and models get
         # included from the signal handlers
         from .signals import handlers  # pylint: disable=unused-import  # noqa: F401
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import GradesService
             set_runtime_service('grades', GradesService())

--- a/lms/djangoapps/instructor/apps.py
+++ b/lms/djangoapps/instructor/apps.py
@@ -37,6 +37,6 @@ class InstructorConfig(AppConfig):
 
     def ready(self):
         from . import handlers  # pylint: disable=unused-import,import-outside-toplevel  # noqa: F401
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import InstructorService
             set_runtime_service('instructor', InstructorService())

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -82,13 +82,14 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/21260
     settings.ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS = False
 
-    # .. toggle_name: FEATURES['CERTIFICATES_INSTRUCTOR_GENERATION']  # pylint: disable=annotation-missing-token
+    # .. toggle_name: CERTIFICATES_INSTRUCTOR_GENERATION
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Enable to allow batch generation of certificates from the instructor dashboard.
     #   In case of self-paced courses, the certificate generation button is hidden if certificate
     #   generation is not explicitly enabled globally or for the specific course.
     # .. toggle_use_cases: opt_in
+    # .. toggle_creation_date: 2017-06-16
     settings.CERTIFICATES_INSTRUCTOR_GENERATION = False
 
     # .. toggle_name: ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -30,7 +30,7 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/13196
     settings.ENABLE_CCX_ANALYTICS_DASHBOARD_URL = False
 
-    # .. setting_name: FEATURES['MAX_ENROLLMENT_INSTR_BUTTONS']
+    # .. setting_name: MAX_ENROLLMENT_INSTR_BUTTONS
     # .. setting_default: 200
     # .. setting_description: Disable instructor dashboard buttons for downloading course data
     #   when enrollment exceeds this number. The number indicates the maximum allowed enrollments

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -91,11 +91,12 @@ def plugin_settings(settings):
     # .. toggle_use_cases: opt_in
     settings.CERTIFICATES_INSTRUCTOR_GENERATION = False
 
-    # .. toggle_name: FEATURES['ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE]  # pylint: disable=annotation-missing-token
+    # .. toggle_name: ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Allow course instructors to manage certificates from the instructor dashboard.
     # .. toggle_use_cases: opt_in
+    # .. toggle_creation_date: 2025-11-19
     settings.ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE = False
 
     # .. toggle_name: FEATURES['BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT']

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -8,7 +8,6 @@ from urllib.parse import urlencode
 from uuid import uuid4
 
 import ddt
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.http import Http404
 from django.test import SimpleTestCase, override_settings
@@ -3051,7 +3050,7 @@ class CourseTeamRolesViewTest(SharedModuleStoreTestCase):
         for expected in ['Administrator', 'Moderator', 'Group Moderator', 'Community TA']:
             assert expected in returned_roles
 
-    @override_settings(FEATURES={**settings.FEATURES, 'CUSTOM_COURSES_EDX': True})
+    @override_settings(CUSTOM_COURSES_EDX=True)
     def test_list_roles_with_ccx_enabled(self):
         """Returns all roles including ccx_coach when CCX is enabled for the course."""
         ccx_course = CourseFactory.create(
@@ -3072,7 +3071,7 @@ class CourseTeamRolesViewTest(SharedModuleStoreTestCase):
         ccx_entry = next(r for r in response.data['results'] if r['role'] == 'ccx_coach')
         assert ccx_entry['display_name'] == 'CCX Coach'
 
-    @override_settings(FEATURES={**settings.FEATURES, 'CUSTOM_COURSES_EDX': True})
+    @override_settings(CUSTOM_COURSES_EDX=True)
     def test_roles_sort_order(self):
         """Roles are returned in the expected display order, with ccx_coach last."""
         ccx_course = CourseFactory.create(

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -451,7 +451,8 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase, MasqueradeMixin):
 
         self.assertIn('open_responses', tab_ids)  # noqa: PT009
 
-    @patch('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True, 'MAX_ENROLLMENT_INSTR_BUTTONS': 200})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
+    @patch.dict('django.conf.settings.FEATURES', {'MAX_ENROLLMENT_INSTR_BUTTONS': 200})
     def test_special_exams_tab_with_proctored_exams_enabled(self):
         """
         Test that special_exams tab appears when course has proctored exams enabled.
@@ -461,7 +462,8 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase, MasqueradeMixin):
 
         self.assertIn('special_exams', tab_ids)  # noqa: PT009
 
-    @patch('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True, 'MAX_ENROLLMENT_INSTR_BUTTONS': 200})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
+    @patch.dict('django.conf.settings.FEATURES', {'MAX_ENROLLMENT_INSTR_BUTTONS': 200})
     def test_special_exams_tab_with_timed_exams_enabled(self):
         """
         Test that special_exams tab appears when course has timed exams enabled.

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -450,8 +450,7 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase, MasqueradeMixin):
 
         self.assertIn('open_responses', tab_ids)  # noqa: PT009
 
-    @override_settings(ENABLE_SPECIAL_EXAMS=True)
-    @patch.dict('django.conf.settings.FEATURES', {'MAX_ENROLLMENT_INSTR_BUTTONS': 200})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True, MAX_ENROLLMENT_INSTR_BUTTONS=200)
     def test_special_exams_tab_with_proctored_exams_enabled(self):
         """
         Test that special_exams tab appears when course has proctored exams enabled.
@@ -461,8 +460,7 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase, MasqueradeMixin):
 
         self.assertIn('special_exams', tab_ids)  # noqa: PT009
 
-    @override_settings(ENABLE_SPECIAL_EXAMS=True)
-    @patch.dict('django.conf.settings.FEATURES', {'MAX_ENROLLMENT_INSTR_BUTTONS': 200})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True, MAX_ENROLLMENT_INSTR_BUTTONS=200)
     def test_special_exams_tab_with_timed_exams_enabled(self):
         """
         Test that special_exams tab appears when course has timed exams enabled.
@@ -479,9 +477,9 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase, MasqueradeMixin):
         tab_ids = [tab['tab_id'] for tab in tabs]
         self.assertIn('special_exams', tab_ids)  # noqa: PT009
 
+    @override_settings(MAX_ENROLLMENT_INSTR_BUTTONS=200)
     @patch('lms.djangoapps.instructor.views.serializers_v2.CertificateGenerationConfiguration.current')
-    @patch('django.conf.settings.FEATURES', {'ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE': True,
-                                             'MAX_ENROLLMENT_INSTR_BUTTONS': 200})
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE': True})
     def test_certificates_tab_for_instructor_when_enabled(self, mock_cert_config):
         """
         Test that certificates tab appears for instructors when certificate management is enabled.

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -477,9 +477,8 @@ class CourseMetadataViewTest(SharedModuleStoreTestCase, MasqueradeMixin):
         tab_ids = [tab['tab_id'] for tab in tabs]
         self.assertIn('special_exams', tab_ids)  # noqa: PT009
 
-    @override_settings(MAX_ENROLLMENT_INSTR_BUTTONS=200)
+    @override_settings(MAX_ENROLLMENT_INSTR_BUTTONS=200, ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE=True)
     @patch('lms.djangoapps.instructor.views.serializers_v2.CertificateGenerationConfiguration.current')
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE': True})
     def test_certificates_tab_for_instructor_when_enabled(self, mock_cert_config):
         """
         Test that certificates tab appears for instructors when certificate management is enabled.

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -9,7 +9,6 @@ from unittest import mock
 import ddt
 import pytest
 from config_models.models import cache
-from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.utils import override_settings
@@ -265,8 +264,7 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
         self.assertContains(response, 'enable-certificates-submit')
         self.assertNotContains(response, 'Generate Example Certificates')
 
-    @override_settings(CERTIFICATES_HTML_VIEW=True)
-    @mock.patch.dict(settings.FEATURES, {'CERTIFICATES_INSTRUCTOR_GENERATION': False})
+    @override_settings(CERTIFICATES_HTML_VIEW=True, CERTIFICATES_INSTRUCTOR_GENERATION=False)
     def test_buttons_for_html_certs_in_self_paced_course(self):
         """
         Tests `Enable Student-Generated Certificates` button is enabled

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -207,7 +207,7 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
         self.client.login(username=self.global_staff.username, password=self.TEST_PASSWORD)
         self._assert_certificates_visible(False)
 
-    @mock.patch.dict(settings.FEATURES, {'ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE': True})
+    @override_settings(ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE=True)
     def test_visible_for_instructors_when_feature_is_enabled(self):
         self.client.login(username=self.instructor.username, password=self.TEST_PASSWORD)
         self._assert_certificates_visible(True)

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -249,7 +249,7 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
             certs_api.set_cert_generation_enabled(self.course.id, True)
             self._assert_enable_certs_button(False)
 
-    @mock.patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_show_enabled_button_for_html_certs(self):
         """
         Tests `Enable Student-Generated Certificates` button is enabled
@@ -265,11 +265,8 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
         self.assertContains(response, 'enable-certificates-submit')
         self.assertNotContains(response, 'Generate Example Certificates')
 
-    @mock.patch.dict(settings.FEATURES, {
-        'CERTIFICATES_HTML_VIEW': True,
-        'CERTIFICATES_INSTRUCTOR_GENERATION': False
-    }
-    )
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
+    @mock.patch.dict(settings.FEATURES, {'CERTIFICATES_INSTRUCTOR_GENERATION': False})
     def test_buttons_for_html_certs_in_self_paced_course(self):
         """
         Tests `Enable Student-Generated Certificates` button is enabled

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -12,6 +12,7 @@ import pytest
 from ccx_keys.locator import CCXLocator
 from crum import set_current_request
 from django.conf import settings
+from django.test import override_settings
 from django.utils.translation import get_language
 from django.utils.translation import override as override_language
 from opaque_keys.edx.locator import CourseLocator
@@ -887,7 +888,7 @@ class TestGetEmailParamsCCX(SharedModuleStoreTestCase):
         super().setUpClass()
         cls.course = CourseFactory.create()
 
-    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    @override_settings(CUSTOM_COURSES_EDX=True)
     def setUp(self):
         super().setUp()
         self.coach = AdminFactory.create()
@@ -905,7 +906,7 @@ class TestGetEmailParamsCCX(SharedModuleStoreTestCase):
         self.course_about_url = self.course_url + 'about'
         self.registration_url = f'https://{site}/register'
 
-    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    @override_settings(CUSTOM_COURSES_EDX=True)
     def test_ccx_enrollment_email_params(self):
         # For a CCX, what do we expect to get for the URLs?
         # Also make sure `auto_enroll` is properly passed through.
@@ -993,7 +994,7 @@ class TestRenderMessageToString(EmailTemplateTagMixin, SharedModuleStoreTestCase
         cls.subject_template = 'instructor/edx_ace/allowedenroll/email/subject.txt'
         cls.message_template = 'instructor/edx_ace/allowedenroll/email/body.txt'
 
-    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    @override_settings(CUSTOM_COURSES_EDX=True)
     def setUp(self):
         super().setUp()
         coach = AdminFactory.create()
@@ -1066,7 +1067,7 @@ class TestRenderMessageToString(EmailTemplateTagMixin, SharedModuleStoreTestCase
             assert 'You have been' in subject
             assert 'You have been' in message
 
-    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    @override_settings(CUSTOM_COURSES_EDX=True)
     @ddt.data('body.txt', 'body.html')
     def test_render_enrollment_message_ccx_members(self, body_file_name):
         """
@@ -1089,7 +1090,7 @@ class TestRenderMessageToString(EmailTemplateTagMixin, SharedModuleStoreTestCase
         )
         assert course_url in message
 
-    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    @override_settings(CUSTOM_COURSES_EDX=True)
     @ddt.data('body.txt', 'body.html')
     def test_render_unenrollment_message_ccx_members(self, body_file_name):
         """
@@ -1105,7 +1106,7 @@ class TestRenderMessageToString(EmailTemplateTagMixin, SharedModuleStoreTestCase
         assert self.ccx.display_name in subject
         assert self.ccx.display_name in message
 
-    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    @override_settings(CUSTOM_COURSES_EDX=True)
     @ddt.data('body.txt', 'body.html')
     def test_render_enrollment_message_ccx_non_members(self, body_file_name):
         """
@@ -1124,7 +1125,7 @@ class TestRenderMessageToString(EmailTemplateTagMixin, SharedModuleStoreTestCase
         registration_url = f'https://{site}/register'
         assert registration_url in message
 
-    @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
+    @override_settings(CUSTOM_COURSES_EDX=True)
     @ddt.data('body.txt', 'body.html')
     def test_render_unenrollment_message_ccx_non_members(self, body_file_name):
         """

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import ddt
 from django.apps import apps
 from django.conf import settings
+from django.test.utils import override_settings
 from django.urls import reverse
 from edx_proctoring.api import create_exam
 from edx_proctoring.backends.tests.test_backend import TestBackendProvider
@@ -173,7 +174,7 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
             'test_proctoring_provider': {"requires_escalation_email": True},
         },
     )
-    @patch.dict(settings.FEATURES, {'ENABLE_PROCTORED_EXAMS': True})
+    @override_settings(ENABLE_PROCTORED_EXAMS=True)
     def test_requires_escalation_email_set_with_email(self):
         """
         Escalation email will be visible if 'requires_escalation_email' is set, and there
@@ -193,7 +194,7 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
             'lti_external': {}
         },
     )
-    @patch.dict(settings.FEATURES, {'ENABLE_PROCTORED_EXAMS': True})
+    @override_settings(ENABLE_PROCTORED_EXAMS=True)
     def test_lti_proctoring_dashboard(self):
         """
         The exams dasboard MFE will be shown instead of the default special exams tab content

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -22,7 +22,7 @@ from xmodule.modulestore.tests.django_utils import (
 from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable=wrong-import-order
 
 
-@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 @ddt.ddt
 # Tests for legacy views. When DEPR-38432 is picked up, these tests will require the following changes:
 # Either remove or leave the specific parts that reference the legacy instructor dashboard,
@@ -128,7 +128,7 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
         self.instructor.save()
         self._assert_proctoring_tab_available(False)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': False})
+    @override_settings(ENABLE_SPECIAL_EXAMS=False)
     @ddt.data(
         (True, False),
         (False, True)

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -516,7 +516,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         """
         Test whether the "CCX Coaches" option is visible or hidden depending on the value of course.enable_ccx.
         """
-        with patch.dict(settings.FEATURES, {'CUSTOM_COURSES_EDX': ccx_feature_flag}):
+        with override_settings(CUSTOM_COURSES_EDX=ccx_feature_flag):
             self.course.enable_ccx = enable_ccx
             self.store.update_item(self.course, self.instructor.id)
 

--- a/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
@@ -1,10 +1,7 @@
 """
 Tests for Instructor API v2 Special Exams endpoints.
 """
-from unittest.mock import patch
-
 import ddt
-from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -31,7 +28,7 @@ PROCTORING_SETTINGS = {
 
 
 @override_settings(**PROCTORING_SETTINGS)
-@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 @ddt.ddt
 class SpecialExamsListViewTest(ModuleStoreTestCase):
     """Tests for GET /api/instructor/v2/courses/{course_key}/special_exams"""
@@ -129,7 +126,7 @@ class SpecialExamsListViewTest(ModuleStoreTestCase):
 
 
 @override_settings(**PROCTORING_SETTINGS)
-@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 class SpecialExamDetailViewTest(ModuleStoreTestCase):
     """Tests for GET /api/instructor/v2/courses/{course_key}/special_exams/{exam_id}"""
 
@@ -177,7 +174,7 @@ class SpecialExamDetailViewTest(ModuleStoreTestCase):
 
 
 @override_settings(**PROCTORING_SETTINGS)
-@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 class SpecialExamResetViewTest(ModuleStoreTestCase):
     """Tests for POST /api/instructor/v2/courses/{course_key}/special_exams/{exam_id}/reset/{username}"""
 
@@ -220,7 +217,7 @@ class SpecialExamResetViewTest(ModuleStoreTestCase):
 
 
 @override_settings(**PROCTORING_SETTINGS)
-@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 @ddt.ddt
 class SpecialExamAttemptsViewTest(ModuleStoreTestCase):
     """Tests for GET /api/instructor/v2/courses/{course_key}/special_exams/{exam_id}/attempts"""
@@ -296,7 +293,7 @@ class SpecialExamAttemptsViewTest(ModuleStoreTestCase):
 
 
 @override_settings(**PROCTORING_SETTINGS)
-@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 class ProctoringSettingsViewTest(ModuleStoreTestCase):
     """Tests for GET/PATCH /api/instructor/v2/courses/{course_key}/proctoring_settings"""
 
@@ -341,7 +338,7 @@ class ProctoringSettingsViewTest(ModuleStoreTestCase):
 
 
 @override_settings(**PROCTORING_SETTINGS)
-@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 class ExamAllowanceViewTest(ModuleStoreTestCase):
     """Tests for POST /api/instructor/v2/courses/{course_key}/special_exams/{exam_id}/allowance"""
 
@@ -512,7 +509,7 @@ class ExamAllowanceViewTest(ModuleStoreTestCase):
 
 
 @override_settings(**PROCTORING_SETTINGS)
-@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 @ddt.ddt
 class CourseAllowancesViewTest(ModuleStoreTestCase):
     """Tests for GET /api/instructor/v2/courses/{course_key}/special_exams/allowances"""
@@ -663,7 +660,7 @@ class CourseAllowancesViewTest(ModuleStoreTestCase):
 
 
 @override_settings(**PROCTORING_SETTINGS)
-@patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+@override_settings(ENABLE_SPECIAL_EXAMS=True)
 @ddt.ddt
 class CourseExamAttemptsViewTest(ModuleStoreTestCase):
     """Tests for GET /api/instructor/v2/courses/{course_key}/special_exams/attempts"""

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -3242,7 +3242,7 @@ class CourseTeamRolesView(DeveloperErrorViewMixin, APIView):
 
         roles = set(ROLES.keys()) | set(FORUM_ROLES)
 
-        ccx_enabled = settings.FEATURES.get('CUSTOM_COURSES_EDX', False) and course.enable_ccx
+        ccx_enabled = settings.CUSTOM_COURSES_EDX and course.enable_ccx
         if not ccx_enabled:
             roles.discard('ccx_coach')
 

--- a/lms/djangoapps/instructor/views/gradebook_api.py
+++ b/lms/djangoapps/instructor/views/gradebook_api.py
@@ -106,7 +106,7 @@ def get_grade_book_page(request, course, course_key):
 def spoc_gradebook(request, course_id):
     """
     Show the gradebook for this course:
-    - Only shown for courses with enrollment < settings.FEATURES.get("MAX_ENROLLMENT_INSTR_BUTTONS")
+    - Only shown for courses with enrollment < settings.MAX_ENROLLMENT_INSTR_BUTTONS
     - Only displayed to course staff
     """
     course_key = CourseKey.from_string(course_id)

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -278,7 +278,7 @@ def instructor_dashboard_2(request, course_id):  # pylint: disable=too-many-stat
         'generate_bulk_certificate_exceptions_url': generate_bulk_certificate_exceptions_url,
         'certificate_exception_view_url': certificate_exception_view_url,
         'certificate_invalidation_view_url': certificate_invalidation_view_url,
-        'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
+        'xqa_server': settings.XQA_SERVER,
     }
 
     context_from_plugins = get_plugins_view_context(

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -386,7 +386,7 @@ def _section_certificates(course):
                 for cert_status in example_cert_status
             )
         )
-    instructor_generation_enabled = settings.FEATURES.get('CERTIFICATES_INSTRUCTOR_GENERATION', False)
+    instructor_generation_enabled = settings.CERTIFICATES_INSTRUCTOR_GENERATION
     certificate_statuses_with_count = {
         certificate['status']: certificate['count']
         for certificate in certs_api.get_unique_certificate_statuses(course.id)

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -218,8 +218,8 @@ def instructor_dashboard_2(request, course_id):  # pylint: disable=too-many-stat
         CourseInstructorRole(course_key).has_user(request.user)
     ])
     course_has_special_exams = course.enable_proctored_exams or course.enable_timed_exams
-    can_see_special_exams = course_has_special_exams and user_has_access and settings.FEATURES.get(
-        'ENABLE_SPECIAL_EXAMS', False)
+    can_see_special_exams = course_has_special_exams and user_has_access and getattr(
+        settings, 'ENABLE_SPECIAL_EXAMS', False)
 
     if can_see_special_exams:
         sections.append(_section_special_exams(course, access))
@@ -660,7 +660,7 @@ def _section_data_download(course, access):
     course_key = course.id
 
     show_proctored_report_button = (
-        settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
+        settings.ENABLE_SPECIAL_EXAMS and
         course.enable_proctored_exams
     )
     section_key = 'data_download_2' if data_download_v2_is_enabled() else 'data_download'

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -519,7 +519,7 @@ def _section_course_info(course, access):
 def _section_membership(course, access):
     """ Provide data for the corresponding dashboard section """
     course_key = course.id
-    ccx_enabled = settings.FEATURES.get('CUSTOM_COURSES_EDX', False) and course.enable_ccx
+    ccx_enabled = settings.CUSTOM_COURSES_EDX and course.enable_ccx
 
     section_data = {
         'section_key': 'membership',

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -228,7 +228,7 @@ def instructor_dashboard_2(request, course_id):  # pylint: disable=too-many-stat
     # and enable self-generated certificates for a course.
     # Note: This is hidden for all CCXs
     certs_enabled = certs_api.is_certificate_generation_enabled() and not hasattr(course_key, 'ccx')
-    certs_instructor_enabled = settings.FEATURES.get('ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE', False)
+    certs_instructor_enabled = settings.ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE
 
     if certs_enabled and (access['admin'] or (access['instructor'] and certs_instructor_enabled)):
         sections.append(_section_certificates(course))

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -271,7 +271,7 @@ class CourseInformationSerializerV2(serializers.Serializer):
 
         # Note: This is hidden for all CCXs
         certs_enabled = CertificateGenerationConfiguration.current().enabled and not hasattr(course_key, 'ccx')
-        certs_instructor_enabled = settings.FEATURES.get('ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE', False)
+        certs_instructor_enabled = settings.ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE
 
         if certs_enabled and access['admin'] or (access['instructor'] and certs_instructor_enabled):
             tabs.append({

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -291,8 +291,8 @@ class CourseInformationSerializerV2(serializers.Serializer):
             access['instructor'],
         ])
         course_has_special_exams = course.enable_proctored_exams or course.enable_timed_exams
-        can_see_special_exams = course_has_special_exams and user_has_access and settings.FEATURES.get(
-            'ENABLE_SPECIAL_EXAMS', False)
+        can_see_special_exams = course_has_special_exams and user_has_access and getattr(
+            settings, 'ENABLE_SPECIAL_EXAMS', False)
 
         if can_see_special_exams:
             tabs.append({

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -101,7 +101,7 @@ class TestUserInfoApi(MobileAPITestCase, MobileAuthTestMixin):
 
 
 @ddt.ddt
-@override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
+@override_settings(MKTG_URLS={'ROOT': 'dummy-root'}, ENABLE_DISCUSSION_SERVICE=True)
 class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTestMixin,
                             MobileCourseAccessTestMixin, MilestonesTestCaseMixin):
     """
@@ -121,10 +121,6 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         'last_week': LAST_WEEK,
         'default_start_date': DEFAULT_START_DATE,
     }
-
-    @patch.dict(settings.FEATURES, {"ENABLE_DISCUSSION_SERVICE": True})
-    def setUp(self):
-        super().setUp()
 
     def verify_success(self, response):
         """
@@ -251,7 +247,8 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         assert courses[0]['course']['start_display'] == expected_display
 
     @ddt.data(API_V05, API_V1, API_V2)
-    @patch.dict(settings.FEATURES, {"ENABLE_DISCUSSION_SERVICE": True, 'ENABLE_MKTG_SITE': True})
+    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
+    @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
     def test_discussion_url(self, api_version):
         self.login_and_enroll()
 
@@ -1381,7 +1378,7 @@ class TestDiscussionCourseEnrollmentSerializer(UrlResetMixin, MobileAPITestCase,
         """
         Setup data for test
         """
-        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_DISCUSSION_SERVICE': True}):
+        with override_settings(ENABLE_DISCUSSION_SERVICE=True):
             super().setUp()
         self.login_and_enroll()
         self.request = RequestFactory().get('/')
@@ -1409,7 +1406,7 @@ class TestDiscussionCourseEnrollmentSerializer(UrlResetMixin, MobileAPITestCase,
         config, _ = DiscussionsConfiguration.objects.get_or_create(context_key=self.course.id)
         config.enabled = discussion_tab_enabled
         config.save()
-        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_DISCUSSION_SERVICE': True}):
+        with override_settings(ENABLE_DISCUSSION_SERVICE=True):
             serialized = self.get_serialized_data(API_V2)
         discussion_url = serialized["course"]["discussion_url"]
         if discussion_tab_enabled:

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -1089,21 +1089,24 @@ class TestUserEnrollmentCertificates(UrlResetMixin, MobileAPITestCase, Milestone
         certificate_data = response.data[0]['certificate']
         self.assertDictEqual(certificate_data, {})  # noqa: PT009
 
-    @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': False, 'ENABLE_MKTG_SITE': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=False)
+    @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
     def test_pdf_certificate_with_html_cert_disabled(self):
         """
         Tests PDF certificates with CERTIFICATES_HTML_VIEW set to True.
         """
         self.verify_pdf_certificate()
 
-    @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True, 'ENABLE_MKTG_SITE': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
+    @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
     def test_pdf_certificate_with_html_cert_enabled(self):
         """
         Tests PDF certificates with CERTIFICATES_HTML_VIEW set to True.
         """
         self.verify_pdf_certificate()
 
-    @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True, 'ENABLE_MKTG_SITE': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
+    @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
     def test_web_certificate(self):
         self.login_and_enroll()
 

--- a/lms/djangoapps/teams/__init__.py
+++ b/lms/djangoapps/teams/__init__.py
@@ -12,4 +12,4 @@ def is_feature_enabled(course):
     """
     Returns True if the teams feature is enabled.
     """
-    return settings.FEATURES.get('ENABLE_TEAMS', False) and course.teams_enabled
+    return settings.ENABLE_TEAMS and course.teams_enabled

--- a/lms/djangoapps/teams/management/commands/reindex_course_team.py
+++ b/lms/djangoapps/teams/management/commands/reindex_course_team.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
             if not options['course_team_ids']:
                 raise CommandError('At least one course_team_id or --all needs to be specified')
 
-        if not settings.FEATURES.get('ENABLE_TEAMS', False):
+        if not settings.ENABLE_TEAMS:
             raise CommandError('ENABLE_TEAMS must be enabled to use course team indexing')
 
         if options['all']:

--- a/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
+++ b/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import ddt
 from django.core.management import CommandError, call_command
+from django.test import override_settings
 from opaque_keys.edx.keys import CourseKey
 from search.search_engine_base import SearchEngine
 
@@ -50,7 +51,7 @@ class ReindexCourseTeamTest(SharedModuleStoreTestCase):
         with self.assertRaisesRegex(CommandError, '.*Course teams cannot be specified when --all is also specified.*'):  # noqa: PT027  # pylint: disable=line-too-long
             call_command('reindex_course_team', self.team1.team_id, all=True)
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_TEAMS': False})
+    @override_settings(ENABLE_TEAMS=False)
     def test_teams_search_flag_disabled_raises_command_error(self):
         """
         Test that raises CommandError for disabled feature flag.

--- a/lms/djangoapps/teams/plugins.py
+++ b/lms/djangoapps/teams/plugins.py
@@ -63,7 +63,7 @@ class TeamsCourseApp(CourseApp):
         """
         if not ENABLE_TEAMS_APP.is_enabled():
             return False
-        return settings.FEATURES.get("ENABLE_TEAMS", False)
+        return settings.ENABLE_TEAMS
 
     @classmethod
     def is_enabled(cls, course_key: CourseKey) -> bool:

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -134,6 +134,7 @@ class StartView(TestCase):
 
 
 @ddt.ddt
+@override_settings(EMBARGO=True)
 class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin, TestVerificationBase):
     """
     Tests for the payment and verification flow views.
@@ -151,7 +152,6 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin, Tes
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
 
-    @mock.patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):
         super().setUp()
         self.user = UserFactory.create(username=self.USERNAME, password=self.PASSWORD)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -138,6 +138,16 @@ ENABLE_UNICODE_USERNAME = False
 ENABLE_DJANGO_ADMIN_SITE = True
 ENABLE_LMS_MIGRATION = False
 
+# .. toggle_name: ENABLE_FORUM_DAILY_DIGEST
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Settings for forums/discussions to on/off daily digest
+#   feature. Set this to True if you want to enable users to subscribe and unsubscribe
+#   for daily digest. This setting enables deprecation of daily digest.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2020-03-09
+ENABLE_FORUM_DAILY_DIGEST = False
+
 # .. toggle_name: settings.ENABLE_MASQUERADE
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: True

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -721,7 +721,7 @@ urlpatterns += [
 ]
 
 # discussion forums live within courseware, so courseware must be enabled first
-if settings.FEATURES.get('ENABLE_DISCUSSION_SERVICE'):
+if settings.ENABLE_DISCUSSION_SERVICE:
     urlpatterns += [
         path(
             'api/discussion/',

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -872,7 +872,7 @@ urlpatterns += [
 ]
 
 # Third-party auth.
-if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
+if settings.ENABLE_THIRD_PARTY_AUTH:
     urlpatterns += [
         path('', include('common.djangoapps.third_party_auth.urls')),
         path('api/third_party_auth/', include('common.djangoapps.third_party_auth.api.urls')),

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -682,7 +682,7 @@ urlpatterns += [
     ),
 ]
 
-if settings.FEATURES.get('ENABLE_TEAMS'):
+if settings.ENABLE_TEAMS:
     # Teams endpoints
     urlpatterns += [
         path(

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -909,7 +909,7 @@ urlpatterns += [
 ]
 
 # Custom courses on edX (CCX) URLs
-if settings.FEATURES.get('CUSTOM_COURSES_EDX'):
+if settings.CUSTOM_COURSES_EDX:
     urlpatterns += [
         re_path(fr'^courses/{settings.COURSE_ID_PATTERN}/', include('lms.djangoapps.ccx.urls')),
         path('api/ccx/', include(('lms.djangoapps.ccx.api.urls', 'lms.djangoapps.ccx'), namespace='ccx_api')),

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -825,7 +825,7 @@ if configuration_helpers.get_value('ENABLE_BULK_ENROLLMENT_VIEW', settings.FEATU
     ]
 
 # Embargo
-if settings.FEATURES.get('EMBARGO'):
+if settings.EMBARGO:
     urlpatterns += [
         path('embargo/', include(('openedx.core.djangoapps.embargo.urls', 'openedx.core.djangoapps.embargo'),
                                  namespace='embargo')),

--- a/openedx/core/djangoapps/agreements/tests/test_views.py
+++ b/openedx/core/djangoapps/agreements/tests/test_views.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 from freezegun import freeze_time
 from rest_framework import status
@@ -27,7 +28,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @skip_unless_lms
-@patch.dict(settings.FEATURES, {'ENABLE_INTEGRITY_SIGNATURE': True})
+@override_settings(ENABLE_INTEGRITY_SIGNATURE=True)
 class IntegritySignatureViewTests(APITestCase, ModuleStoreTestCase):
     """
     Tests for the Integrity Signature View
@@ -161,7 +162,7 @@ class IntegritySignatureViewTests(APITestCase, ModuleStoreTestCase):
         )
         self._assert_response(response, status.HTTP_200_OK, self.user, self.course_id)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_INTEGRITY_SIGNATURE': False})
+    @override_settings(ENABLE_INTEGRITY_SIGNATURE=False)
     def test_404_for_no_waffle_flag(self):
         self._create_signature(self.user.username, self.course_id)
         response = self.client.get(
@@ -213,7 +214,7 @@ class IntegritySignatureViewTests(APITestCase, ModuleStoreTestCase):
             self.assertEqual(len(signatures), 1)  # noqa: PT009
             self.assertEqual(signatures[0].user.username, self.USERNAME)  # noqa: PT009
 
-    @patch.dict(settings.FEATURES, {'ENABLE_INTEGRITY_SIGNATURE': False})
+    @override_settings(ENABLE_INTEGRITY_SIGNATURE=False)
     def test_post_integrity_signature_no_waffle_flag(self):
         response = self.client.post(
             reverse(

--- a/openedx/core/djangoapps/agreements/tests/test_views.py
+++ b/openedx/core/djangoapps/agreements/tests/test_views.py
@@ -4,9 +4,7 @@ Tests for agreements views
 
 import json
 from datetime import datetime, timedelta
-from unittest.mock import patch
 
-from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
 from freezegun import freeze_time
@@ -226,7 +224,7 @@ class IntegritySignatureViewTests(APITestCase, ModuleStoreTestCase):
 
 
 @skip_unless_lms
-@patch.dict(settings.FEATURES, {'ENABLE_LTI_PII_ACKNOWLEDGEMENT': True})
+@override_settings(ENABLE_LTI_PII_ACKNOWLEDGEMENT=True)
 class LTIPIISignatureSignatureViewTests(APITestCase, ModuleStoreTestCase):
     """
         Tests for the LTI PII Signature View
@@ -268,7 +266,7 @@ class LTIPIISignatureSignatureViewTests(APITestCase, ModuleStoreTestCase):
             assert data['username'] == user.username
             assert data['course_id'] == course_id
 
-    @patch.dict(settings.FEATURES, {'ENABLE_LTI_PII_ACKNOWLEDGEMENT': False})
+    @override_settings(ENABLE_LTI_PII_ACKNOWLEDGEMENT=False)
     def test_enabled_lti_pii_signature(self):
         response = self.client.post(
             reverse(

--- a/openedx/core/djangoapps/agreements/views.py
+++ b/openedx/core/djangoapps/agreements/views.py
@@ -77,7 +77,7 @@ class IntegritySignatureView(AuthenticatedAPIView):
         If a username is not given, it should default to the requesting user (or masqueraded user).
         Only staff should be able to access this endpoint for other users.
         """
-        if not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE'):
+        if not settings.ENABLE_INTEGRITY_SIGNATURE:
             return Response(
                 status=status.HTTP_404_NOT_FOUND,
             )
@@ -120,7 +120,7 @@ class IntegritySignatureView(AuthenticatedAPIView):
                 created_at: "2021-04-23T18:25:43.511Z"
             }
         """
-        if not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE'):
+        if not settings.ENABLE_INTEGRITY_SIGNATURE:
             return Response(
                 status=status.HTTP_404_NOT_FOUND,
             )

--- a/openedx/core/djangoapps/agreements/views.py
+++ b/openedx/core/djangoapps/agreements/views.py
@@ -155,7 +155,7 @@ class LTIPIISignatureView(AuthenticatedAPIView):
                 created_at: "2021-04-23T18:25:43.511Z"
             }
         """
-        if not settings.FEATURES.get('ENABLE_LTI_PII_ACKNOWLEDGEMENT'):
+        if not settings.ENABLE_LTI_PII_ACKNOWLEDGEMENT:
             return Response(
                 status=status.HTTP_404_NOT_FOUND,
             )

--- a/openedx/core/djangoapps/auth_exchange/tests/utils.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/utils.py
@@ -9,7 +9,7 @@ from social_django.models import Partial, UserSocialAuth
 from common.djangoapps.third_party_auth.tests.utils import ThirdPartyOAuthTestMixin
 
 TPA_FEATURES_KEY = 'ENABLE_THIRD_PARTY_AUTH'
-TPA_FEATURE_ENABLED = TPA_FEATURES_KEY in settings.FEATURES
+TPA_FEATURE_ENABLED = hasattr(settings, TPA_FEATURES_KEY)
 
 
 class AccessTokenExchangeTestMixin(ThirdPartyOAuthTestMixin):

--- a/openedx/core/djangoapps/catalog/views.py
+++ b/openedx/core/djangoapps/catalog/views.py
@@ -18,7 +18,7 @@ def cache_programs(request):
     # checks that does site has configuration if not then
     # add a configuration with COURSE_CATALOG_API_URL parameter.
 
-    if settings.FEATURES.get('EXPOSE_CACHE_PROGRAMS_ENDPOINT'):
+    if settings.EXPOSE_CACHE_PROGRAMS_ENDPOINT:
         call_command('cache_programs')
 
         return HttpResponse('Programs cached.')

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/special_exams.py
@@ -35,7 +35,7 @@ class SpecialExamsOutlineProcessor(OutlineProcessor):
         """
         Check if special exams are enabled
         """
-        self.special_exams_enabled = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False)  # pylint: disable=attribute-defined-outside-init
+        self.special_exams_enabled = settings.ENABLE_SPECIAL_EXAMS  # pylint: disable=attribute-defined-outside-init
 
     def exam_data(self, pruned_course_outline: UserCourseOutlineData) -> SpecialExamAttemptData:
         """

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -9,9 +9,9 @@ from unittest.mock import MagicMock, patch
 import attr
 import ddt
 import pytest
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import signals
+from django.test import override_settings
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
 from edx_toggles.toggles.testutils import override_waffle_flag
 from edx_when.api import set_dates_for_course
@@ -996,7 +996,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # pylint: disable=missing
         # Enroll student in the course
         cls.student.courseenrollment_set.create(course_id=cls.course_key, is_active=True, mode="audit")
 
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     def test_special_exams_enabled_all_sequences_visible(self):
         at_time = datetime(2020, 5, 22, tzinfo=timezone.utc)  # pylint: disable=unused-variable  # noqa: F841, UP017
 
@@ -1012,7 +1012,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # pylint: disable=missing
         assert len(student_details.outline.accessible_sequences) == 4
         assert len(student_details.outline.sequences) == 4
 
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': False})
+    @override_settings(ENABLE_SPECIAL_EXAMS=False)
     def test_special_exams_disabled_preserves_exam_sequences(self):
         at_time = datetime(2020, 5, 22, tzinfo=timezone.utc)  # pylint: disable=unused-variable  # noqa: F841, UP017
 
@@ -1031,7 +1031,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # pylint: disable=missing
             assert key in student_details.outline.accessible_sequences
             assert key in student_details.outline.sequences
 
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.special_exams.get_attempt_status_summary')
     def test_special_exam_attempt_data_in_details(self, mock_get_attempt_status_summary):
         at_time = datetime(2020, 5, 22, tzinfo=timezone.utc)  # pylint: disable=unused-variable  # noqa: F841, UP017
@@ -1065,7 +1065,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # pylint: disable=missing
             assert type(attempt_summary) == dict  # pylint: disable=unidiomatic-typecheck
             assert attempt_summary["summary"]["usage_key"] == str(sequence_key)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': False})
+    @override_settings(ENABLE_SPECIAL_EXAMS=False)
     @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.special_exams.get_attempt_status_summary')
     def test_special_exam_attempt_data_empty_when_disabled(self, mock_get_attempt_status_summary):
         at_time = datetime(2020, 5, 22, tzinfo=timezone.utc)  # pylint: disable=unused-variable  # noqa: F841, UP017
@@ -1079,7 +1079,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # pylint: disable=missing
         assert len(student_details.special_exam_attempts.sequences) == 0
 
     @override_waffle_flag(EXAMS_IDA, active=True)
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     @patch('openedx.core.djangoapps.content.learning_sequences.api.processors.special_exams.get_attempt_status_summary')
     def test_special_exam_attempt_data_exams_ida_flag_on(self, mock_get_attempt_status_summary):
         _, student_details, _ = self.get_details(
@@ -1090,7 +1090,7 @@ class SpecialExamsTestCase(OutlineProcessorTestCase):  # pylint: disable=missing
         assert mock_get_attempt_status_summary.call_count == 0
 
     @override_waffle_flag(EXAMS_IDA, active=True)
-    @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+    @override_settings(ENABLE_SPECIAL_EXAMS=True)
     def test_special_exam_attempt_data_exam_type(self):
         _, student_details, _ = self.get_details(
             datetime(2020, 5, 25, tzinfo=timezone.utc)  # noqa: UP017

--- a/openedx/core/djangoapps/content/learning_sequences/apps.py
+++ b/openedx/core/djangoapps/content/learning_sequences/apps.py
@@ -13,6 +13,6 @@ class LearningSequencesConfig(AppConfig):  # pylint: disable=missing-class-docst
         # Register celery workers
         # from .tasks import ls_listen_for_course_publish  # pylint: disable=unused-variable
 
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import LearningSequencesRuntimeService
             set_runtime_service('learning_sequences', LearningSequencesRuntimeService())

--- a/openedx/core/djangoapps/content/learning_sequences/views.py
+++ b/openedx/core/djangoapps/content/learning_sequences/views.py
@@ -122,7 +122,7 @@ class CourseOutlineView(APIView):
             }
 
             # Only include this data if special exams are on
-            if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False):
+            if settings.ENABLE_SPECIAL_EXAMS:
                 sequence_representation["exam"] = sequence_exam
 
             return sequence_representation

--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -239,7 +239,7 @@ perms[CAN_LEARN_FROM_THIS_CONTENT_LIBRARY] = (
 
 # Is the user allowed to create content libraries?
 CAN_CREATE_CONTENT_LIBRARY = 'content_libraries.create_library'
-if settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
+if getattr(settings, 'ENABLE_CREATOR_GROUP', False):
     perms[CAN_CREATE_CONTENT_LIBRARY] = is_global_staff | (is_user_active & is_course_creator)
 else:
     perms[CAN_CREATE_CONTENT_LIBRARY] = is_global_staff

--- a/openedx/core/djangoapps/course_apps/tests/test_proctoring_app.py
+++ b/openedx/core/djangoapps/course_apps/tests/test_proctoring_app.py
@@ -1,10 +1,9 @@
 """
 Tests for proctoring course app.
 """
-from unittest.mock import patch
-
 import ddt
 from django.conf import settings
+from django.test.utils import override_settings
 
 from lms.djangoapps.courseware.plugins import ProctoringCourseApp
 from openedx.core.djangolib.testing.utils import skip_unless_cms
@@ -16,7 +15,7 @@ from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable
 
 
 @skip_unless_cms
-@patch.dict(settings.FEATURES, {'ENABLE_PROCTORED_EXAMS': True})
+@override_settings(ENABLE_PROCTORED_EXAMS=True)
 @ddt.ddt
 class ProctoringCourseAppTestCase(ModuleStoreTestCase):
     """Test cases for proctoring CourseApp."""
@@ -39,7 +38,7 @@ class ProctoringCourseAppTestCase(ModuleStoreTestCase):
         """
         Test that proctoring card's availability can configured using feature flag.
         """
-        with patch.dict("django.conf.settings.FEATURES", {'ENABLE_PROCTORED_EXAMS': available_status}):
+        with override_settings(ENABLE_PROCTORED_EXAMS=available_status):
             assert self.course.enable_proctored_exams is True
             assert ProctoringCourseApp().is_available(self.course.id) == available_status
 

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -128,7 +128,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         (True, 'verified'),
     )
     @ddt.unpack
-    @mock.patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_enrolled_course_metadata(self, logged_in, enrollment_mode):
         check_public_access = mock.Mock()
         check_public_access.return_value = ACCESS_DENIED
@@ -204,7 +204,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         (False, ACCESS_GRANTED),
     )
     @ddt.unpack
-    @mock.patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    @override_settings(CERTIFICATES_HTML_VIEW=True)
     def test_unenrolled_course_metadata(self, logged_in, enable_anonymous):
         check_public_access = mock.Mock()
         check_public_access.return_value = enable_anonymous

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -330,7 +330,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         ('audit', True, False, False),
     )
     @ddt.unpack
-    @mock.patch.dict(settings.FEATURES, {'ENABLE_INTEGRITY_SIGNATURE': True})
+    @override_settings(ENABLE_INTEGRITY_SIGNATURE=True)
     def test_user_needs_integrity_signature(
         self, enrollment_mode, is_staff, has_integrity_signature, needs_integrity_signature,
     ):
@@ -366,7 +366,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         (3, True),
     )
     @ddt.unpack
-    @mock.patch.dict(settings.FEATURES, {'ENABLE_INTEGRITY_SIGNATURE': True})
+    @override_settings(ENABLE_INTEGRITY_SIGNATURE=True)
     def test_course_staff_masquerade(self, masquerade_group_id, needs_signature):
         self.user.is_staff = True
         self.user.save()

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -391,7 +391,7 @@ class CoursewareMeta:
             course_with_access = get_course_with_access(self.request.user, permission, self.course_key)
             return bool(
                 self.request.user.has_perm(VIEW_COURSEWARE, course_with_access)
-                or settings.FEATURES.get('ENABLE_LMS_MIGRATION')
+                or settings.ENABLE_LMS_MIGRATION
             )
 
     @property

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -291,14 +291,14 @@ class CoursewareMeta:
         """
         Django setting for the integrity signature feature.
         """
-        return settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE', False)
+        return settings.ENABLE_INTEGRITY_SIGNATURE
 
     @property
     def user_needs_integrity_signature(self):
         """
         Boolean describing whether the user needs to sign the integrity agreement for a course.
         """
-        if not settings.FEATURES.get('ENABLE_INTEGRITY_SIGNATURE'):
+        if not settings.ENABLE_INTEGRITY_SIGNATURE:
             return False
 
         integrity_signature_required = (

--- a/openedx/core/djangoapps/credit/apps.py
+++ b/openedx/core/djangoapps/credit/apps.py
@@ -16,6 +16,6 @@ class CreditConfig(AppConfig):
 
     def ready(self):
         from .signals import handlers  # pylint: disable=unused-import  # noqa: F401
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import CreditService
             set_runtime_service('credit', CreditService())

--- a/openedx/core/djangoapps/embargo/api.py
+++ b/openedx/core/djangoapps/embargo/api.py
@@ -47,7 +47,7 @@ def redirect_if_blocked(
     Returns:
         If blocked, a URL path to a page explaining why the user was blocked. Else None.
     """
-    if settings.FEATURES.get('EMBARGO'):
+    if settings.EMBARGO:
         client_ips = ip.get_all_client_ips(request)
         user = user or request.user
         is_blocked = not check_course_access(course_key, user=user, ip_addresses=client_ips, url=request.path)
@@ -79,7 +79,7 @@ def check_course_access(
 
     """
     # No-op if the country access feature is not enabled
-    if not settings.FEATURES.get('EMBARGO'):
+    if not settings.EMBARGO:
         return True
 
     # First, check whether there are any restrictions on the course.

--- a/openedx/core/djangoapps/embargo/middleware.py
+++ b/openedx/core/djangoapps/embargo/middleware.py
@@ -63,7 +63,7 @@ class EmbargoMiddleware(MiddlewareMixin):
 
     def __init__(self, *args, **kwargs):
         # If embargoing is turned off, make this middleware do nothing
-        if not settings.FEATURES.get('EMBARGO'):
+        if not settings.EMBARGO:
             raise MiddlewareNotUsed()
         super().__init__(*args, **kwargs)
 

--- a/openedx/core/djangoapps/embargo/tests/test_api.py
+++ b/openedx/core/djangoapps/embargo/tests/test_api.py
@@ -42,9 +42,8 @@ MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {})
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
+@override_settings(MODULESTORE=MODULESTORE_CONFIG, EMBARGO=True)
 @skip_unless_lms
-@mock.patch.dict(settings.FEATURES, {'EMBARGO': True})
 class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
     """Test the embargo API calls to determine whether a user has access. """
     ENABLED_CACHES = ['default', 'mongo_metadata_inheritance', 'loc_cache']
@@ -153,7 +152,6 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
             result = embargo_api.check_course_access(self.course.id, user=self.user, ip_addresses=['0.0.0.0'])
             assert result
 
-    @mock.patch.dict(settings.FEATURES, {'EMBARGO': True})
     def test_profile_country_db_null(self):
         # Django country fields treat NULL values inconsistently.
         # When saving a profile with country set to None, Django saves an empty string to the database.
@@ -302,7 +300,7 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
 
 
 @ddt.ddt
-@override_settings(MODULESTORE=MODULESTORE_CONFIG)
+@override_settings(MODULESTORE=MODULESTORE_CONFIG, EMBARGO=True)
 @skip_unless_lms
 class EmbargoMessageUrlApiTests(UrlResetMixin, ModuleStoreTestCase):
     """Test the embargo API calls for retrieving the blocking message URLs. """
@@ -310,7 +308,6 @@ class EmbargoMessageUrlApiTests(UrlResetMixin, ModuleStoreTestCase):
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
     ENABLED_CACHES = ['default', 'mongo_metadata_inheritance', 'loc_cache']
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create()

--- a/openedx/core/djangoapps/embargo/tests/test_middleware.py
+++ b/openedx/core/djangoapps/embargo/tests/test_middleware.py
@@ -3,12 +3,11 @@ Tests for EmbargoMiddleware with CountryAccessRules
 """
 
 
-from unittest.mock import patch
 
 import ddt
 from config_models.models import cache as config_cache
-from django.conf import settings
 from django.core.cache import cache as django_cache
+from django.test import override_settings
 from django.urls import reverse
 
 from common.djangoapps.student.tests.factories import UserFactory
@@ -23,6 +22,7 @@ from ..test_utils import restrict_course
 
 @ddt.ddt
 @skip_unless_lms
+@override_settings(EMBARGO=True)
 class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
     """Tests of embargo middleware country access rules.
 
@@ -36,7 +36,6 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):
         super().setUp()
         self.user = UserFactory(username=self.USERNAME, password=self.PASSWORD)
@@ -50,7 +49,6 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
         django_cache.clear()
         config_cache.clear()
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
     @ddt.data(True, False)
     def test_blocked(self, disable_access_check):
         with restrict_course(self.course.id, access_point='courseware', disable_access_check=disable_access_check) as redirect_url:  # pylint: disable=line-too-long
@@ -60,7 +58,6 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
             else:
                 self.assertRedirects(response, redirect_url)
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def test_allowed(self):
         # Add the course to the list of restricted courses
         # but don't create any access rules
@@ -70,13 +67,11 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
         response = self.client.get(self.courseware_url)
         assert response.status_code == 200
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def test_non_courseware_url(self):
         with restrict_course(self.course.id):
             response = self.client.get(self.non_courseware_url)
             assert response.status_code == 200
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
     @ddt.data(
         # request ip chain, blacklist, whitelist, is_enabled, allow_access
         (['192.178.2.3'], [], [], True, True),  # confirm that test setup & no config allows users by default
@@ -119,7 +114,6 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
             )
             self.assertRedirects(response, redirect_url)
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
     @ddt.data(
         # request ip chain, blacklist, whitelist, is_enabled, allow_access
         (['192.178.2.3'], [], [], True, False),  # confirm that test setup & no config blocks users by default
@@ -160,7 +154,6 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
             )
             self.assertRedirects(response, redirect_url)
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
     @ddt.data(
         ('courseware', 'default'),
         ('courseware', 'embargo'),

--- a/openedx/core/djangoapps/embargo/tests/test_views.py
+++ b/openedx/core/djangoapps/embargo/tests/test_views.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import ddt
 import geoip2.database
 import maxminddb
-from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 
 from common.djangoapps.student.tests.factories import UserFactory  # pylint: disable=wrong-import-order
@@ -32,6 +32,7 @@ from .factories import CountryAccessRuleFactory, RestrictedCourseFactory
 
 @skip_unless_lms
 @ddt.ddt
+@override_settings(EMBARGO=True)
 class CourseAccessMessageViewTest(CacheIsolationTestCase, UrlResetMixin):
     """Tests for the courseware access message view.
 
@@ -53,10 +54,6 @@ class CourseAccessMessageViewTest(CacheIsolationTestCase, UrlResetMixin):
     ENABLED_CACHES = ['default']
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
-
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
-    def setUp(self):
-        super().setUp()
 
     @ddt.data(*list(messages.ENROLL_MESSAGES.keys()))
     def test_enrollment_messages(self, msg_key):
@@ -99,10 +96,10 @@ class CourseAccessMessageViewTest(CacheIsolationTestCase, UrlResetMixin):
 
 
 @skip_unless_lms
+@override_settings(EMBARGO=True)
 class CheckCourseAccessViewTest(CourseApiFactoryMixin, ModuleStoreTestCase):
     """ Tests the course access check endpoint. """
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):
         super().setUp()
         self.url = reverse('api_embargo:v1_course_access')

--- a/openedx/core/djangoapps/embargo/views.py
+++ b/openedx/core/djangoapps/embargo/views.py
@@ -13,8 +13,7 @@ from rest_framework.views import APIView
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 
-from . import messages
-from .api import check_course_access
+from . import api, messages
 
 
 class CheckCourseAccessView(APIView):  # pylint: disable=missing-class-docstring
@@ -48,7 +47,7 @@ class CheckCourseAccessView(APIView):  # pylint: disable=missing-class-docstring
                     course_key = CourseKey.from_string(course_id)
                 except InvalidKeyError as exc:
                     raise ValidationError('Invalid course_ids') from exc
-                if not check_course_access(course_key, user=user, ip_addresses=[user_ip_address]):
+                if not api.check_course_access(course_key, user=user, ip_addresses=[user_ip_address]):
                     response['access'] = False
                     break
         else:

--- a/openedx/core/djangoapps/enrollments/api.py
+++ b/openedx/core/djangoapps/enrollments/api.py
@@ -573,7 +573,7 @@ def is_enrollment_valid_for_proctoring(username, course_id):
         * username (str): The user associated with the enrollment.
         * course_id (str): The course id associated with the enrollment.
     """
-    if not settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+    if not settings.ENABLE_SPECIAL_EXAMS:
         return False
 
     # Verify that the learner's enrollment is active

--- a/openedx/core/djangoapps/enrollments/apps.py
+++ b/openedx/core/djangoapps/enrollments/apps.py
@@ -20,6 +20,6 @@ class EnrollmentsConfig(AppConfig):
         """
         Connect handlers to fetch enrollments.
         """
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             from .services import EnrollmentsService
             set_runtime_service('enrollments', EnrollmentsService())

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -1329,7 +1329,7 @@ class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestC
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def setUp(self):
         """ Create a course and user, then log in. """
         super().setUp()
@@ -1369,7 +1369,7 @@ class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestC
         # Verify that we were not enrolled
         assert self._get_enrollments() == []
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_embargo_change_enrollment_restrict_geoip(self):
         """ Validates that enrollment changes are blocked if the request originates from an embargoed country. """
 
@@ -1395,7 +1395,7 @@ class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestC
         return unrestricted_country, restricted_country
 
     @override_settings(EDX_API_KEY=EnrollmentTestMixin.API_KEY)
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_embargo_change_enrollment_restrict_user_profile(self):
         """ Validates that enrollment changes are blocked if the user's profile is linked to an embargoed country. """
 
@@ -1409,7 +1409,7 @@ class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestC
         self.assert_access_denied(path)
 
     @override_settings(EDX_API_KEY=EnrollmentTestMixin.API_KEY)
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_embargo_change_enrollment_allow_user_profile(self):
         """
         Validates that enrollment changes are allowed if the user's profile is NOT linked to an embargoed country.
@@ -1423,7 +1423,7 @@ class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestC
         self.user.profile.save()
         self.assert_enrollment_status()
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_embargo_change_enrollment_allow(self):
         self.assert_enrollment_status()
 

--- a/openedx/core/djangoapps/oauth_dispatch/urls.py
+++ b/openedx/core/djangoapps/oauth_dispatch/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
     re_path(r'^revoke_token/?$', csrf_exempt(views.RevokeTokenView.as_view()), name='revoke_token'),
 ]
 
-if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
+if settings.ENABLE_THIRD_PARTY_AUTH:
     urlpatterns += [
         path('exchange_access_token/<str:backend>/', csrf_exempt(views.AccessTokenExchangeView.as_view()),
              name='exchange_access_token',

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -232,7 +232,7 @@ def _validate_email_change(user, data, field_errors):
     if "email" not in data:
         return
 
-    if not settings.FEATURES['ALLOW_EMAIL_ADDRESS_CHANGE']:
+    if not settings.ALLOW_EMAIL_ADDRESS_CHANGE:
         raise AccountUpdateError("Email address changes have been disabled by the site operators.")
 
     new_email = data["email"]

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -160,7 +160,7 @@ def update_account_settings(requesting_user, update, username=None):
     _validate_email_change(user, update, field_errors)
     _validate_secondary_email(user, update, field_errors)
     if (
-        settings.FEATURES.get('EMBARGO', False) and
+        settings.EMBARGO and
         GlobalRestrictedCountry.is_country_restricted(update.get('country', ''))
     ):
         field_errors['country'] = {

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -10,13 +10,12 @@ from zoneinfo import ZoneInfo
 
 import ddt
 import pytest
-from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.core.exceptions import ValidationError
 from django.db import DatabaseError, IntegrityError
 from django.http import HttpResponse
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 
@@ -432,7 +431,7 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         account_settings = get_account_settings(self.default_request)[0]
         assert 'Mickey Mouse' == account_settings['name']
 
-    @patch.dict(settings.FEATURES, dict(ALLOW_EMAIL_ADDRESS_CHANGE=False))
+    @override_settings(ALLOW_EMAIL_ADDRESS_CHANGE=False)
     def test_email_changes_disabled(self):
         """
         Test that email address changes are rejected when ALLOW_EMAIL_ADDRESS_CHANGE is not set.
@@ -443,7 +442,7 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
             update_account_settings(self.user, disabled_update)
         assert 'Email address changes have been disabled' in context_manager.value.developer_message
 
-    @patch.dict(settings.FEATURES, dict(ALLOW_EMAIL_ADDRESS_CHANGE=True))
+    @override_settings(ALLOW_EMAIL_ADDRESS_CHANGE=True)
     def test_email_changes_blocked_on_retired_email(self):
         """
         Test that email address changes are rejected when an email associated with a *partially* retired account is

--- a/openedx/core/djangoapps/user_authn/api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_views.py
@@ -130,7 +130,7 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
             },
         }
 
-    @patch.dict(settings.FEATURES, {'ENABLE_THIRD_PARTY_AUTH': False})
+    @override_settings(ENABLE_THIRD_PARTY_AUTH=False)
     def test_no_third_party_auth_providers(self):
         """
         Test that if third party auth is enabled, context returned by API contains
@@ -347,7 +347,7 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
     @override_settings(
         ENABLE_DYNAMIC_REGISTRATION_FIELDS=True,
     )
-    @patch.dict(settings.FEATURES, {'ENABLE_THIRD_PARTY_AUTH': False})
+    @override_settings(ENABLE_THIRD_PARTY_AUTH=False)
     def test_response_structure(self):
         """
         Test that API return valid response dictionary with both required and optional fields

--- a/openedx/core/djangoapps/user_authn/toggles.py
+++ b/openedx/core/djangoapps/user_authn/toggles.py
@@ -22,7 +22,7 @@ def should_redirect_to_authn_microfrontend():
     if request and request.GET.get('skip_authn_mfe'):
         return False
     return configuration_helpers.get_value(
-        'ENABLE_AUTHN_MICROFRONTEND', settings.FEATURES.get('ENABLE_AUTHN_MICROFRONTEND')
+        'ENABLE_AUTHN_MICROFRONTEND', getattr(settings, 'ENABLE_AUTHN_MICROFRONTEND', False)
     )
 
 

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -642,7 +642,7 @@ def password_change_request_handler(request):
             # If enabled, send an email saying that a password reset was attempted, but that there is
             # no user associated with the email
             if configuration_helpers.get_value('ENABLE_PASSWORD_RESET_FAILURE_EMAIL',
-                                               settings.FEATURES['ENABLE_PASSWORD_RESET_FAILURE_EMAIL']):
+                                               settings.ENABLE_PASSWORD_RESET_FAILURE_EMAIL):
                 site = get_current_site()
                 message_context = get_base_template_context(site)
 

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -310,7 +310,7 @@ class AccountCreationForm(forms.Form):
         """
         country = self.cleaned_data.get("country")
         if (
-            settings.FEATURES.get('EMBARGO', False) and
+            settings.EMBARGO and
             country in GlobalRestrictedCountry.get_countries()
         ):
             raise ValidationError(_("Registration from this country is not allowed due to restrictions."))

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -71,7 +71,7 @@ def validate_username(username):
     flags = None
     message = accounts.USERNAME_INVALID_CHARS_ASCII
 
-    if settings.FEATURES.get("ENABLE_UNICODE_USERNAME"):
+    if getattr(settings, 'ENABLE_UNICODE_USERNAME', False):
         username_re = fr"^{settings.USERNAME_REGEX_PARTIAL}$"
         flags = re.UNICODE
         message = accounts.USERNAME_INVALID_CHARS_UNICODE

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -93,9 +93,6 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
         self._assert_response(response, success=True)
         self._assert_audit_log(mock_audit_log, 'info', ['Login success', self.user_email])
 
-    FEATURES_WITH_AUTHN_MFE_ENABLED = settings.FEATURES.copy()
-    FEATURES_WITH_AUTHN_MFE_ENABLED['ENABLE_AUTHN_MICROFRONTEND'] = True
-
     @override_settings(MARKETING_EMAILS_OPT_IN=True)
     def test_login_success_with_opt_in_flag_enabled(self):
         self.user.is_active = False
@@ -188,7 +185,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
     )
     @ddt.unpack
     @override_settings(LOGIN_REDIRECT_WHITELIST=['openedx.service'])
-    @override_settings(FEATURES=FEATURES_WITH_AUTHN_MFE_ENABLED)
+    @override_settings(ENABLE_AUTHN_MICROFRONTEND=True)
     @skip_unless_lms
     def test_login_success_with_redirect(self, next_url, course_id, expected_redirect):
         post_params = {}
@@ -209,7 +206,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
 
     @ddt.data(('/dashboard', False), ('/enterprise/select/active/?success_url=/dashboard', True))
     @ddt.unpack
-    @patch.dict(settings.FEATURES, {'ENABLE_AUTHN_MICROFRONTEND': True, 'ENABLE_ENTERPRISE_INTEGRATION': True})
+    @override_settings(ENABLE_AUTHN_MICROFRONTEND=True, ENABLE_ENTERPRISE_INTEGRATION=True)
     @override_settings(LOGIN_REDIRECT_WHITELIST=['openedx.service'])
     @patch('openedx.features.enterprise_support.api.EnterpriseApiClient')
     @patch('openedx.core.djangoapps.user_authn.views.login.reverse')
@@ -259,7 +256,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
 
     @ddt.data(('', True), ('/enterprise/select/active/?success_url=', False))
     @ddt.unpack
-    @patch.dict(settings.FEATURES, {'ENABLE_AUTHN_MICROFRONTEND': True, 'ENABLE_ENTERPRISE_INTEGRATION': True})
+    @override_settings(ENABLE_AUTHN_MICROFRONTEND=True, ENABLE_ENTERPRISE_INTEGRATION=True)
     @patch('openedx.features.enterprise_support.api.EnterpriseApiClient')
     @patch('openedx.core.djangoapps.user_authn.views.login.activate_learner_enterprise')
     @patch('openedx.core.djangoapps.user_authn.views.login.reverse')

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -37,6 +37,7 @@ from xmodule.modulestore.tests.django_utils import (
 
 @skip_unless_lms
 @ddt.ddt
+@override_settings(EMBARGO=True)
 class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleStoreTestCase):
     """ Tests for Login and Registration. """
     USERNAME = "bob"
@@ -45,7 +46,6 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
 
-    @mock.patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -64,16 +64,13 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         )
         self.hidden_disabled_provider = self.configure_azure_ad_provider()
 
-    FEATURES_WITH_AUTHN_MFE_ENABLED = settings.FEATURES.copy()
-    FEATURES_WITH_AUTHN_MFE_ENABLED['ENABLE_AUTHN_MICROFRONTEND'] = True
-
     @ddt.data(
         ("signin_user", "/login"),
         ("register_user", "/register"),
         ("password_assistance", "/reset"),
     )
     @ddt.unpack
-    @override_settings(FEATURES=FEATURES_WITH_AUTHN_MFE_ENABLED)
+    @override_settings(ENABLE_AUTHN_MICROFRONTEND=True)
     def test_logistration_mfe_redirects(self, url_name, path):
         """
         Test that if Logistration MFE is enabled, then we redirect to
@@ -96,7 +93,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         )
     )
     @ddt.unpack
-    @override_settings(FEATURES=FEATURES_WITH_AUTHN_MFE_ENABLED)
+    @override_settings(ENABLE_AUTHN_MICROFRONTEND=True)
     def test_logistration_redirect_params(self, url_name, path, query_params):
         """
         Test that if request is redirected to logistration MFE,

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -186,7 +186,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         expected_url = f'/login?{self._finish_auth_url_param(params)}'
         self.assertNotContains(response, expected_url)
 
-    @mock.patch.dict(settings.FEATURES, {"ENABLE_THIRD_PARTY_AUTH": False})
+    @override_settings(ENABLE_THIRD_PARTY_AUTH=False)
     @ddt.data("signin_user", "register_user")
     def test_third_party_auth_disabled(self, url_name):
         response = self.client.get(reverse(url_name))

--- a/openedx/core/djangoapps/user_authn/views/tests/test_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_password.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.core.cache import cache
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 from freezegun import freeze_time
@@ -215,7 +215,7 @@ class TestPasswordChange(CreateAccountMixin, CacheIsolationTestCase):
             self._change_password()
             self.assertRaises(UserAPIInternalError)  # noqa: PT027
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PASSWORD_RESET_FAILURE_EMAIL': True})
+    @override_settings(ENABLE_PASSWORD_RESET_FAILURE_EMAIL=True)
     def test_password_reset_failure_email(self):
         """Test that a password reset failure email notification is sent, when enabled."""
         # Log the user out

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -2684,7 +2684,7 @@ class ThirdPartyRegistrationTestMixin(
         self._verify_user_existence(user_exists=False, social_link_exists=False)
 
 
-@skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
+@skipUnless(getattr(settings, 'ENABLE_THIRD_PARTY_AUTH', False), "third party auth not enabled")
 class TestFacebookRegistrationView(
     ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinFacebook, TransactionTestCase
 ):
@@ -2705,7 +2705,7 @@ class TestFacebookRegistrationView(
         self._verify_user_existence(user_exists=False, social_link_exists=False)
 
 
-@skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
+@skipUnless(getattr(settings, 'ENABLE_THIRD_PARTY_AUTH', False), "third party auth not enabled")
 class TestGoogleRegistrationView(
     ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinGoogle, TransactionTestCase
 ):

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -3,7 +3,6 @@
 import json
 from datetime import datetime
 from unittest import mock, skipIf, skipUnless
-from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import ddt
@@ -2429,7 +2428,7 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
             })
         assert response.status_code == 400
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_register_with_disabled_country(self):
         """
         Test case to check user registration is forbidden when registration is disabled for a country
@@ -2456,7 +2455,7 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
                 ], 'error_code': 'validation-error'}
         )
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': False})
+    @override_settings(EMBARGO=False)
     def test_registration_allowed_when_embargo_disabled(self):
         """
         Ensures that user registration proceeds normally even for restricted countries
@@ -2572,7 +2571,7 @@ class ThirdPartyRegistrationTestMixin(
 
         self._verify_user_existence(user_exists=True, social_link_exists=True, user_is_active=False)
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     def test_with_disabled_country(self):
         """
         Test case to check user registration is forbidden when registration is restricted for a country
@@ -2592,7 +2591,7 @@ class ThirdPartyRegistrationTestMixin(
         }
         self._verify_user_existence(user_exists=False, social_link_exists=False, user_is_active=False)
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': False})
+    @override_settings(EMBARGO=False)
     def test_with_disabled_country_when_embargo_disabled(self):
         """
         Ensures that user registration proceeds normally even for restricted countries

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -2867,7 +2867,7 @@ class RegistrationValidationViewTests(OpenEdxEventsTestMixin, test_utils.ApiTest
             {'username': str(USERNAME_BAD_LENGTH_MSG)}
         )
 
-    @skipUnless(settings.FEATURES.get("ENABLE_UNICODE_USERNAME"), "Unicode usernames disabled.")
+    @skipUnless(getattr(settings, 'ENABLE_UNICODE_USERNAME', False), "Unicode usernames disabled.")
     @ddt.data(*testutils.INVALID_USERNAMES_UNICODE)
     def test_username_invalid_unicode_validation_decision(self, username):
         self.assertValidationDecision(
@@ -2875,7 +2875,7 @@ class RegistrationValidationViewTests(OpenEdxEventsTestMixin, test_utils.ApiTest
             {'username': str(USERNAME_INVALID_CHARS_UNICODE)}
         )
 
-    @skipIf(settings.FEATURES.get("ENABLE_UNICODE_USERNAME"), "Unicode usernames enabled.")
+    @skipIf(getattr(settings, 'ENABLE_UNICODE_USERNAME', False), "Unicode usernames enabled.")
     @ddt.data(*testutils.INVALID_USERNAMES_ASCII)
     def test_username_invalid_ascii_validation_decision(self, username):
         self.assertValidationDecision(

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -48,9 +48,6 @@ from openedx.core.djangoapps.user_authn.views.password_reset import (
 )
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 
-ENABLE_AUTHN_MICROFRONTEND = settings.FEATURES.copy()
-ENABLE_AUTHN_MICROFRONTEND['ENABLE_AUTHN_MICROFRONTEND'] = True
-
 
 def process_request(request):
     middleware = SessionMiddleware(get_response=lambda request: None)
@@ -380,7 +377,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
             SETTING_CHANGE_INITIATED, user_id=self.user.id, setting='password', old=None, new=None
         )
 
-    @override_settings(FEATURES=ENABLE_AUTHN_MICROFRONTEND)
+    @override_settings(ENABLE_AUTHN_MICROFRONTEND=True)
     @skip_unless_lms
     @ddt.data(('Crazy Awesome Site', 'Crazy Awesome Site'), ('edX', 'edX'))
     @ddt.unpack

--- a/openedx/core/djangoapps/user_authn/views/utils.py
+++ b/openedx/core/djangoapps/user_authn/views/utils.py
@@ -199,7 +199,7 @@ def remove_disabled_country_from_list(countries: Dict) -> Dict:  # noqa: UP006
     Returns:
     - dict: Dict of countries with disabled countries removed.
     """
-    if not settings.FEATURES.get("EMBARGO", False):
+    if not settings.EMBARGO:
         return countries
 
     for country_code in GlobalRestrictedCountry.get_countries():

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -289,7 +289,7 @@ def add_staff_markup(user, disable_staff_debug_info, block, view, frag, context)
         histogram = None
         render_histogram = False
 
-    if settings.FEATURES.get('ENABLE_LMS_MIGRATION') and hasattr(block.runtime, 'resources_fs'):
+    if getattr(settings, 'ENABLE_LMS_MIGRATION', False) and hasattr(block.runtime, 'resources_fs'):
         [filepath, filename] = getattr(block, 'xml_attributes', {}).get('filename', ['', None])
         osfs = block.runtime.resources_fs
         if filename is not None and osfs.exists(filename):

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -337,7 +337,7 @@ def add_staff_markup(user, disable_staff_debug_info, block, view, frag, context)
         'element_id': sanitize_html_id(block.location.html_id()),
         'edit_link': edit_link,
         'user': user,
-        'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
+        'xqa_server': settings.XQA_SERVER,
         'histogram': json.dumps(histogram),
         'render_histogram': render_histogram,
         'block_content': frag.content,

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1065,6 +1065,16 @@ CUSTOM_COURSES_EDX = False
 # Settings for course import olx validation
 ENABLE_COURSE_OLX_VALIDATION = False
 
+# .. toggle_name: ENABLE_PROCTORED_EXAMS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Global gate on the proctoring app. When True, the proctoring
+#   app advertises itself as available for all courses; per-course opt-in is a
+#   separate check.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2015-07-24
+ENABLE_PROCTORED_EXAMS = False
+
 # .. toggle_name: AUTOMATIC_AUTH_FOR_TESTING
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1075,6 +1075,14 @@ ENABLE_COURSE_OLX_VALIDATION = False
 # .. toggle_creation_date: 2015-07-24
 ENABLE_PROCTORED_EXAMS = False
 
+# .. setting_name: XQA_SERVER
+# .. setting_default: 'http://your_xqa_server.com'
+# .. setting_description: URL of the XQA staff debug/inspection server linked from the
+#   staff-only markup rendered by openedx.core.lib.xblock_utils.add_staff_markup. Set
+#   to a real endpoint if operating an XQA-compatible service; leave the placeholder
+#   default to effectively disable the link.
+XQA_SERVER = 'http://your_xqa_server.com'
+
 # .. toggle_name: AUTOMATIC_AUTH_FOR_TESTING
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False

--- a/openedx/features/name_affirmation_api/apps.py
+++ b/openedx/features/name_affirmation_api/apps.py
@@ -20,7 +20,7 @@ class NameAffirmationApiConfig(AppConfig):
         """
         Connect services.
         """
-        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+        if settings.ENABLE_SPECIAL_EXAMS:
             name_affirmation_service = get_name_affirmation_service()
             if name_affirmation_service:
                 set_runtime_service('name_affirmation', name_affirmation_service)

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -54,7 +54,7 @@ DEFAULT_COURSE_VISIBILITY_IN_CATALOG = getattr(
 DEFAULT_MOBILE_AVAILABLE = getattr(settings, 'DEFAULT_MOBILE_AVAILABLE', False)
 # Note: updating assets does not have settings defined, so using `getattr`.
 EXAM_SETTINGS_HTML_VIEW_ENABLED = getattr(settings, 'FEATURES', {}).get('ENABLE_EXAM_SETTINGS_HTML_VIEW', False)
-SPECIAL_EXAMS_ENABLED = getattr(settings, 'FEATURES', {}).get('ENABLE_SPECIAL_EXAMS', False)
+SPECIAL_EXAMS_ENABLED = getattr(settings, 'ENABLE_SPECIAL_EXAMS', False)
 
 COURSE_VISIBILITY_PRIVATE = 'private'
 COURSE_VISIBILITY_PUBLIC_OUTLINE = 'public_outline'

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -236,7 +236,7 @@ class ProctoringProvider(String):
         and include any inherited values from the platform default.
         """
         value = super().from_json(value)
-        if settings.FEATURES.get('ENABLE_PROCTORED_EXAMS'):
+        if getattr(settings, 'ENABLE_PROCTORED_EXAMS', False):
             # Only validate the provider value if ProctoredExams are enabled on the environment
             # Otherwise, the passed in provider does not matter. We should always return default
             if validate_providers:

--- a/xmodule/modulestore/django.py
+++ b/xmodule/modulestore/django.py
@@ -355,7 +355,7 @@ def modulestore():
             settings.MODULESTORE['default'].get('OPTIONS', {})
         )
 
-        if settings.FEATURES.get('CUSTOM_COURSES_EDX'):
+        if getattr(settings, 'CUSTOM_COURSES_EDX', False):
             # TODO: This import prevents a circular import issue, but is
             # symptomatic of a lib having a dependency on code in lms.  This
             # should be updated to have a setting that enumerates modulestore

--- a/xmodule/tests/test_course_block.py
+++ b/xmodule/tests/test_course_block.py
@@ -427,10 +427,7 @@ class ProctoringProviderTestCase(unittest.TestCase):
         provider = 'invalid-provider'
         allowed_proctoring_providers = xmodule.course_block.get_available_providers()
 
-        FEATURES_WITH_PROCTORED_EXAMS = settings.FEATURES.copy()
-        FEATURES_WITH_PROCTORED_EXAMS['ENABLE_PROCTORED_EXAMS'] = proctored_exams_setting_enabled
-
-        with override_settings(FEATURES=FEATURES_WITH_PROCTORED_EXAMS):
+        with override_settings(ENABLE_PROCTORED_EXAMS=proctored_exams_setting_enabled):
             if proctored_exams_setting_enabled:
                 with pytest.raises(InvalidProctoringProvider) as context_manager:
                     self.proctoring_provider.from_json(provider, validate_providers=True)
@@ -447,10 +444,7 @@ class ProctoringProviderTestCase(unittest.TestCase):
         """
         provider = 'invalid-provider'
 
-        FEATURES_WITH_PROCTORED_EXAMS = settings.FEATURES.copy()
-        FEATURES_WITH_PROCTORED_EXAMS['ENABLE_PROCTORED_EXAMS'] = True
-
-        with override_settings(FEATURES=FEATURES_WITH_PROCTORED_EXAMS):
+        with override_settings(ENABLE_PROCTORED_EXAMS=True):
             provider_value = self.proctoring_provider.from_json(provider, validate_providers=False)
             assert provider_value == provider
 


### PR DESCRIPTION
Second PR in the FEATURES-as-dict migration stack. #38818 (the bridge) is merged.

Per-flag `refactor:` commits that move callers off `settings.FEATURES['X']` / `patch.dict(settings.FEATURES, …)` and onto `settings.X` / `@override_settings(X=…)`. The underlying flat settings already exist in `lms/envs/common.py`, `cms/envs/common.py`, and the shared `openedx/envs/common.py` — the env files were previously flattened, so this PR only touches call sites (plus a few flag definitions that needed to move into the shared file).

### `settings.X` vs `getattr(settings, 'X', <default>)`

Most reads drop the `getattr` fallback in favor of a bare `settings.X` — but not all. The rule is: **a bare `settings.X` requires that the setting be defined in the `common.py` file of every process that can reach the read.**

- **Setting defined in `openedx/envs/common.py`** (shared, imported by both LMS and CMS) — use bare `settings.X` at every caller.
- **Setting defined only in `lms/envs/common.py`** — use bare `settings.X` only if the caller is exclusively reachable from the LMS process. If the caller lives under `common/djangoapps/` or `openedx/core/` and can be pulled in by CMS test collection or CMS request handling, keep `getattr(settings, 'X', <default>)` so CMS doesn't `AttributeError`.
- **Setting defined only in `cms/envs/common.py`** — the mirror rule. Bare `settings.X` at CMS-only callers; `getattr` at shared/LMS-reachable callers. This deliberately keeps Studio-only concepts (e.g. `ENABLE_CREATOR_GROUP`, `DISABLE_COURSE_CREATION`) from leaking into LMS settings.
- **Setting not previously defined anywhere** — the migration adds an explicit definition (with a proper `.. toggle_name:` / `.. setting_name:` annotation) in the smallest common file that covers all callers, then drops `getattr` at the call sites.

`hasattr(settings, 'X')` is used in a few module-load contexts (test util constants) where we specifically want "is the setting defined" rather than "what is its value" — safe against a missing setting on either process.

Stack:
- #38818 — bridge → master (merged)
- (this PR) migrations → master
- #38819 — temp diagnostic (lists flags still to migrate) → migrations