### PR TITLE
fix: course cert not created on credentials service

### DIFF
--- a/openedx/core/djangoapps/programs/signals.py
+++ b/openedx/core/djangoapps/programs/signals.py
@@ -4,6 +4,7 @@ This module contains signals / handlers related to programs.
 
 import logging
 
+from django.db import transaction
 from django.dispatch import receiver
 
 from openedx.core.djangoapps.content.course_overviews.signals import COURSE_PACING_CHANGED
@@ -86,7 +87,7 @@ def handle_course_cert_changed(sender, user, course_key, mode, status, **kwargs)
     # import here, because signal is registered at startup, but items in tasks are not yet able to be loaded
     from openedx.core.djangoapps.programs.tasks import award_course_certificate
 
-    award_course_certificate.delay(user.username, str(course_key))
+    transaction.on_commit(lambda: award_course_certificate.delay(user.username, str(course_key)))
 
 
 @receiver(COURSE_CERT_REVOKED)

--- a/openedx/core/djangoapps/programs/tests/test_signals.py
+++ b/openedx/core/djangoapps/programs/tests/test_signals.py
@@ -142,7 +142,8 @@ class CertChangedReceiverTest(TestCase):
         assert mock_is_learner_issuance_enabled.call_count == 1
         assert mock_task.call_count == 0
 
-    def test_credentials_enabled(self, mock_is_learner_issuance_enabled, mock_task):
+    @mock.patch("django.db.transaction.on_commit", side_effect=lambda f: f())
+    def test_credentials_enabled(self, mock_on_commit, mock_is_learner_issuance_enabled, mock_task):
         """
         Ensures that the receiver function invokes the expected celery task
         when the credentials API configuration is enabled.
@@ -152,23 +153,28 @@ class CertChangedReceiverTest(TestCase):
         handle_course_cert_changed(**self.signal_kwargs)
 
         assert mock_is_learner_issuance_enabled.call_count == 1
+        assert mock_on_commit.call_count == 1
         assert mock_task.call_count == 1
         assert mock_task.call_args[0] == (TEST_USERNAME, str(TEST_COURSE_KEY))
 
-    def test_records_enabled(self, mock_is_learner_issuance_enabled, mock_task):
+    @mock.patch("django.db.transaction.on_commit", side_effect=lambda f: f())
+    def test_records_enabled(self, mock_on_commit, mock_is_learner_issuance_enabled, mock_task):
         mock_is_learner_issuance_enabled.return_value = True
 
         site_config = SiteConfigurationFactory.create(site_values={"course_org_filter": ["edX"]})
 
-        # Correctly sent
+        # Correctly sent (scheduled via transaction.on_commit)
         handle_course_cert_changed(**self.signal_kwargs)
+        assert mock_on_commit.called
         assert mock_task.called
+        mock_on_commit.reset_mock()
         mock_task.reset_mock()
 
         # Correctly not sent
         site_config.site_values["ENABLE_LEARNER_RECORDS"] = False
         site_config.save()
         handle_course_cert_changed(**self.signal_kwargs)
+        assert not mock_on_commit.called
         assert not mock_task.called
 
 


### PR DESCRIPTION
## Description

### Fixes
https://github.com/openedx/openedx-platform/issues/38776

### Root Cause

`COURSE_CERT_CHANGED` fires synchronously inside `GeneratedCertificate.save()`, which itself runs inside the `generate_certificate` Celery task. The `.delay()` call was enqueuing `award_course_certificate` **before the DB transaction committed**, so a second Celery worker picked up the task immediately, called `eligible_certificates.get()`, found nothing (the row wasn't committed yet), and returned silently — **no retry, no error, no course cert posted to Credentials**.

The race window is small (~30ms in observed logs) but consistent, and reproducible on every fresh course completion:

```
10:09:52.540  award_course_certificate RUNNING   → eligible_certificates.get() → DoesNotExist → returns
10:09:52.572  generate_certificate commits cert as downloadable                  ← 32ms too late
```

### Impact

**Course certificates are never synced to the Credentials IDA**, even when:
- `CredentialsApiConfig.enable_learner_issuance` is `True`
- `ENABLE_LEARNER_RECORDS` is `True`
- The learner has a valid `downloadable` `GeneratedCertificate` in the LMS

The `eligible_certificates` manager only excludes `audit_passing` / `audit_notpassing` statuses — mode (`verified`, `no-id-professional`, etc.) is irrelevant. The cert is perfectly eligible; it simply does not exist in the DB at query time.

**Program certificates are unaffected** — `handle_course_cert_awarded` (the program cert handler) does not query `eligible_certificates`; it delegates to `get_completed_programs` which reads from the Credentials API directly.

### Downstream breakage: Learner Record MFE

The Learner Record MFE (`frontend-app-learner-record`) renders program record pages by querying the Credentials service for both the program `UserCredential` and individual course-run `UserCredential`s. When course certs are never posted to Credentials, the MFE shows every course in the program as **"Not Earned"** — even for learners who have fully completed all courses and hold a program certificate.

Example (observed):

| Course | Grade | Status shown in MFE |
|---|---|---|
| Paid Course 1 | Pass | ❌ Not Earned |
| Paid Course 2 | Pass | ❌ Not Earned |
| Paid Course 3 | Pass | ❌ Not Earned |

Program certificate: ✅ Awarded — making the "Not Earned" course rows even more confusing to learners.

The only workaround is the `notify_credentials` management command backfill, which calls `award_course_certificate` directly (bypassing the signal handler and therefore bypassing the race), but this needs to be run manually after the fact for each affected learner.

### Fix

Wrap the `.delay()` call in `transaction.on_commit()` so `award_course_certificate` is only enqueued **after** the `generate_certificate` transaction commits — guaranteeing the `GeneratedCertificate` row exists in the DB when the task runs.

```python
# before
award_course_certificate.delay(user.username, str(course_key))

# after
transaction.on_commit(lambda: award_course_certificate.delay(user.username, str(course_key)))
```

## Testing

1. Enrol a **new** learner (no prior certs) in a course that is part of a program
2. Complete all graded content so the course grade passes for the first time
3. Check Celery worker logs — confirm `award_course_certificate` log shows **"will award a course certificate to user X in course run Y"** (the line logged just before the credentials POST, at `tasks.py`)
4. Verify a `UserCredential` of type `course-run` is created in the Credentials service admin for that learner
5. Open the Learner Record MFE for the program — confirm the course shows **Earned** with grade and date populated
6. Confirm no regression on program certificate issuance

## Notes

- The `notify_credentials` management command backfill remains the correct remediation for learners affected before this fix is deployed.
- `handle_course_cert_revoked` dispatches `revoke_program_certificates` (program-level, not course-level) so is not affected by this race.
- `CertificateDateOverride` signal handlers already use `transaction.on_commit` — this fix makes `handle_course_cert_changed` consistent with that pattern.