### PR TITLE
feat: apply ADR 0034 (auth standardization) across 6 standardized APIs

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/xblock.py
@@ -8,6 +8,13 @@ XblockViewSet applying the FC-0118 ADRs:
   * ADR 0026 - explicit authentication_classes + permission_classes
   * ADR 0028 - consolidated into XblockViewSet via DefaultRouter
   * ADR 0029 - standardized error envelope via StandardizedErrorMixin
+  * ADR 0034 - already compliant. ``authentication_classes`` is
+    ``(JwtAuthentication, SessionAuthenticationAllowInactiveUser)`` — no
+    ``BearerAuthentication`` / ``OAuth2Authentication`` to remove. This view
+    is set explicitly (rather than relying on platform defaults) because it
+    needs ``SessionAuthenticationAllowInactiveUser`` instead of the default
+    ``SessionAuthentication`` so inactive Studio authors can still hit the
+    endpoint while their session is being verified.
   * ADR 0036 - minimal/flattened views. ``retrieve`` accepts a ``?view=minimal``
     query parameter that strips the (tree-shaped) xblock response to a small
     set of structural fields. The full xblock response is kept as the default

--- a/cms/djangoapps/contentstore/rest_api/v3/views/authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v3/views/authoring_grading.py
@@ -30,6 +30,13 @@ restructured to apply the FC-0118 ADRs from the start:
     real-world payload is always small. A hard cap is enforced upstream of
     this endpoint by :func:`CourseGradingModel.update_from_json`; we surface
     that as a documentation note rather than re-implement the bound here.
+  * ADR 0034 – auth standardization (OEP-0042).
+    ``authentication_classes`` is ``(JwtAuthentication, SessionAuthenticationAllowInactiveUser)``;
+    ``BearerAuthenticationAllowInactiveUser`` has been removed per the
+    deprecation policy. ``SessionAuthenticationAllowInactiveUser`` is
+    retained (rather than relying on the platform-default
+    ``SessionAuthentication``) so Studio authors whose accounts are
+    temporarily inactive can still update grading.
 
 Permission model note:
     PR #38363 proposed a class-level ``HasStudioReadAccess`` permission. The
@@ -63,7 +70,6 @@ from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
 from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
-from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.mixins import StandardizedErrorMixin
 
 _COURSE_KEY_PARAMETER = OpenApiParameter(
@@ -87,9 +93,12 @@ class AuthoringGradingViewSet(StandardizedErrorMixin, viewsets.ViewSet):
     Supersedes ``AuthoringGradingView`` at ``POST /api/contentstore/v0/grading/{course_id}``.
     """
 
+    # ADR 0034 — JWT + session-with-inactive-user (BearerAuthenticationAllowInactiveUser
+    # removed per OEP-0042). SessionAuthenticationAllowInactiveUser is retained
+    # (instead of relying on the platform-default SessionAuthentication) so Studio
+    # authors whose accounts are temporarily inactive can still update grading.
     authentication_classes = (
         JwtAuthentication,
-        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (IsAuthenticated,)

--- a/cms/djangoapps/contentstore/rest_api/v3/views/course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v3/views/course_details.py
@@ -12,6 +12,12 @@ restructured to apply the FC-0118 ADRs:
   * ADR 0029 – standardized error envelope via :class:`StandardizedErrorMixin`
     (v3-scoped — does not change the project-wide DRF ``EXCEPTION_HANDLER``
     setting)
+  * ADR 0034 – already compliant. ``authentication_classes`` is
+    ``(JwtAuthentication, SessionAuthenticationAllowInactiveUser)`` — no
+    ``BearerAuthentication`` / ``OAuth2Authentication`` to remove.
+    Explicit declaration kept (rather than relying on platform defaults)
+    so that ``SessionAuthenticationAllowInactiveUser`` is used instead of
+    the default ``SessionAuthentication``.
 
 Permission model note:
     PR #38365 proposed a class-level ``HasStudioReadAccess`` permission. The

--- a/cms/djangoapps/contentstore/rest_api/v3/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v3/views/home.py
@@ -18,6 +18,12 @@ to apply the FC-0118 ADRs:
     explicitly. The flat-list ``courses`` and ``libraries`` actions are
     out of scope (single-key dict around a list) and do not honour
     ``?fields=``.
+  * ADR 0034 – already compliant. ``authentication_classes`` is
+    ``(JwtAuthentication, SessionAuthenticationAllowInactiveUser)`` —
+    no ``BearerAuthentication`` / ``OAuth2Authentication`` to remove.
+    The explicit declaration is kept (rather than relying on platform
+    defaults) so that ``SessionAuthenticationAllowInactiveUser`` is used
+    instead of the default ``SessionAuthentication``.
 """
 
 import edx_api_doc_tools as apidocs

--- a/cms/djangoapps/contentstore/rest_api/v4/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v4/views/home.py
@@ -128,6 +128,11 @@ class HomeCoursesViewSet(StandardizedErrorMixin, viewsets.ViewSet):
           a dynamic-fields serializer mixin and per-field schema documentation)
           but is intentionally NOT added here to keep the v4 contract stable
           for the existing Studio frontend.
