### PR TITLE
fix: studio access notifications

### DIFF
--- a/cms/djangoapps/course_creators/admin.py
+++ b/cms/djangoapps/course_creators/admin.py
@@ -22,6 +22,7 @@ from cms.djangoapps.course_creators.models import (
 )
 from cms.djangoapps.course_creators.views import update_course_creator_group, update_org_content_creator_role
 from common.djangoapps.edxmako.shortcuts import render_to_string
+from openedx.core.djangoapps.theming.helpers import get_current_site
 
 log = logging.getLogger("studio.coursecreatoradmin")
 
@@ -134,6 +135,16 @@ def update_creator_group_callback(sender, **kwargs):  # pylint: disable=unused-a
     update_course_creator_group(kwargs['caller'], user, create_role)
 
 
+def course_creator_notification_context(subject):
+    return {
+        'studio_request_email': settings.FEATURES.get('STUDIO_REQUEST_EMAIL', ''),
+        'is_secure': (settings.CMS_ROOT_URL or '').split(':')[0].lower() == 'https',
+        'site': str(get_current_site() or settings.CMS_BASE),
+        'user_name': subject.username,
+        'user_email': subject.email,
+    }
+
+
 @receiver(send_user_notification, sender=CourseCreator)
 def send_user_notification_callback(sender, **kwargs):  # pylint: disable=unused-argument
     """
@@ -142,9 +153,8 @@ def send_user_notification_callback(sender, **kwargs):  # pylint: disable=unused
     user = kwargs['user']
     updated_state = kwargs['state']
 
-    studio_request_email = settings.FEATURES.get('STUDIO_REQUEST_EMAIL', '')
-    context = {'studio_request_email': studio_request_email}
-
+    context = course_creator_notification_context(user)
+    studio_request_email = context['studio_request_email']
     subject = render_to_string('emails/course_creator_subject.txt', context)
     subject = ''.join(subject.splitlines())
     if updated_state == CourseCreator.GRANTED:
@@ -169,8 +179,8 @@ def send_admin_notification_callback(sender, **kwargs):  # pylint: disable=unuse
     """
     user = kwargs['user']
 
-    studio_request_email = settings.FEATURES.get('STUDIO_REQUEST_EMAIL', '')
-    context = {'user_name': user.username, 'user_email': user.email}
+    context = course_creator_notification_context(user)
+    studio_request_email = context['studio_request_email']
 
     subject = render_to_string('emails/course_creator_admin_subject.txt', context)
     subject = ''.join(subject.splitlines())

--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -12,14 +12,10 @@ from django.test import TestCase
 
 from cms.djangoapps.course_creators.admin import CourseCreatorAdmin
 from cms.djangoapps.course_creators.models import CourseCreator
+from common.djangoapps.edxmako.shortcuts import render_to_string
 from common.djangoapps.student import auth
 from common.djangoapps.student.roles import CourseCreatorRole
 from common.djangoapps.student.tests.factories import UserFactory
-
-
-def mock_render_to_string(template_name, context):
-    """Return a string that encodes template_name and context"""
-    return str((template_name, context))
 
 
 class CourseCreatorAdminTest(TestCase):
@@ -55,11 +51,14 @@ class CourseCreatorAdminTest(TestCase):
             "ENABLE_CREATOR_GROUP": True,
             "STUDIO_REQUEST_EMAIL": self.studio_request_email
         }
+        self.context = {
+            'studio_request_email': self.studio_request_email,
+            'is_secure': False,
+            'site': 'localhost:8001',
+            'user_name': 'test_user',
+            'user_email': 'test_user+courses@edx.org',
+        }
 
-    @mock.patch(
-        'cms.djangoapps.course_creators.admin.render_to_string',
-        mock.Mock(side_effect=mock_render_to_string, autospec=True)
-    )
     @mock.patch('django.contrib.auth.models.User.email_user')
     def test_change_status(self, email_user):
         """
@@ -71,7 +70,6 @@ class CourseCreatorAdminTest(TestCase):
             self._change_state(state)
             self.assertEqual(is_creator, auth.user_has_role(self.user, CourseCreatorRole()))  # noqa: PT009
 
-            context = {'studio_request_email': self.studio_request_email}
             if state == CourseCreator.GRANTED:
                 template = 'emails/course_creator_granted.txt'
             elif state == CourseCreator.DENIED:
@@ -79,8 +77,8 @@ class CourseCreatorAdminTest(TestCase):
             else:
                 template = 'emails/course_creator_revoked.txt'
             email_user.assert_called_with(
-                mock_render_to_string('emails/course_creator_subject.txt', context),
-                mock_render_to_string(template, context),
+                render_to_string('emails/course_creator_subject.txt', self.context).strip(),
+                render_to_string(template, self.context),
                 self.studio_request_email
             )
 
@@ -103,10 +101,6 @@ class CourseCreatorAdminTest(TestCase):
 
             change_state_and_verify_email(CourseCreator.DENIED, False)
 
-    @mock.patch(
-        'cms.djangoapps.course_creators.admin.render_to_string',
-        mock.Mock(side_effect=mock_render_to_string, autospec=True)
-    )
     def test_mail_admin_on_pending(self):
         """
         Tests that the admin account is notified when a user is in the 'pending' state.
@@ -121,16 +115,15 @@ class CourseCreatorAdminTest(TestCase):
             # message sent. Admin message will follow.
             base_num_emails = 1 if expect_sent_to_user else 0
             if expect_sent_to_admin:
-                context = {'user_name': 'test_user', 'user_email': 'test_user+courses@edx.org'}
 
                 self.assertEqual(base_num_emails + 1, len(mail.outbox), 'Expected admin message to be sent')  # noqa: PT009  # pylint: disable=line-too-long
                 sent_mail = mail.outbox[base_num_emails]
                 self.assertEqual(  # noqa: PT009
-                    mock_render_to_string('emails/course_creator_admin_subject.txt', context),
+                    render_to_string('emails/course_creator_admin_subject.txt', self.context).strip(),
                     sent_mail.subject
                 )
                 self.assertEqual(  # noqa: PT009
-                    mock_render_to_string('emails/course_creator_admin_user_pending.txt', context),
+                    render_to_string('emails/course_creator_admin_user_pending.txt', self.context),
                     sent_mail.body
                 )
                 self.assertEqual(self.studio_request_email, sent_mail.from_email)  # noqa: PT009


### PR DESCRIPTION
## Description

This pull request fixes email notifications for studio access grants. They have possibly never worked, as the tests written for them were written in such a way that bugs in the way the templates were called were not detected.

## Supporting information

Internal ticket: https://tasks.opencraft.com/browse/BB-10700

## Testing instructions

1. Create an account on the sandbox
2. Register a user
3. Go to the studio
4. Apply for course creator access
5. Switch to the superuser
6. Go to the Admin
7. Go to Course Creators
8. Set the status to 'granted' (you may need to check the 'all organizations' checkbox
9. Get email

