### PR TITLE
fix: ensure navigation sidebar serves fresh data after course publish

### DIFF
--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -25,6 +25,7 @@ from lms.djangoapps.course_home_api.outline.views import CourseNavigationBlocksV
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
 from lms.djangoapps.course_home_api.toggles import COURSE_HOME_SEND_COURSE_PROGRESS_ANALYTICS_FOR_STUDENT
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
+from openedx.core.djangoapps.content.block_structure.api import update_course_in_cache
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.learning_sequences.api import replace_course_outline
 from openedx.core.djangoapps.content.learning_sequences.data import CourseOutlineData, CourseVisibility
@@ -907,3 +908,55 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         response = self.client.get(reverse('course-home:course-navigation', args=[self.course.id]))
         vertical_data = response.data['blocks'][str(self.vertical.location)]
         assert vertical_data['icon'] == 'video'
+
+    def test_navigation_does_not_cache_stale_data_after_publish(self):
+        """
+        Regression test: after the block structure rebuild task completes,
+        the navigation sidebar should serve fresh data.
+
+        This simulates a production scenario where:
+        1. A unit is deleted and the course is auto-published
+        2. The block structure rebuild Celery task is queued with a delay (30s by default)
+        3. A learner hits the navigation endpoint during that 30s window
+        4. The rebuild task completes (bumping block_structure_version)
+        5. Another request arrives
+
+        Without the fix, step 3 caches stale data under a key that step 5
+        also hits (because course_version changed eagerly). With the fix,
+        the cache key uses block_structure_version which only changes when
+        the rebuild completes, so step 5 gets a cache miss and fresh data.
+        """
+        self.add_blocks_to_course()
+        CourseEnrollment.enroll(self.user, self.course.id, CourseMode.VERIFIED)
+
+        # First request — populates both block structure and navigation cache
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        sequential_data = response.data['blocks'][str(self.sequential.location)]
+        assert str(self.vertical.location) in sequential_data['children']
+
+        # Delete the vertical directly in the modulestore. Signals are disabled
+        # in ModuleStoreTestCase, so the block structure cache is now stale —
+        # mirroring the 30s window in production before the rebuild task runs.
+        self.store.delete_item(self.vertical.location, self.user.id)
+        update_outline_from_modulestore(self.course.id)
+
+        # Request during the stale window — served from the pre-delete cache
+        # (block_structure_version hasn't changed yet, so same cache key).
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+        # The vertical is still in the cache, even though it has been deleted
+        sequential_data = response.data['blocks'][str(self.sequential.location)]
+        assert str(self.vertical.location) in sequential_data['children']
+
+        # Now simulate the block structure rebuild task completing.
+        # This bumps block_structure_version → new cache key on next request.
+        update_course_in_cache(self.course.id)
+
+        # Next request has a new cache key (version bumped) → cache miss →
+        # fresh data built from updated block structure.
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        sequential_data = response.data['blocks'][str(self.sequential.location)]
+        assert str(self.vertical.location) not in sequential_data['children']

--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -51,6 +51,7 @@ from lms.djangoapps.courseware.toggles import courseware_disable_navigation_side
 from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.utils import OptimizelyClient
+from openedx.core.djangoapps.content.block_structure.api import get_block_structure_version
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_404
 from openedx.core.djangoapps.content.learning_sequences.api import get_user_course_outline
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort
@@ -434,7 +435,7 @@ class CourseNavigationBlocksView(RetrieveAPIView):
 
     serializer_class = CourseBlockSerializer
     COURSE_BLOCKS_CACHE_KEY_TEMPLATE = (
-        'course_sidebar_blocks_{course_key_string}_{course_version}_{user_id}_{user_cohort_id}'
+        'course_sidebar_blocks_{course_key_string}_{block_structure_version}_{user_id}_{user_cohort_id}'
         '_{enrollment_mode}_{allow_public}_{allow_public_outline}_{is_masquerading}'
     )
     COURSE_BLOCKS_CACHE_TIMEOUT = 60 * 60  # 1 hour