+        - 0034: already compliant. ``authentication_classes`` is
+          ``(JwtAuthentication, SessionAuthenticationAllowInactiveUser)`` — no
+          ``BearerAuthentication`` / ``OAuth2Authentication`` to remove.
+          Explicit declaration kept so ``SessionAuthenticationAllowInactiveUser``
+          is used instead of the default ``SessionAuthentication``.
     """
 
     authentication_classes = (JwtAuthentication, SessionAuthenticationAllowInactiveUser)

--- a/openedx/core/djangoapps/enrollments/v2/views.py
+++ b/openedx/core/djangoapps/enrollments/v2/views.py
@@ -6,6 +6,13 @@ to apply the FC-0118 ADRs from the start:
 
   * ADR 0025 – ``serializer_class`` on every viewset/view
   * ADR 0026 – explicit ``authentication_classes`` + ``permission_classes``
+  * ADR 0034 – auth standardization (OEP-0042). All four v2 viewsets/views use
+    ``(JwtAuthentication, EnrollmentCrossDomainSessionAuth)``;
+    ``BearerAuthenticationAllowInactiveUser`` has been removed per the
+    deprecation policy. ``EnrollmentCrossDomainSessionAuth`` is retained
+    (rather than relying on the platform-default ``SessionAuthentication``)
+    because these endpoints must accept cross-domain Studio/LMS CSRF-validated
+    session cookies.
   * ADR 0027 – ``drf_spectacular`` for OpenAPI schema generation
   * ADR 0028 – consolidated into ``ViewSet`` classes registered via
     ``DefaultRouter`` where the URL shape allows it
@@ -70,7 +77,6 @@ from openedx.core.djangoapps.enrollments.views import (
     EnrollmentUserThrottle,
 )
 from openedx.core.djangoapps.user_api.accounts.permissions import CanRetireUser
-from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.mixins import StandardizedErrorMixin
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermissionIsAuthenticated
 
@@ -209,9 +215,12 @@ class EnrollmentViewSet(StandardizedErrorMixin, viewsets.ViewSet, ApiKeyPermissi
         DELETE /api/enrollment/v2/enrollment/enrollment_allowed/  → allowed (DELETE)
     """
 
