### PR TITLE
feat: bridge FEATURES proxy reads to @override_settings overrides

### DIFF
--- a/openedx/core/lib/features_setting_proxy.py
+++ b/openedx/core/lib/features_setting_proxy.py
@@ -24,8 +24,37 @@ class FeaturesProxy(MutableMapping):
         """Store the namespace (as a dict)"""
         self.ns = namespace or {}
 
+    _NOT_OVERRIDDEN = object()
+
+    def _resolve(self, key):
+        """Return key's value if it's been overridden via @override_settings, else self._NOT_OVERRIDDEN.
+
+        We deliberately walk only the UserSettingsHolder chain (the layers that
+        @override_settings pushes onto django.conf.settings._wrapped) rather
+        than reading django.conf.settings.X directly. Django's bottom Settings
+        layer is a *snapshot* taken at init time, so it doesn't reflect runtime
+        mutations of the settings module's globals (which is what
+        proxy.ns mutations and legacy patch.dict(settings.FEATURES, ...) do).
+        Walking only the explicit override layers lets the new
+        @override_settings(X=Y) path work while leaving the legacy patch.dict
+        path untouched.
+        """
+        from django.conf import settings as django_settings
+        wrapped = django_settings._wrapped  # pylint: disable=protected-access
+        # UserSettingsHolder has a `default_settings` attribute and stores
+        # explicit overrides in its own __dict__; the bottom Settings has no
+        # default_settings, so the loop terminates there.
+        while hasattr(wrapped, 'default_settings'):
+            if key in wrapped.__dict__:
+                return wrapped.__dict__[key]
+            wrapped = wrapped.default_settings
+        return self._NOT_OVERRIDDEN
+
     def __getitem__(self, key):
-        """Retrieve a feature flag by key"""
+        """Retrieve a feature flag by key, preferring @override_settings overrides."""
+        value = self._resolve(key)
+        if value is not self._NOT_OVERRIDDEN:
+            return value
         return self.ns[key]
 
     def __setitem__(self, key, value):
@@ -49,14 +78,17 @@ class FeaturesProxy(MutableMapping):
         return len(self.ns)
 
     def __contains__(self, key):
-        return key in self.ns
+        return self._resolve(key) is not self._NOT_OVERRIDDEN or key in self.ns
 
     def clear(self):
         """Remove all feature flags from the namespace."""
         self.ns.clear()
 
     def get(self, key, default=None):
-        """Standard dict-style get with default"""
+        """Standard dict-style get with default; prefers @override_settings overrides."""
+        value = self._resolve(key)
+        if value is not self._NOT_OVERRIDDEN:
+            return value
         return self.ns.get(key, default)
 
     def update(self, other=(), /, **kwds):


### PR DESCRIPTION
First PR in a 3-PR stack that migrates callers off of `settings.FEATURES['X']` access. Follow-on to #38771.

This PR adds a single bridge to `FeaturesProxy` so that `settings.FEATURES.get('X')` walks the `UserSettingsHolder` chain — i.e. an `@override_settings(X=...)` decorator on the new flat setting is visible to legacy callers that still read the FEATURES dict. This lets us migrate call sites incrementally (#38772) without breaking unmigrated tests.

Stack:
- (this PR) bridge → master
- #38772 — per-flag migrations → bridge
- #38819 — temp diagnostic (lists flags still to migrate) → migrations