### PR TITLE
feat: bookmarks rm user foreign key db constraint

### DIFF
--- a/openedx/core/djangoapps/bookmarks/migrations/0002_rm_db_user_foreign_key_constraint.py
+++ b/openedx/core/djangoapps/bookmarks/migrations/0002_rm_db_user_foreign_key_constraint.py
@@ -1,0 +1,21 @@
+# Remove User foreign key constraint on bookmarks table. Improves writes performance.
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('bookmarks', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='bookmark',
+            name='user',
+            field=models.ForeignKey(db_constraint=False, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/openedx/core/djangoapps/bookmarks/models.py
+++ b/openedx/core/djangoapps/bookmarks/models.py
@@ -46,7 +46,7 @@ class Bookmark(TimeStampedModel):
 
     .. no_pii:
     """
-    user = models.ForeignKey(User, db_index=True, on_delete=models.CASCADE)
+    user = models.ForeignKey(User, db_index=True, on_delete=models.CASCADE, db_constraint=False)
     course_key = CourseKeyField(max_length=255, db_index=True)
     usage_key = UsageKeyField(max_length=255, db_index=True)
     _path = JSONField(db_column='path', help_text='Path in course tree to the block')


### PR DESCRIPTION
# Description

### **Title: Refactor: Remove Database Foreign Key Constraint on User Table in Bookmarks to Optimize Write Performance**

Inspired by the courseware student module's good performance.
https://github.com/openedx/openedx-platform/blob/b1b59ddc5a7d8af31091c74d1f3b75ff38acde3e/lms/djangoapps/courseware/models.py#L95

#### **1. Context & Architecture**

The `Bookmarks` service allows students to save specific course components (e.g., videos, text blocks, or assignments) for quick reference later. Historically, the `Bookmark` model mapped directly to the central `User` table using a strict, database-enforced Foreign Key (FK) constraint. This ensured rigid referential integrity at the database layer.

#### **2. The Problem: Write Bottlenecks and Lock Contention**

In a high-traffic environment where thousands of students are interacting with the platform simultaneously, the act of creating or deleting a bookmark becomes a micro-transaction that can disproportionately impact the wider database ecosystem.

Because of the hard Foreign Key constraint, every time a new bookmark is inserted or updated, the database engine must acquire a shared lock on the parent `User` table row to verify the user exists and maintain referential integrity.

* The `User` table is a "hot" table, concurrently accessed and modified by almost every other model in the system (e.g., CourseEnrollment, Completion, tracking logs).
* Stacking these shared locks for frequent, low-priority write operations like bookmarking causes unnecessary transaction queueing.
* This lock contention drags down the performance of the `User` table globally, resulting in latency spikes and reducing overall write throughput across the platform.

#### **3. The Solution**

This PR drops the explicit database-level Foreign Key constraint linking `Bookmarks` to the `User` table (utilizing `db_constraint=False` in the model definition).

The application will continue to store the `user_id` as a conceptual relationship to track ownership of the bookmark, but the database will no longer execute strict referential integrity checks or place shared locks on the `User` table during `INSERT` or `UPDATE` operations on bookmarks.

#### **4. Impact & Benefits**

* **Optimized Write Performance:** `INSERT` operations for bookmarks are now completely decoupled from the `User` table's lock state, executing immediately without queueing.
* **Reduced Database Contention:** Eliminating shared locks on the core `User` table during bookmarking events heavily reduces transaction overhead, improving the latency and responsiveness of the platform during high-traffic spikes.
* **Better Scalability for Low-Priority Actions:** Bookmarking is a high-frequency, low-criticality action. Isolating its database impact protects core services like authentication, enrollment, and grade calculation from being slowed down by users interacting with course materials.

#### **5. Trade-offs & Considerations**

* **Application-Level Responsibility:** We are trading strict database referential integrity for speed and scale. The database will no longer automatically block user deletions if dependent bookmarks exist.
* **Orphaned Record Management:** Any cleanup of orphaned bookmarks (e.g., when a user is permanently deleted) must now be handled at the application layer or offloaded to an asynchronous background cleanup job (e.g., via Celery tasks).

## Test
run migrations

<img width="1453" height="492" alt="2026-06-11_09-08" src="https://github.com/user-attachments/assets/fce784c7-bf86-471a-978a-cd3e2ee65e24" />


Inspired also by PR https://github.com/nelc/edx-platform/pull/78

similar approach in https://github.com/openedx/completion/pull/443