### PR TITLE
feat: expose field type and options in advanced settings API

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -201,7 +201,15 @@ class CourseMetadata:
                 'display_name': _(field.display_name),  # pylint: disable=translation-of-non-string
                 'help': field_help,
                 'deprecated': field.runtime_options.get('deprecated', False),
-                'hide_on_enabled_publisher': field.runtime_options.get('hide_on_enabled_publisher', False)
+                'hide_on_enabled_publisher': field.runtime_options.get('hide_on_enabled_publisher', False),
+                # The field's class name (e.g. "String", "Boolean", "Integer", "List", "Dict") lets the
+                # frontend pick the right input type without inferring it from the value's shape.
+                'type': field.__class__.__name__,
+                # The field's declared choices, when it has any. For enum-like settings this is a list of
+                # {"display_name", "value"} dicts; for numeric ranges it may be a {"min"/"max"} dict; for
+                # free-form settings it is None. Exposing it here keeps the valid options as a single source
+                # of truth in the backend instead of being hardcoded in the frontend.
+                'options': field.values,
             }
         return result
 

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -28,6 +28,7 @@ from openedx.core.lib.license import LicenseMixin
 from openedx.core.lib.teams_config import TeamsConfig  # pylint: disable=unused-import
 from xmodule import course_metadata_utils
 from xmodule.course_metadata_utils import DEFAULT_GRADING_POLICY, DEFAULT_START_DATE
+from xmodule.course_settings_field_options import CERTIFICATES_DISPLAY_BEHAVIOR_FIELD_OPTIONS
 from xmodule.data import CertificatesDisplayBehaviors
 from xmodule.graders import grader_from_conf
 from xmodule.seq_block import SequenceBlock
@@ -605,6 +606,7 @@ class CourseFields:  # pylint: disable=missing-class-docstring
         ),
         scope=Scope.settings,
         default=CertificatesDisplayBehaviors.END.value,
+        values=CERTIFICATES_DISPLAY_BEHAVIOR_FIELD_OPTIONS,
     )
     course_image = String(
         display_name=_("Course About Page Image"),

--- a/xmodule/course_settings_field_options.py
+++ b/xmodule/course_settings_field_options.py
@@ -1,0 +1,60 @@
+"""
+Canonical option lists ("values") for course-level Advanced Settings fields
+that should be presented as dropdowns in Studio.
+
+These describe the valid choices for enum-like course settings so the Advanced
+Settings API can expose them to the frontend, instead of the frontend
+hardcoding them. Each list follows the XBlock ``values`` format:
+``[{"display_name": ..., "value": ...}, ...]``.
+
+``display_name`` values are plain strings (not wrapped in gettext) for two
+reasons: this module is imported by ``xmodule/modulestore/inheritance.py``,
+which explicitly forbids importing Django, and the existing enum ``values`` in
+``xmodule/course_block.py`` already use plain-string labels. User-facing
+translation of these labels is handled by the frontend.
+
+NOTE: ``showanswer`` / ``rerandomize`` / ``show_correctness`` also exist as
+problem-level fields in ``xmodule/capa_block.py`` with their own inline
+``values``. Those should eventually be migrated to reference these constants so
+there is a single source of truth. They are mirrored here (matching the
+SHOWANSWER / RANDOMIZATION / ShowCorrectness constants) to keep this module
+dependency-light and avoid import cycles.
+"""
+
+# Mirrors SHOWANSWER in xmodule/capa_block.py
+SHOWANSWER_FIELD_OPTIONS = [
+    {"display_name": "Always", "value": "always"},
+    {"display_name": "Answered", "value": "answered"},
+    {"display_name": "Attempted or Past Due", "value": "attempted"},
+    {"display_name": "Closed", "value": "closed"},
+    {"display_name": "Finished", "value": "finished"},
+    {"display_name": "Correct or Past Due", "value": "correct_or_past_due"},
+    {"display_name": "Past Due", "value": "past_due"},
+    {"display_name": "Never", "value": "never"},
+    {"display_name": "After Some Number of Attempts", "value": "after_attempts"},
+    {"display_name": "After All Attempts", "value": "after_all_attempts"},
+    {"display_name": "After All Attempts or Correct", "value": "after_all_attempts_or_correct"},
+    {"display_name": "Attempted", "value": "attempted_no_past_due"},
+]
+
+# Mirrors RANDOMIZATION in xmodule/capa_block.py
+RERANDOMIZE_FIELD_OPTIONS = [
+    {"display_name": "Always", "value": "always"},
+    {"display_name": "On Reset", "value": "onreset"},
+    {"display_name": "Never", "value": "never"},
+    {"display_name": "Per Student", "value": "per_student"},
+]
+
+# Mirrors ShowCorrectness in the xblock.scorable library
+SHOW_CORRECTNESS_FIELD_OPTIONS = [
+    {"display_name": "Always", "value": "always"},
+    {"display_name": "Never", "value": "never"},
+    {"display_name": "Past Due", "value": "past_due"},
+]
+
+# Mirrors CertificatesDisplayBehaviors in xmodule/data.py
+CERTIFICATES_DISPLAY_BEHAVIOR_FIELD_OPTIONS = [
+    {"display_name": "End of course", "value": "end"},
+    {"display_name": "End of course, with date", "value": "end_with_date"},
+    {"display_name": "Immediately upon earning", "value": "early_no_info"},
+]

--- a/xmodule/modulestore/inheritance.py
+++ b/xmodule/modulestore/inheritance.py
@@ -10,6 +10,11 @@ from xblock.core import XBlockMixin
 from xblock.fields import Boolean, Date, Dict, Float, Integer, List, Scope, String, Timedelta
 from xblock.runtime import KeyValueStore, KvsFieldData
 
+from xmodule.course_settings_field_options import (
+    RERANDOMIZE_FIELD_OPTIONS,
+    SHOW_CORRECTNESS_FIELD_OPTIONS,
+    SHOWANSWER_FIELD_OPTIONS,
+)
 from xmodule.error_block import ErrorBlock
 from xmodule.partitions.partitions import UserPartition
 
@@ -97,6 +102,7 @@ class InheritanceMixin(XBlockMixin):
         ),
         scope=Scope.settings,
         default="finished",
