### PR TITLE
fix: allow periods in block_ids

### DIFF
--- a/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
+++ b/cms/djangoapps/modulestore_migrator/tests/test_tasks.py
@@ -352,7 +352,10 @@ class TestMigrateFromModulestore(ModuleStoreTestCase):
         """
         Test _migrate_component successfully creates a new component
         """
-        source_key = self.course.id.make_usage_key("problem", "test_problem")
+        source_key = self.course.id.make_usage_key(
+            "problem",
+            "Test.Problem-With_Acceptable_Chars"  # ".", "-", and "_" are all legal.
+        )
         olx = '<problem display_name="Test Problem"><multiplechoiceresponse></multiplechoiceresponse></problem>'
         context = self._make_migration_context()
         result, reason = _migrate_component(

--- a/openedx/core/djangoapps/content_libraries/api/blocks.py
+++ b/openedx/core/djangoapps/content_libraries/api/blocks.py
@@ -14,7 +14,7 @@ from uuid import UUID, uuid4
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.core.validators import validate_unicode_slug
+from django.core.validators import RegexValidator
 from django.db import transaction
 from django.db.models import F, QuerySet
 from django.urls import reverse
@@ -99,6 +99,14 @@ __all__ = [
     "get_library_component_publish_history_entries",
     "get_library_component_creation_entry",
 ]
+
+
+validate_block_id = RegexValidator(
+    r"^[\w.-]+\Z",
+    _(
+        "Block ID slugs can only have letters, numbers, underscores, hyphens, and periods."
+    )
+)
 
 
 def get_library_components(
@@ -523,7 +531,8 @@ def validate_can_add_block_to_library(
         )
 
     # Make sure the proposed ID will be valid:
-    validate_unicode_slug(block_id)
+    validate_block_id(block_id)
+
     # Ensure the XBlock type is valid and installed:
     block_class = XBlock.load_class(block_type)  # Will raise an exception if invalid
     if block_class.has_children:


### PR DESCRIPTION
Course -> Library import would previously fail if the block_id contained
a period, but periods are legal in UsageKeys and can turn up, e.g.
"good-vs.-evil" should be allowed. This is not *common* because most
courses are edited in Studio and don't get descriptive block_ids. But
OLX-edited courses can end up with block_ids like this.
