### PR TITLE
[Backport] feat: add ora reminder notification

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -274,6 +274,25 @@ _COURSE_NOTIFICATION_TYPES = {
 
         'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE],
     },
+    'ora_reminder': {
+        'notification_app': 'grading',
+        'name': 'ora_reminder',
+
+        'info': 'Reminder notifications for learners who have pending self or peer review steps in an ORA.',
+        'web': True,
+        'email': True,
+        'push': False,
+        'email_cadence': EmailCadence.DAILY,
+        'non_editable': ['push'],
+        'content_template': _('<{p}>You have <{strong}>{pending_step}</{strong}> to complete for assessment '
+                              '<{strong}>{ora_name}</{strong}></{p}>'),
+        'content_context': {
+            'ora_name': 'Name of ORA in course',
+            'pending_step': 'Pending step description (e.g. "self review" or "peer reviews")',
+        },
+
+        'filters': [FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE],
+    },
     'new_instructor_all_learners_post': {
         'notification_app': 'discussion',
         'name': 'new_instructor_all_learners_post',

--- a/openedx/core/djangoapps/notifications/email/notification_icons.py
+++ b/openedx/core/djangoapps/notifications/email/notification_icons.py
@@ -36,6 +36,7 @@ class NotificationTypeIcons:
             "course_updates": cls.NEWSPAPER,
             "ora_staff_notifications": cls.OPEN_RESPONSE_OUTLINE,
             "ora_grade_assigned": cls.OPEN_RESPONSE_OUTLINE,
+            "ora_reminder": cls.OPEN_RESPONSE_OUTLINE,
         }
         return notification_type_dict.get(notification_type, default)
 

--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -643,11 +643,20 @@ class TestNotificationPreferencesViewV3(ModuleStoreTestCase):
                             "push": False,
                             "email_cadence": "Daily",
                             "info": ""
+                        },
+                        "ora_reminder": {
+                            "web": True,
+                            "email": True,
+                            "push": False,
+                            "email_cadence": "Daily",
+                            "info": "Reminder notifications for learners who have pending self or peer "
+                                    "review steps in an ORA."
                         }
 
                     },
                     "non_editable": {
                         "ora_grade_assigned": ["push"],
+                        "ora_reminder": ["push"],
                         "ora_staff_notifications": ["push"]
                     }
                 },
@@ -801,10 +810,19 @@ class TestNotificationPreferencesViewV3(ModuleStoreTestCase):
                             "email_cadence": "Daily",
                             "info": ""
                         },
+                        "ora_reminder": {
+                            "web": False,
+                            "email": False,
+                            "push": False,
+                            "email_cadence": "Daily",
+                            "info": "Reminder notifications for learners who have pending self or peer "
+                                    "review steps in an ORA."
+                        },
 
                     },
                     "non_editable": {
-                        "ora_grade_assigned": ["push"]
+                        "ora_grade_assigned": ["push"],
+                        "ora_reminder": ["push"]
                     }
                 },
             }

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -871,7 +871,7 @@ openedx-forum==0.4.2
     # via -r requirements/edx/kernel.in
 optimizely-sdk==5.4.0
     # via -r requirements/edx/bundled.in
-ora2==7.0.0
+ora2==7.1.0
     # via -r requirements/edx/bundled.in
 packaging==26.2
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1428,7 +1428,7 @@ optimizely-sdk==5.4.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2==7.0.0
+ora2==7.1.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1051,7 +1051,7 @@ openedx-forum==0.4.2
     # via -r requirements/edx/base.txt
 optimizely-sdk==5.4.0
     # via -r requirements/edx/base.txt
-ora2==7.0.0
+ora2==7.1.0
     # via -r requirements/edx/base.txt
 packaging==26.2
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1091,7 +1091,7 @@ openedx-forum==0.4.2
     # via -r requirements/edx/base.txt
 optimizely-sdk==5.4.0
     # via -r requirements/edx/base.txt
-ora2==7.0.0
+ora2==7.1.0
     # via -r requirements/edx/base.txt
 packaging==26.2
     # via


### PR DESCRIPTION
## Backport

Backport of #38298 (commit 6ec5d41e83d718599fb939da36c130089105eeb0) to `release/verawood`.

Cherry-picked cleanly with no conflicts.

## Description

Introduces a new notification type `ora_reminder` for Open Response Assessment (ORA) reminders, ensuring learners are notified about pending self or peer review steps.

- Added a new notification type `ora_reminder` to the `NotificationType` dictionary (grading app), with web and email channels enabled, daily email cadence, and a content template for pending ORA steps.
- Mapped the `ora_reminder` notification type to its icon in the notification icon mapping.
- Updated `test_views.py` test data for notification settings and non-editable preferences.
- Bumped `ora2` from `7.0.0` to `7.1.0` (the version that ships the ORA reminder sweeper).

> Depends on edx-ora2 ≥ 7.1.0 (openedx/edx-ora2#2389).

## Original PR

https://github.com/openedx/edx-platform/pull/38298