### PR TITLE
 chore: migrate Dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,3 +65,7 @@ cms/envs/production.py                                               @feanil @kd
 
 # Ensure that this file is only used when strictly necessary
 requirements/edx/github.in                                           @feanil @kdmccormick
+
+# Review GitHub Actions workflow changes (incl. Dependabot PRs).
+# Replaces the deprecated `reviewers:` key in dependabot.yml.
+/.github/workflows/                                                  @openedx/wg-maintenance-edx-platform

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,7 @@
 version: 2
 updates:
-    # Adding new check for github-actions
+  # Keep GitHub Actions up to date
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-        interval: "weekly"
-    reviewers:
-      - "openedx/wg-maintenance-edx-platform"
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Keep GitHub Actions up to date
+  # Adding new check for github-actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
GitHub retired the `reviewers` key in dependabot.yml (deprecated 2025-05-27, removed 2025-08) in favor of CODEOWNERS. The key is now ignored, so the wg-maintenance-edx-platform team is no longer auto-requested on Dependabot PRs.

- Remove the dead `reviewers` key and tidy indentation in dependabot.yml
- Add a /.github/workflows/ entry in CODEOWNERS so the maintenance team continues to review GitHub Actions changes (incl. Dependabot bumps)

Ref: https://github.com/dependabot/codeowner-migration-action