+        values=SHOWANSWER_FIELD_OPTIONS,
     )
 
     show_correctness = String(
@@ -109,6 +115,7 @@ class InheritanceMixin(XBlockMixin):
         ),
         scope=Scope.settings,
         default="always",
+        values=SHOW_CORRECTNESS_FIELD_OPTIONS,
     )
 
     rerandomize = String(
@@ -123,6 +130,7 @@ class InheritanceMixin(XBlockMixin):
         ),
         scope=Scope.settings,
         default="never",
+        values=RERANDOMIZE_FIELD_OPTIONS,
     )
     days_early_for_beta = Float(
         display_name=_("Days Early for Beta Users"),


### PR DESCRIPTION
## Description

The Advanced Settings API (`/api/contentstore/v0/advanced_settings/{course_id}`)
returns, for each setting, only `value`, `display_name`, `help`, `deprecated`,
and `hide_on_enabled_publisher`. It does **not** tell clients what *type* a
setting is, nor what *valid choices* an enum-like setting accepts.

This forces any UI that wants to render type-specific controls (toggles, number
fields, dropdowns) to hardcode that metadata on the client. That duplication
drifts from the platform over time and can cause **silent data loss** — e.g. a
dropdown that omits a value the course actually has set.

This PR moves that metadata to the backend, which already knows it, so it can be
the single source of truth.

## Changes

- `CourseMetadata.fetch_all` now includes two additional fields per setting:
  - **`type`** — the XBlock field class name (`String`, `Boolean`, `Integer`,
    `Float`, `List`, `Dict`, …), so clients can choose an input type without
    inferring it from the value's shape.
  - **`options`** — the field's `values`: a list of `{display_name, value}`
    choices for enum-like fields, a constraints dict (e.g. `{"min": 0}`) for some
    numeric fields, or `null` for free-form fields.
- Adds course-level `values` to enum settings that lacked them, so their valid
  choices are defined in the backend:
  - `showanswer`, `rerandomize`, `show_correctness` (`xmodule/modulestore/inheritance.py`)
  - `certificates_display_behavior` (`xmodule/course_block.py`)
  - These reference a new `xmodule/course_settings_field_options.py` that holds
    the canonical option lists.
- Settings that already declared `values` (`catalog_visibility`,
  `course_visibility`, `video_sharing_options`) are exposed automatically by the
  serializer change — no per-field edit needed.

The problem-level field definitions in `xmodule/capa_block.py` are **unchanged**.
As a follow-up, those could be migrated to reference the same shared option lists
so the problem and course levels share a single source.

The response is additive and backward compatible: existing fields are untouched,
the two new keys are simply added.

## Context

This is the backend counterpart to the Advanced Settings redesign frontend PR
openedx/frontend-app-authoring#3019. It addresses review feedback there that the
redesign should not hardcode field metadata in the frontend, but source it from
the backend instead.

## Testing

- Verified `CourseMetadata.fetch_all` returns `type` and `options` for all
  settings via the CMS shell (all 8 enum settings now carry their options;
  booleans report `type: "Boolean"`; numeric fields report `type: "Integer"`/
  `"Float"`).
- Verified end-to-end against the redesigned authoring MFE: enum settings render
  as dropdowns populated from the backend `options`, booleans as toggles, etc.

## Draft

Opened as a draft as the companion to the frontend PR and to gather feedback on
the approach before requesting formal review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
