### PR TITLE
fix: pin django-autocomplete-light to 4.0.3

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -252,7 +252,7 @@ django==5.2.15
     #   xss-utils
 django-appconf==1.2.0
     # via django-statici18n
-django-autocomplete-light==4.0.1
+django-autocomplete-light==4.0.0
     # via -r requirements/edx/kernel.in
 django-cache-memoize==0.2.1
     # via edx-enterprise

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -252,7 +252,7 @@ django==5.2.15
     #   xss-utils
 django-appconf==1.2.0
     # via django-statici18n
-django-autocomplete-light==4.0.0
+django-autocomplete-light==4.0.3
     # via -r requirements/edx/kernel.in
 django-cache-memoize==0.2.1
     # via edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -423,7 +423,7 @@ django-appconf==1.2.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-statici18n
-django-autocomplete-light==4.0.0
+django-autocomplete-light==4.0.3
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -423,7 +423,7 @@ django-appconf==1.2.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   django-statici18n
-django-autocomplete-light==4.0.1
+django-autocomplete-light==4.0.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -318,7 +318,7 @@ django-appconf==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   django-statici18n
-django-autocomplete-light==4.0.1
+django-autocomplete-light==4.0.0
     # via -r requirements/edx/base.txt
 django-cache-memoize==0.2.1
     # via

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -318,7 +318,7 @@ django-appconf==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   django-statici18n
-django-autocomplete-light==4.0.0
+django-autocomplete-light==4.0.3
     # via -r requirements/edx/base.txt
 django-cache-memoize==0.2.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -339,7 +339,7 @@ django-appconf==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   django-statici18n
-django-autocomplete-light==4.0.0
+django-autocomplete-light==4.0.3
     # via -r requirements/edx/base.txt
 django-cache-memoize==0.2.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -339,7 +339,7 @@ django-appconf==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   django-statici18n
-django-autocomplete-light==4.0.1
+django-autocomplete-light==4.0.0
     # via -r requirements/edx/base.txt
 django-cache-memoize==0.2.1
     # via


### PR DESCRIPTION
## Summary

- `django-autocomplete-light==4.0.1` does not exist on PyPI
- The version might be  withdrawn shortly after being published or was never released properly.

Ref: https://pypi.org/project/django-autocomplete-light/#history
## Fix

Pin `django-autocomplete-light` to `4.0.3` (the last known-good version) in all four compiled requirements files: `base.txt`, `testing.txt`, `doc.txt`, `development.txt`.

## Test plan

- CI dependency installation should succeed with `4.0.0`.
- No code changes — requirements pin only.
