### PR TITLE
fix: sync block structure cache before building navigation sidebar

### DIFF
--- a/lms/djangoapps/course_home_api/outline/views.py
+++ b/lms/djangoapps/course_home_api/outline/views.py
@@ -51,6 +51,7 @@ from lms.djangoapps.courseware.toggles import courseware_disable_navigation_side
 from lms.djangoapps.courseware.views.views import get_cert_data
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.utils import OptimizelyClient
+from openedx.core.djangoapps.content.block_structure.api import update_course_in_cache
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_404
 from openedx.core.djangoapps.content.learning_sequences.api import get_user_course_outline
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort
@@ -483,6 +484,9 @@ class CourseNavigationBlocksView(RetrieveAPIView):
             course_blocks = cache.get(cache_key)
 
         if not course_blocks:
+            # get_collected() may still serve a pre-publish block structure until Celery runs;
+            # sync the cache here so the sidebar is not built from stale data on a cache miss.
+            update_course_in_cache(course_key)
             if getattr(enrollment, 'is_active', False) or bool(staff_access):
                 course_blocks = get_course_outline_block_tree(request, course_key_string, request.user)
             elif allow_public_outline or allow_public or user_is_masquerading:


### PR DESCRIPTION
## Description

This PR fixes stale content in the Learning MFE left navigation sidebar after course publish (e.g., content group visibility changes in Studio OR updates in the block names).

On sidebar cache miss, synchronously refresh the block structure cache before building the outline tree, so the sidebar is not populated from outdated block structure data while the async Celery task is still pending.

### Problem
After publishing course changes in Studio, the Learning MFE sidebar (`GET /api/course_home/v1/navigation/{course_key}`) can show outdated blocks for up to one hour.

### Root cause
The navigation endpoint caches the intermediate outline tree for one hour, keyed in part by `course_version` (the published structure `version_guid`).

When a course is published:

1. `course_version` changes > sidebar cache miss (new cache key).
2. The view rebuilds the tree via `get_course_outline_block_tree` > `get_blocks` > `get_collected()`.
3. `get_collected()` can return stale block structure from cache because it does not re-check freshness on a cache hit.
4. Block structure is updated asynchronously by Celery (`update_course_in_cache_v2`), with a 30-second delay after course_published (`BLOCK_STRUCTURES_SETTINGS['COURSE_PUBLISH_TASK_DELAY']`).

If the sidebar is requested in that window, stale block structure is cached under the new `course_version` key for one hour, even though Celery later updates block structure correctly.

### Solution
On sidebar cache miss, call `update_course_in_cache(course_key)` synchronously before building the outline tree. This uses the existing `update_collected_if_needed()` path, which refreshes the block structure only when it is outdated.

## Supporting information

- https://github.com/openedx/wg-build-test-release/issues/600

## Testing instructions

Using Tutor local:

1. From Studio, create a course and create two content groups (**Content Group A** and **Content Group B**).
2. From the LMS, create 2 cohorts, each linked to a Content Group.
3. Assign a user to a cohort.
4. Create two or more units.
5. Modify the visibility of the one unit so that it is restricted only to **Content Group A**.
6. Modify the visibility of the other unit so that it is restricted only to **Content Group B**.
7. Make changes by modifying the visibility of the units and immediately (_before 30 seconds pass_), as a student, verify that the sidebar is correctly updated.

## Deadline

Verawood
