### PR TITLE
feat!: rm user db_constraint in CourseEnrollment

### DIFF
--- a/common/djangoapps/student/migrations/0047_coursenrollment_rm_user_foreign_db_constraint.py
+++ b/common/djangoapps/student/migrations/0047_coursenrollment_rm_user_foreign_db_constraint.py
@@ -1,0 +1,26 @@
+# rm user foreign key db constraint to avoid deadlocks when deleting users.
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('student', '0046_alter_userprofile_phone_number'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='courseenrollment',
+            name='user',
+            field=models.ForeignKey(db_constraint=False, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AlterField(
+            model_name='courseenrollmentallowed',
+            name='user',
+            field=models.ForeignKey(blank=True, db_constraint=False, help_text="First user which enrolled in the specified course through the specified e-mail. Once set, it won't change.", null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/common/djangoapps/student/migrations/0050_coursenrollment_rm_user_foreign_db_constraint.py
+++ b/common/djangoapps/student/migrations/0050_coursenrollment_rm_user_foreign_db_constraint.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('student', '0046_alter_userprofile_phone_number'),
+        ('student', '0049_manualenrollmentaudit_statetransition_typo'),
     ]
 
     operations = [

--- a/common/djangoapps/student/models/course_enrollment.py
+++ b/common/djangoapps/student/models/course_enrollment.py
@@ -307,7 +307,7 @@ class CourseEnrollment(models.Model):
     """
     MODEL_TAGS = ['course', 'is_active', 'mode']
 
-    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, db_constraint=False)
 
     course = models.ForeignKey(
         CourseOverview,
@@ -1611,6 +1611,7 @@ class CourseEnrollmentAllowed(DeletableByUserValue, models.Model):
         help_text="First user which enrolled in the specified course through the specified e-mail. "
                   "Once set, it won't change.",
         on_delete=models.CASCADE,
+        db_constraint=False,
     )
 
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)


### PR DESCRIPTION



### **Title: Refactor: Remove Database Foreign Key Constraint on User Table in CourseEnrollment**

Inspired by the courseware student module's good performance.
https://github.com/openedx/openedx-platform/blob/b1b59ddc5a7d8af31091c74d1f3b75ff38acde3e/lms/djangoapps/courseware/models.py#L95

#### **1. Context & Architecture**

The `CourseEnrollment` model is a critical piece of the application's core logic, tracking the many-to-many relationship between users and the courses they are enrolled in. Historically, the database schema linked the `CourseEnrollment` to the central `User` table using a strict database-level Foreign Key (FK) constraint to enforce referential integrity.

#### **2. The Problem: High-Traffic Lock Contention on the User Table**

In scenarios involving mass enrollments or high concurrency (e.g., thousands of students joining a course simultaneously at the start of a semester), the strict database-level Foreign Key constraint introduces a major performance bottleneck.

Whenever an application inserts or updates a `CourseEnrollment` row, the relational database engine (e.g., MySQL or PostgreSQL) acquires a shared read lock on the corresponding row in the parent `User` table to guarantee that the referenced user exists. Because the `User` table is centrally accessed and locked by numerous other services and domains simultaneously, this causes contention.

The resulting lock queues drastically slow down all database transactions touching the `User` table, causing latency spikes, connection pool exhaustion, and potentially triggering application-wide timeouts and deadlocks during periods of heavy traffic.

#### **3. The Solution**

This PR removes the database-level enforcement of the foreign key constraint on the `User` table within the `CourseEnrollment` model (e.g., by utilizing `db_constraint=False` in the Django model field).

To ensure data integrity is maintained at the application level, a safety check has been established within the model layer:

* **Application-Level Enforcement:** We ensure `get_or_create_enrollment` is strictly interacting with a valid `User` object (rather than raw integer IDs).
* **Pre-save User Persistence Check:** If an unpersisted `User` object is passed (i.e., one lacking an `.id`), the application explicitly forces a `user.save()` before attempting to log the enrollment. This guarantees we have a real identifier mapped in the `CourseEnrollment` table, thus avoiding a potential `IntegrityError` due to a null `user_id`.

#### **4. Impact & Benefits**

* **Significantly Boosted Write Throughput:** Decoupling the writes in `CourseEnrollment` from locks on the `User` table allows enrollment inserts/updates to execute concurrently and independently without queuing behind lock states.
* **Reduction of Database Contention:** Eliminating the shared locks mitigates transaction latency across all services that frequently update or query the core `User` table.
* **Enhanced System Scalability:** The database can gracefully process high-volume, concurrent mass-enrollment events without degrading the core user-access performance.

#### **5. Trade-offs & Considerations**

* **Application-Enforced Integrity:** We are trading absolute database-level referential integrity for high availability and write performance. While the database will no longer inherently block deleting a user if child enrollments exist, our application controls handle data validations upstream.
* **Orphaned Records:** As the database does not enforce cascading rules or restrict deletes automatically anymore for this relationship, logic handling user deletion must safely account for cleaning up or archiving orphaned `CourseEnrollment` records either inline or via asynchronous background jobs.

## Consideration

The model get_or_create receives an user object. So is controlled that user is used to create a course_enrollment without using a random int.

https://github.com/openedx/openedx-platform/blob/a022b690a6b779d82592b6b1844d970d4fbec39b/common/djangoapps/student/models/course_enrollment.py#L375-L407
## Test
Run migrations 

<img width="1332" height="728" alt="image" src="https://github.com/user-attachments/assets/c0abba22-3f98-4b24-b439-fc8f67b6f6e5" />


Inspired also by PR https://github.com/nelc/edx-platform/pull/78

similar approach in https://github.com/openedx/completion/pull/443