@@ -469,7 +470,7 @@ class CourseNavigationBlocksView(RetrieveAPIView):
 
         cache_key = self.COURSE_BLOCKS_CACHE_KEY_TEMPLATE.format(
             course_key_string=course_key_string,
-            course_version=str(course.course_version),
+            block_structure_version=get_block_structure_version(course_key),
             user_id=request.user.id,
             enrollment_mode=getattr(enrollment, 'mode', ''),
             user_cohort_id=getattr(user_cohort, 'id', ''),

--- a/openedx/core/djangoapps/content/block_structure/api.py
+++ b/openedx/core/djangoapps/content/block_structure/api.py
@@ -8,6 +8,47 @@ from django.core.cache import cache
 from xmodule.modulestore.django import modulestore
 
 from .manager import BlockStructureManager
+from .models import BlockStructureModel
+
+BLOCK_STRUCTURE_VERSION_KEY = 'block_structure_version:{}'
+
+
+def get_block_structure_version(course_key):
+    """
+    Returns the current block structure version for the given course.
+    This version corresponds to the data_version stored in BlockStructureModel
+    and changes each time the block structure cache is rebuilt.
+
+    Reads from cache first; on a miss, falls back to the database
+    without populating the cache. The cache is populated exclusively by
+    _update_block_structure_version after a successful rebuild, which
+    prevents readers from accidentally caching a stale version during
+    a concurrent rebuild.
+    """
+    cache_key = BLOCK_STRUCTURE_VERSION_KEY.format(course_key)
+    version = cache.get(cache_key)
+    if version is None:
+        try:
+            course_usage_key = modulestore().make_course_usage_key(course_key)
+            block_structure_model = BlockStructureModel.objects.get(data_usage_key=course_usage_key)
+            version = str(block_structure_model.data_version or '')
+        except BlockStructureModel.DoesNotExist:
+            version = ''
+    return version
+
+
+def _update_block_structure_version(course_key):
+    """
+    Reads the current data_version from BlockStructureModel and updates
+    the cached block structure version key.
+    """
+    try:
+        course_usage_key = modulestore().make_course_usage_key(course_key)
+        block_structure_model = BlockStructureModel.objects.get(data_usage_key=course_usage_key)
+        version = str(block_structure_model.data_version or '')
+    except BlockStructureModel.DoesNotExist:
+        version = ''
+    cache.set(BLOCK_STRUCTURE_VERSION_KEY.format(course_key), version, timeout=None)
 
 
 def get_course_in_cache(course_key):
@@ -29,7 +70,8 @@ def update_course_in_cache(course_key):
     block_structure.updated_collected function that updates the block
     structure in the cache for the given course_key.
     """
-    return get_block_structure_manager(course_key).update_collected_if_needed()
+    get_block_structure_manager(course_key).update_collected_if_needed()
+    _update_block_structure_version(course_key)
 
 
 def clear_course_from_cache(course_key):


### PR DESCRIPTION
## Description

After a course publish in Studio, the navigation sidebar (`CourseNavigationBlocksView`) can serve stale block structure data for up to 1 hour. This happens because the sidebar cache key previously used `course_version` (which changes immediately on publish), causing a cache miss during the ~30s window before the async block structure rebuild task completes. The view would read the still-stale block structure, cache that stale result under the new key for 1 hour, and serve stale data indefinitely.

**Fix:** Replace `course_version` with `block_structure_version` in the navigation sidebar cache key. This version is derived from `BlockStructureModel.data_version` and only changes when the block structure rebuild task actually completes. Additionally, `get_block_structure_version()` never populates the cache — only the writer (`_update_block_structure_version`, called after a successful rebuild) sets the cached value. This eliminates a race condition where concurrent readers could permanently cache a stale version.

**Impacted user roles:** Learner (sees correct course outline sooner after a publish), Course Author (changes reflected faster).

Fixes https://github.com/openedx/wg-build-test-release/issues/600

### How it works

1. `update_course_in_cache` rebuilds the block structure, then calls `_update_block_structure_version()` which reads the new `data_version` from `BlockStructureModel` and sets it in cache with `timeout=None`
2. `get_block_structure_version()` reads from cache; on a miss it falls back to the database **without caching** the result — the cache is populated exclusively by the writer after a successful rebuild
3. `CourseNavigationBlocksView` uses `block_structure_version` in its cache key instead of `course_version`
4. The cache key only changes when data is actually ready — no more caching stale data for 1 hour

### Why not synchronous rebuild on the request path?

The [initial approach](https://github.com/openedx/openedx-platform/pull/38785#pullrequestreview-2957000721) called `update_collected_if_needed()` on the GET path. As noted in review, block structure collection for large courses can exceed 30s and risks a stampede under concurrent load. The version-based approach avoids any expensive work on the request path.

### Performance impact

- **Every request (cache hit):** One additional `cache.get()` call to read `block_structure_version`.
- **Every request (cache miss, during rebuild window):** One database call - `BlockStructureModel.objects.get()` by primary key
- **Cache miss on sidebar (version bumped):** Same as before — `get_course_outline_block_tree()` runs and result is cached for 1 hour
- **During 30s rebuild window:** Old sidebar cache entries continue to serve (consistent pre-publish data, same version key)
- **No stampede risk:** Version only bumps once the rebuild is complete

### Deploy considerations

`BlockStructureModel.data_version` stores the same value as `course.course_version` (set from [`root_block.course_version`](https://github.com/openedx/openedx-platform/blob/59358990e42e6478ba53658becea167ec2957c01/openedx/core/djangoapps/content/block_structure/store.py#L220) at rebuild time). Since the sidebar cache key substitutes one for the other, existing cached sidebar entries remain warm — the key resolves to the same string.

The `block_structure_version` cache key itself won't exist until the first post-deploy publish per course. Until then, `get_block_structure_version()` falls through to a single PK database lookup on `BlockStructureModel`.

## Supporting information

This issue was discovered testing an internal Open edX instance. After deleting a unit in Studio and refreshing the course in the learning MFE within a few seconds, the deleted unit remained visible in the sidebar for up to 1 hour.

The root cause involves three components:
- [30s Celery task delay for block structure rebuild](https://github.com/openedx/openedx-platform/blob/47c5078b2da4455efa6cddda815b867779b14bcf/openedx/core/djangoapps/content/block_structure/signals.py#L29-L31) ([configured here](https://github.com/openedx/openedx-platform/blob/47c5078b2da4455efa6cddda815b867779b14bcf/openedx/envs/common.py#L1511-L1519))
- Navigation cache key using eagerly-changing `course_version`
- 1-hour cache TTL on the stale response

## Testing instructions

Automated:
```bash
tutor dev run lms pytest \
  lms/djangoapps/course_home_api/outline/tests/test_view.py::SidebarBlocksTestViews::test_navigation_does_not_cache_stale_data_after_publish \
  --ds=lms.envs.test --no-migrations -x
```

Manual (requires async Celery):
1. Open a course in the learning MFE, note a unit in the sidebar
2. In Studio, delete that unit (auto-publishes)
3. Immediately refresh the course in the MFE
4. Wait 30+ seconds, refresh again
5. Verify the deleted unit is no longer in the sidebar

Without the fix: unit remains visible for up to 1 hour after step 2.
With the fix: unit disappears after step 4 (once the rebuild task completes).

## Deadline

None

## Other information

- No database migrations
- No new dependencies
- The `block_structure_version` cache key is set with `timeout=None` (no expiry) by the writer. Readers never populate the cache, eliminating the race condition entirely.
- If the cache is flushed, readers gracefully fall back to the database until the next rebuild populates the cache.

## AI Usage

Used Kiro to aid in root cause discovery, evaluate multiple fix approaches (synchronous rebuild, TTL-based self-healing, writer-only cache ownership), debug the race condition via log analysis, and draft this PR description.
