### PR TITLE
fix: re-indexing courses fails if course is a tombstone

### DIFF
--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -557,6 +557,10 @@ def index_course(
 
     # Pre-fetch the course with all of its children:
     course = store.get_course(course_key, depth=None)
+    if not course:
+        # Might happen if the entry is a deleted course.
+        log.error("Course not found with key: %s", course_key)
+        return docs
 
     if course is None:
         status_cb(f"Error: course {course_key} does not seem to exist! It may have been incompletely deleted.")

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -12,7 +12,7 @@ import pytest
 from django.test import override_settings
 from freezegun import freeze_time
 from meilisearch.errors import MeilisearchApiError
-from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import LibraryCollectionLocator, LibraryContainerLocator
 from openedx_content import api as content_api
 from openedx_content import models_api as content_models
@@ -1436,3 +1436,10 @@ class TestSearchApi(ModuleStoreTestCase):
                 "attributesToRetrieve": ["usage_key", "display_name"],
             }
         )
+
+        @override_settings(MEILISEARCH_ENABLED=True)
+        @patch('openeedx.core.djangoapps.content.search.api.log')
+        def test_graceful_handling_of_missing_course(self, mock_log, _mock_meilisearch) -> None:
+            key = CourseKey.from_string('course-v1:Bogus+CourseX+BogoCourse')
+            assert api.index_course(key) == []
+            mock_log.error.assert_called_with("Course not found with key: %s", key)


### PR DESCRIPTION
## Description

This PR prevents indexing from failing if a course, not fully removed, is requested for indexing. In this case, instead of completely aborting the indexing process, an error should be logged and indexing should continue.

## Supporting information

Internal ticket: https://tasks.opencraft.com/browse/BB-10999

## Testing instructions

TBD