+    # ADR 0034 — JWT + cross-domain session (BearerAuthenticationAllowInactiveUser
+    # removed per OEP-0042). EnrollmentCrossDomainSessionAuth retained because the
+    # endpoint must accept cross-domain Studio/LMS CSRF-validated session cookies;
+    # the platform-default SessionAuthentication would reject those.
     authentication_classes = (
         JwtAuthentication,
-        BearerAuthenticationAllowInactiveUser,
         EnrollmentCrossDomainSessionAuth,
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
@@ -417,9 +426,12 @@ class EnrollmentViewSet(StandardizedErrorMixin, viewsets.ViewSet, ApiKeyPermissi
 class EnrollmentRetrieveView(StandardizedErrorMixin, ApiKeyPermissionMixIn, APIView):
     """GET enrollment for a course (and optionally a named user)."""
 
+    # ADR 0034 — JWT + cross-domain session (BearerAuthenticationAllowInactiveUser
+    # removed per OEP-0042). EnrollmentCrossDomainSessionAuth retained because the
+    # endpoint must accept cross-domain Studio/LMS CSRF-validated session cookies;
+    # the platform-default SessionAuthentication would reject those.
     authentication_classes = (
         JwtAuthentication,
-        BearerAuthenticationAllowInactiveUser,
         EnrollmentCrossDomainSessionAuth,
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
@@ -492,9 +504,12 @@ class EnrollmentRetrieveView(StandardizedErrorMixin, ApiKeyPermissionMixIn, APIV
 class UserRolesView(StandardizedErrorMixin, APIView):
     """List the current user's course-level roles."""
 
+    # ADR 0034 — JWT + cross-domain session (BearerAuthenticationAllowInactiveUser
+    # removed per OEP-0042). EnrollmentCrossDomainSessionAuth retained because the
+    # endpoint must accept cross-domain Studio/LMS CSRF-validated session cookies;
+    # the platform-default SessionAuthentication would reject those.
     authentication_classes = (
         JwtAuthentication,
-        BearerAuthenticationAllowInactiveUser,
         EnrollmentCrossDomainSessionAuth,
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
@@ -644,9 +659,12 @@ class CourseEnrollmentDetailView(StandardizedErrorMixin, APIView):
 class EnrollmentsAdminListView(StandardizedErrorMixin, ListAPIView):
     """Admin-only paginated enrollment list with OEP-68 filter aliases."""
 
+    # ADR 0034 — JWT + cross-domain session (BearerAuthenticationAllowInactiveUser
+    # removed per OEP-0042). EnrollmentCrossDomainSessionAuth retained because the
+    # endpoint must accept cross-domain Studio/LMS CSRF-validated session cookies;
+    # the platform-default SessionAuthentication would reject those.
     authentication_classes = (
         JwtAuthentication,
-        BearerAuthenticationAllowInactiveUser,
         EnrollmentCrossDomainSessionAuth,
     )
     permission_classes = (permissions.IsAdminUser,)


### PR DESCRIPTION
## Summary

Applies [ADR 0034 — Unify Auth (OAuth2 DOT v2)](https://github.com/openedx/edx-platform/blob/feat/axim-api_improvements/docs/decisions/0034-unify-auth-oauth2-dot-v2.rst) to the 6 APIs previously standardized under the FC-0118 effort.

ADR 0034 (per OEP-0042) deprecates \`BearerAuthentication\` / \`BearerAuthenticationAllowInactiveUser\` and their \`OAuth2Authentication*\` aliases. Target pattern is \`(JwtAuthentication, SessionAuthenticationAllowInactiveUser)\` (or the platform default \`JwtAuthentication + SessionAuthentication\`).

| Commit | Area | Related PR | Type | Bearer/OAuth2 found? |
|---|---|---|---|---|
| 1 | Xblock v1 | [#38723](https://github.com/openedx/edx-platform/pull/38723) | \`docs\` audit | no — already compliant |
| 2 | CourseHome v3 | [#38694](https://github.com/openedx/edx-platform/pull/38694) | \`docs\` audit | no — already compliant |
| 3 | CourseHome v4 | [#38684](https://github.com/openedx/edx-platform/pull/38684) | \`docs\` audit | no — already compliant |
| 4 | **Enrollment v2** | [#38724](https://github.com/openedx/edx-platform/pull/38724) | \`feat\` — Bearer removed | **yes** (4 viewsets) |
| 5 | Course Detail v3 | [#38708](https://github.com/openedx/edx-platform/pull/38708) | \`docs\` audit | no — already compliant |
| 6 | **AuthorGrading v3** | [#38726](https://github.com/openedx/edx-platform/pull/38726) | \`feat\` — Bearer removed | **yes** (1 viewset) |

## Changes

### \`feat\` — Enrollment v2 (commit 4)

\`BearerAuthenticationAllowInactiveUser\` removed from 4 viewsets/views:

| View | Before | After |
|---|---|---|
| \`EnrollmentViewSet\` | \`(Jwt, Bearer, EnrollmentCrossDomainSessionAuth)\` | \`(Jwt, EnrollmentCrossDomainSessionAuth)\` |
| \`EnrollmentRetrieveView\` | same | same |
| \`UserRolesView\` | same | same |
| \`EnrollmentsAdminListView\` | same | same |

\`EnrollmentCrossDomainSessionAuth\` is retained (rather than the platform-default \`SessionAuthentication\`) because these endpoints must accept cross-domain Studio/LMS CSRF-validated session cookies. Each viewset carries an inline comment explaining the deviation.

### \`feat\` — AuthorGrading v3 (commit 6)

\`BearerAuthenticationAllowInactiveUser\` removed from \`AuthoringGradingViewSet\`:

| Before | After |
|---|---|
| \`(Jwt, Bearer, SessionAuthenticationAllowInactiveUser)\` | \`(Jwt, SessionAuthenticationAllowInactiveUser)\` |

\`SessionAuthenticationAllowInactiveUser\` is retained so Studio authors whose accounts are temporarily inactive can still update grading.

### \`docs\` — 4 already-compliant areas (commits 1, 2, 3, 5)

Each already uses the ADR 0034 target pattern \`(JwtAuthentication, SessionAuthenticationAllowInactiveUser)\` (or with \`EnrollmentCrossDomainSessionAuth\` in enrollment-adjacent code). The docs commits add an \`ADR 0034\` line to the module docstring confirming compliance and recording *why* the explicit declaration is kept rather than relying on platform defaults.

## Behaviour

- **JWT callers** — no change.
- **Cookie / session callers** — no change.
- **Bearer-token callers** — affected. Per OEP-0042 and the [DEPR ticket](https://github.com/openedx/edx-drf-extensions/issues/284) these clients must migrate to JWT. Token expiry differs (Bearer ~2 weeks → JWT ~1 hour), so long-running jobs that reuse a token without checking expiry will need adjustment.

## Test plan

- [ ] Existing test suites still pass for all 6 endpoints (no auth-class regressions)
- [ ] \`pytest cms/djangoapps/contentstore/rest_api/v3/views/tests/test_authoring_grading.py -v\` — verify the grading viewset still authenticates JWT + session requests correctly
- [ ] \`pytest openedx/core/djangoapps/enrollments/v2/tests/ -v\` — verify the enrollment viewsets still authenticate JWT + cross-domain session requests correctly
- [ ] Smoke-check each affected endpoint with a fresh JWT — confirm 200 response
- [ ] Smoke-check each affected endpoint with an old Bearer token — confirm 401 (expected per ADR; clients must migrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)