### PR TITLE
fix: Cannot rerun courses - authz role assignment expects rerun to already exist

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -56,6 +56,7 @@ from cms.djangoapps.contentstore.storage import course_import_export_storage
 from cms.djangoapps.contentstore.toggles import enable_course_optimizer_check_prev_run_links
 from cms.djangoapps.contentstore.utils import (
     IMPORTABLE_FILE_TYPES,
+    add_instructor,
     contains_course_reference,
     create_course_info_usage_key,
     create_or_update_xblock_upstream_link,
@@ -188,7 +189,9 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
         update_unit_discussion_state_from_discussion_blocks(destination_course_key, user_id)
 
         # set initial permissions for the user to access the course.
-        initialize_permissions(destination_course_key, User.objects.get(id=user_id))
+        user = User.objects.get(id=user_id)
+        add_instructor(destination_course_key, user, user)
+        initialize_permissions(destination_course_key, user)
 
         # update state: Succeeded
         CourseRerunState.objects.succeeded(course_key=destination_course_key)

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -189,6 +189,11 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
         update_unit_discussion_state_from_discussion_blocks(destination_course_key, user_id)
 
         # set initial permissions for the user to access the course.
+        # NOTE: add_instructor is called here (after clone_course) because when
+        # authz.enable_course_authoring is enabled, it cannot be called pre-task
+        # (CourseOverview doesn't exist yet). This is a temporary workaround until
+        # openedx/openedx-authz#352 is implemented. Once resolved, add_instructor
+        # can move back to the pre-task call site unconditionally.
         user = User.objects.get(id=user_id)
         add_instructor(destination_course_key, user, user)
         initialize_permissions(destination_course_key, user)

--- a/cms/djangoapps/contentstore/tests/test_clone_course.py
+++ b/cms/djangoapps/contentstore/tests/test_clone_course.py
@@ -141,3 +141,48 @@ class CloneCourseTest(CourseTestCase):
                 course_key=split_course4_id,
                 state=CourseRerunUIStateManager.State.FAILED
             )
+
+
+    def test_rerun_course_grants_instructor_access(self):
+        """
+        Test that the rerun_course task grants instructor and staff access
+        to the user after cloning. This verifies add_instructor is called
+        inside the task (needed when authz.enable_course_authoring is enabled
+        and add_instructor cannot be called pre-task).
+        """
+        org = 'edX'
+        course_number = 'CS101'
+        course_run = '2025_Q1'
+        display_name = 'rerun_instructor_test'
+        fields = {'display_name': display_name}
+
+        # Create a source course
+        source_course = CourseFactory.create(
+            org=org,
+            number=course_number,
+            run=course_run,
+            display_name=display_name,
+            default_store=ModuleStoreEnum.Type.split,
+        )
+
+        dest_course_id = CourseLocator(org=org, course=course_number, run="instructor_rerun")
+        CourseRerunState.objects.initiated(
+            source_course.id, dest_course_id, self.user, fields['display_name']
+        )
+
+        result = rerun_course.delay(
+            str(source_course.id),
+            str(dest_course_id),
+            self.user.id,
+            json.dumps(fields, cls=EdxJSONEncoder),
+        )
+        self.assertEqual(result.get(), "succeeded")  # noqa: PT009
+
+        # Verify the user has instructor and staff access on the new course
+        self.assertTrue(  # noqa: PT009
+            has_course_author_access(self.user, dest_course_id),
+            "User should have author access after rerun task completes",
+        )
+        from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
+        self.assertTrue(CourseInstructorRole(dest_course_id).has_user(self.user))  # noqa: PT009
+        self.assertTrue(CourseStaffRole(dest_course_id).has_user(self.user))  # noqa: PT009

--- a/cms/djangoapps/contentstore/tests/test_clone_course.py
+++ b/cms/djangoapps/contentstore/tests/test_clone_course.py
@@ -150,6 +150,11 @@ class CloneCourseTest(CourseTestCase):
         to the user after cloning. This verifies add_instructor is called
         inside the task (needed when authz.enable_course_authoring is enabled
         and add_instructor cannot be called pre-task).
+
+        TODO: This test covers a temporary workaround until openedx/openedx-authz#352
+        is implemented. Once authz supports pre-assigning roles without a CourseOverview,
+        add_instructor can move back to the pre-task call site and this test can be
+        simplified.
         """
         org = 'edX'
         course_number = 'CS101'
@@ -177,12 +182,9 @@ class CloneCourseTest(CourseTestCase):
             self.user.id,
             json.dumps(fields, cls=EdxJSONEncoder),
         )
-        self.assertEqual(result.get(), "succeeded")  # noqa: PT009
+        assert result.get() == "succeeded"
 
         # Verify the user has instructor and staff access on the new course
-        self.assertTrue(  # noqa: PT009
-            has_course_author_access(self.user, dest_course_id),
-            "User should have author access after rerun task completes",
-        )
-        self.assertTrue(CourseInstructorRole(dest_course_id).has_user(self.user))  # noqa: PT009
-        self.assertTrue(CourseStaffRole(dest_course_id).has_user(self.user))  # noqa: PT009
+        assert has_course_author_access(self.user, dest_course_id)
+        assert CourseInstructorRole(dest_course_id).has_user(self.user)
+        assert CourseStaffRole(dest_course_id).has_user(self.user)

--- a/cms/djangoapps/contentstore/tests/test_clone_course.py
+++ b/cms/djangoapps/contentstore/tests/test_clone_course.py
@@ -14,6 +14,7 @@ from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from common.djangoapps.course_action_state.managers import CourseRerunUIStateManager
 from common.djangoapps.course_action_state.models import CourseRerunState
 from common.djangoapps.student.auth import has_course_author_access
+from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from xmodule.contentstore.content import StaticContent  # pylint: disable=wrong-import-order
 from xmodule.contentstore.django import contentstore  # pylint: disable=wrong-import-order
 from xmodule.modulestore import EdxJSONEncoder, ModuleStoreEnum  # pylint: disable=wrong-import-order
@@ -183,6 +184,5 @@ class CloneCourseTest(CourseTestCase):
             has_course_author_access(self.user, dest_course_id),
             "User should have author access after rerun task completes",
         )
-        from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
         self.assertTrue(CourseInstructorRole(dest_course_id).has_user(self.user))  # noqa: PT009
         self.assertTrue(CourseStaffRole(dest_course_id).has_user(self.user))  # noqa: PT009

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -491,3 +491,244 @@ class TestCourseHandlerAuthz(
         })
 
         assert response.status_code == 403
+
+
+class TestCourseRerunAuthz(
+    CourseAuthoringAuthzTestMixin,
+    ModuleStoreTestCase,
+):
+    """
+    Tests for course rerun behavior when authz.enable_course_authoring is enabled.
+
+    Verifies that:
+    - Rerun succeeds without calling add_instructor pre-task (which would fail
+      because CourseOverview doesn't exist yet).
+    - add_instructor is called in the task after clone_course, when CourseOverview
+      can be resolved.
+    - The initiating user can see in-process rerun status via created_user check.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.url = reverse("course_handler")
+
+        # Create a source course
+        self.source_course = CourseFactory.create(
+            org='testorg',
+            number='101',
+            run='2025_Spring',
+            display_name='Source Course',
+        )
+        self.source_course_key = self.source_course.id
+
+        # Give the staff user instructor/staff access to the source course
+        for role in [CourseInstructorRole, CourseStaffRole]:
+            role(self.source_course_key).add_users(self.staff_user)
+
+        self.staff_client = AjaxEnabledTestClient()
+        self.staff_client.login(
+            username=self.staff_user.username,
+            password=self.password,
+        )
+
+    def test_rerun_succeeds_with_authz_enabled(self):
+        """
+        Test that course rerun completes successfully when authz.enable_course_authoring
+        is enabled. Previously this would fail with CourseOverview.DoesNotExist because
+        add_instructor was called before the course was cloned.
+        """
+        response = self.staff_client.ajax_post(self.url, {
+            'source_course_key': str(self.source_course_key),
+            'org': self.source_course_key.org,
+            'course': self.source_course_key.course,
+            'run': 'rerun_authz',
+            'display_name': 'Rerun with AuthZ',
+        })
+
+        assert response.status_code == 200
+        data = parse_json(response)
+        dest_course_key = CourseKey.from_string(data['destination_course_key'])
+
+        # Verify the rerun completed (task runs eagerly in tests)
+        dest_course = self.store.get_course(dest_course_key)
+        assert dest_course is not None
+        assert dest_course.display_name == 'Rerun with AuthZ'
+
+    def test_rerun_does_not_create_legacy_roles_with_authz_enabled(self):
+        """
+        Test that when authz.enable_course_authoring is enabled, the rerun does not
+        create legacy CourseAccessRole records pre-task. Legacy roles should not exist
+        when authz is enabled to avoid database inconsistencies.
+        """
+        from common.djangoapps.student.models import CourseAccessRole
+
+        response = self.staff_client.ajax_post(self.url, {
+            'source_course_key': str(self.source_course_key),
+            'org': self.source_course_key.org,
+            'course': self.source_course_key.course,
+            'run': 'rerun_no_legacy',
+            'display_name': 'Rerun No Legacy Roles',
+        })
+
+        assert response.status_code == 200
+        data = parse_json(response)
+        dest_course_key = CourseKey.from_string(data['destination_course_key'])
+
+        # Verify no legacy CourseAccessRole records were created for the destination course.
+        # When authz is enabled, permissions are managed entirely through the authz layer.
+        legacy_roles = CourseAccessRole.objects.filter(
+            user=self.staff_user,
+            course_id=dest_course_key,
+        )
+        assert not legacy_roles.exists()
+
+    def test_rerun_grants_authz_permissions_after_clone(self):
+        """
+        Test that after a successful rerun with authz enabled, the user has proper
+        permissions via the authz layer (add_instructor is called in the task after
+        clone_course completes and CourseOverview is available).
+        """
+        response = self.staff_client.ajax_post(self.url, {
+            'source_course_key': str(self.source_course_key),
+            'org': self.source_course_key.org,
+            'course': self.source_course_key.course,
+            'run': 'rerun_perms',
+            'display_name': 'Rerun Permissions Test',
+        })
+
+        assert response.status_code == 200
+        data = parse_json(response)
+        dest_course_key = CourseKey.from_string(data['destination_course_key'])
+
+        # Verify the user has author access to the new course via the role system
+        from common.djangoapps.student.auth import has_course_author_access
+        assert has_course_author_access(self.staff_user, dest_course_key)
+
+    def test_in_process_rerun_visible_to_initiating_user(self):
+        """
+        Test that the user who initiated the rerun can see the in-process status
+        via the created_user check in get_in_process_course_actions, even when
+        authz permissions haven't been fully established yet.
+        """
+        from cms.djangoapps.contentstore.views.course import get_in_process_course_actions
+
+        # Create a CourseRerunState in non-succeeded state to simulate an in-progress rerun
+        from common.djangoapps.course_action_state.models import CourseRerunState
+        from opaque_keys.edx.locator import CourseLocator
+
+        dest_course_key = CourseLocator(org='testorg', course='101', run='in_progress_rerun')
+        CourseRerunState.objects.initiated(
+            self.source_course_key, dest_course_key, self.staff_user, 'In Progress Rerun'
+        )
+
+        # Build a request for the staff user who initiated the rerun
+        request = RequestFactory().get('/')
+        request.user = self.staff_user
+
+        # The user should see the in-process action even without explicit course permissions
+        in_process_actions = get_in_process_course_actions(request)
+        action_course_keys = [action.course_key for action in in_process_actions]
+        assert dest_course_key in action_course_keys
+
+    def test_in_process_rerun_not_visible_to_other_users(self):
+        """
+        Test that a user who did NOT initiate the rerun cannot see the in-process
+        status (unless they have course permissions).
+        """
+        from cms.djangoapps.contentstore.views.course import get_in_process_course_actions
+        from common.djangoapps.course_action_state.models import CourseRerunState
+        from opaque_keys.edx.locator import CourseLocator
+
+        dest_course_key = CourseLocator(org='testorg', course='101', run='other_user_rerun')
+        CourseRerunState.objects.initiated(
+            self.source_course_key, dest_course_key, self.staff_user, 'Other User Rerun'
+        )
+
+        # Build a request for a different user who did not initiate the rerun
+        request = RequestFactory().get('/')
+        request.user = self.unauthorized_user
+
+        # The other user should NOT see the in-process action
+        in_process_actions = get_in_process_course_actions(request)
+        action_course_keys = [action.course_key for action in in_process_actions]
+        assert dest_course_key not in action_course_keys
+
+
+class TestCourseRerunLegacy(ModuleStoreTestCase):
+    """
+    Tests for course rerun behavior when authz.enable_course_authoring is DISABLED
+    (legacy mode). Verifies the original behavior is preserved.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.url = reverse("course_handler")
+        self.user = UserFactory()
+        self.client = AjaxEnabledTestClient()
+        self.client.login(username=self.user.username, password=self.TEST_PASSWORD)
+
+        # Create a source course and give user access
+        self.source_course = CourseFactory.create(
+            org='legacyorg',
+            number='201',
+            run='2025_Fall',
+            display_name='Legacy Source Course',
+        )
+        self.source_course_key = self.source_course.id
+
+        for role in [CourseInstructorRole, CourseStaffRole]:
+            role(self.source_course_key).add_users(self.user)
+
+    def test_rerun_creates_legacy_roles_pre_task(self):
+        """
+        Test that when authz is disabled (legacy mode), add_instructor is called
+        pre-task and creates CourseAccessRole records immediately.
+        """
+        from common.djangoapps.student.models import CourseAccessRole
+
+        response = self.client.ajax_post(self.url, {
+            'source_course_key': str(self.source_course_key),
+            'org': self.source_course_key.org,
+            'course': self.source_course_key.course,
+            'run': 'legacy_rerun',
+            'display_name': 'Legacy Rerun',
+        })
+
+        assert response.status_code == 200
+        data = parse_json(response)
+        dest_course_key = CourseKey.from_string(data['destination_course_key'])
+
+        # Verify legacy CourseAccessRole records exist for the destination course
+        legacy_roles = CourseAccessRole.objects.filter(
+            user=self.user,
+            course_id=dest_course_key,
+        )
+        assert legacy_roles.filter(role='instructor').exists()
+        assert legacy_roles.filter(role='staff').exists()
+
+    def test_rerun_succeeds_with_authz_disabled(self):
+        """
+        Test that course rerun still works correctly when authz is disabled.
+        """
+        response = self.client.ajax_post(self.url, {
+            'source_course_key': str(self.source_course_key),
+            'org': self.source_course_key.org,
+            'course': self.source_course_key.course,
+            'run': 'legacy_rerun_success',
+            'display_name': 'Legacy Rerun Success',
+        })
+
+        assert response.status_code == 200
+        data = parse_json(response)
+        dest_course_key = CourseKey.from_string(data['destination_course_key'])
+
+        # Verify the course was created
+        dest_course = self.store.get_course(dest_course_key)
+        assert dest_course is not None
+        assert dest_course.display_name == 'Legacy Rerun Success'
+
+        # Verify author access
+        from common.djangoapps.student.auth import has_course_author_access
+        assert has_course_author_access(self.user, dest_course_key)

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -513,6 +513,12 @@ class TestCourseRerunAuthz(
     - add_instructor is called in the task after clone_course, when CourseOverview
       can be resolved.
     - The initiating user can see in-process rerun status via created_user check.
+
+    TODO: These tests cover a temporary workaround needed while (1) the authz system
+    doesn't support pre-assigning roles without a CourseOverview, and (2) we support
+    both authz and legacy systems simultaneously. Once openedx/openedx-authz#352 is
+    implemented, this class can be simplified — the conditional skip of add_instructor
+    and the created_user visibility fallback will no longer be needed.
     """
 
     def setUp(self):

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -14,16 +14,23 @@ from django.test import override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.locator import CourseLocator
 from openedx_authz.constants.roles import COURSE_EDITOR
 from organizations.api import add_organization, get_course_organizations, get_organization_by_short_name
 from organizations.exceptions import InvalidOrganizationException
 from organizations.models import Organization
 
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, parse_json
-from cms.djangoapps.contentstore.views.course import get_allowed_organizations, user_can_create_organizations
+from cms.djangoapps.contentstore.views.course import (
+    get_allowed_organizations,
+    get_in_process_course_actions,
+    user_can_create_organizations,
+)
 from cms.djangoapps.course_creators.admin import CourseCreatorAdmin
 from cms.djangoapps.course_creators.models import CourseCreator
-from common.djangoapps.student.auth import update_org_role
+from common.djangoapps.course_action_state.models import CourseRerunState
+from common.djangoapps.student.auth import has_course_author_access, update_org_role
+from common.djangoapps.student.models import CourseAccessRole
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, OrgContentCreatorRole
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
 from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
@@ -561,8 +568,6 @@ class TestCourseRerunAuthz(
         create legacy CourseAccessRole records pre-task. Legacy roles should not exist
         when authz is enabled to avoid database inconsistencies.
         """
-        from common.djangoapps.student.models import CourseAccessRole
-
         response = self.staff_client.ajax_post(self.url, {
             'source_course_key': str(self.source_course_key),
             'org': self.source_course_key.org,
@@ -602,7 +607,6 @@ class TestCourseRerunAuthz(
         dest_course_key = CourseKey.from_string(data['destination_course_key'])
 
         # Verify the user has author access to the new course via the role system
-        from common.djangoapps.student.auth import has_course_author_access
         assert has_course_author_access(self.staff_user, dest_course_key)
 
     def test_in_process_rerun_visible_to_initiating_user(self):
@@ -611,12 +615,6 @@ class TestCourseRerunAuthz(
         via the created_user check in get_in_process_course_actions, even when
         authz permissions haven't been fully established yet.
         """
-        from cms.djangoapps.contentstore.views.course import get_in_process_course_actions
-
-        # Create a CourseRerunState in non-succeeded state to simulate an in-progress rerun
-        from common.djangoapps.course_action_state.models import CourseRerunState
-        from opaque_keys.edx.locator import CourseLocator
-
         dest_course_key = CourseLocator(org='testorg', course='101', run='in_progress_rerun')
         CourseRerunState.objects.initiated(
             self.source_course_key, dest_course_key, self.staff_user, 'In Progress Rerun'
@@ -636,10 +634,6 @@ class TestCourseRerunAuthz(
         Test that a user who did NOT initiate the rerun cannot see the in-process
         status (unless they have course permissions).
         """
-        from cms.djangoapps.contentstore.views.course import get_in_process_course_actions
-        from common.djangoapps.course_action_state.models import CourseRerunState
-        from opaque_keys.edx.locator import CourseLocator
-
         dest_course_key = CourseLocator(org='testorg', course='101', run='other_user_rerun')
         CourseRerunState.objects.initiated(
             self.source_course_key, dest_course_key, self.staff_user, 'Other User Rerun'
@@ -686,8 +680,6 @@ class TestCourseRerunLegacy(ModuleStoreTestCase):
         Test that when authz is disabled (legacy mode), add_instructor is called
         pre-task and creates CourseAccessRole records immediately.
         """
-        from common.djangoapps.student.models import CourseAccessRole
-
         response = self.client.ajax_post(self.url, {
             'source_course_key': str(self.source_course_key),
             'org': self.source_course_key.org,
@@ -730,5 +722,4 @@ class TestCourseRerunLegacy(ModuleStoreTestCase):
         assert dest_course.display_name == 'Legacy Rerun Success'
 
         # Verify author access
-        from common.djangoapps.student.auth import has_course_author_access
         assert has_course_author_access(self.user, dest_course_key)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -419,8 +419,15 @@ def get_in_process_course_actions(request):
             exclude_args={'state': CourseRerunUIStateManager.State.SUCCEEDED},
             should_display=True,
         )
-        if user_has_course_permission(
-            request.user, COURSES_VIEW_COURSE.identifier, course.course_key, LegacyAuthoringPermission.READ
+        if (
+            # The user who initiated the rerun can always see its status.
+            # This is needed because when the authz flag is enabled, permission
+            # checks require a CourseOverview which doesn't exist until the
+            # rerun task clones the course.
+            course.created_user == request.user
+            or user_has_course_permission(
+                request.user, COURSES_VIEW_COURSE.identifier, course.course_key, LegacyAuthoringPermission.READ
+            )
         )
     ]
 
@@ -1324,8 +1331,13 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
             raise PermissionDenied()
 
     # Make sure user has instructor and staff access to the destination course
-    # so the user can see the updated status for that course
-    add_instructor(destination_course_key, user, user)
+    # so the user can see the updated status for that course.
+    # When authz is enabled, we skip this because the authz layer requires a
+    # CourseOverview (which doesn't exist until the course is cloned in the task).
+    # In that case, visibility of the rerun status is granted by checking
+    # created_user on CourseRerunState instead.
+    if not core_toggles.enable_authz_course_authoring(destination_course_key):
+        add_instructor(destination_course_key, user, user)
 
     # Mark the action as initiated
     CourseRerunState.objects.initiated(source_course_key, destination_course_key, user, fields['display_name'])

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -424,6 +424,10 @@ def get_in_process_course_actions(request):
             # This is needed because when the authz flag is enabled, permission
             # checks require a CourseOverview which doesn't exist until the
             # rerun task clones the course.
+            # TODO: This created_user fallback is a temporary workaround until
+            # openedx/openedx-authz#352 is implemented. Once authz supports
+            # pre-assigning roles without a CourseOverview, this check can be removed
+            # and the standard permission check will suffice.
             course.created_user == request.user
             or user_has_course_permission(
                 request.user, COURSES_VIEW_COURSE.identifier, course.course_key, LegacyAuthoringPermission.READ
@@ -1336,6 +1340,10 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
     # CourseOverview (which doesn't exist until the course is cloned in the task).
     # In that case, visibility of the rerun status is granted by checking
     # created_user on CourseRerunState instead.
+    # TODO: This conditional is a temporary workaround until openedx/openedx-authz#352
+    # is implemented (pre-assigning roles without a CourseOverview). Once resolved,
+    # add_instructor can be called unconditionally here and the created_user fallback
+    # in get_in_process_course_actions can be removed.
     if not core_toggles.enable_authz_course_authoring(destination_course_key):
         add_instructor(destination_course_key, user, user)
 


### PR DESCRIPTION
Fixes: https://github.com/openedx/openedx-platform/issues/38826

## Description

Fixes course rerun failure when the `authz.enable_course_authoring` flag is enabled.

When the flag is active, the `add_instructor` call in `rerun_course` fails because the openedx-authz module requires a `CourseOverview` instance to exist in order to create a `Scope`. At the point where `add_instructor` is called, the destination course hasn't been cloned yet, so no `CourseOverview` exists.

The original purpose of calling `add_instructor` before the Celery task was to grant the user immediate Studio access so they could monitor the rerun progress via `CourseRerunState`.

This PR addresses the issue with the following approach:

- **When `authz.enable_course_authoring` is enabled:** Skip the pre-task `add_instructor` call entirely (since it would fail and legacy roles shouldn't exist when authz is enabled). Instead, grant visibility of the in-process rerun status by checking `CourseRerunState.created_user` — the user who initiated the rerun can always see its status. The proper authz-compatible permissions are established inside the Celery task after `clone_course` completes (at which point `CourseOverview` can be generated).

- **When `authz.enable_course_authoring` is disabled:** The existing behavior is preserved — `add_instructor` is called pre-task using the legacy path (`CourseAccessRole.objects.get_or_create`), which is idempotent.

The `add_instructor` call added inside the rerun task runs after `clone_course`, where the course exists in the modulestore and `CourseOverview` can be resolved. This works correctly for both flag states since `add_users` routes to the appropriate implementation based on the flag.

**Impacted roles:** Course Admin, Superuser.

## Supporting information

Related issue: https://github.com/openedx/openedx-platform/issues/38826

**Relevant Traceback:**

```
File "/openedx/edx-platform/cms/djangoapps/contentstore/views/course.py", line 1198, in _create_or_rerun_course
    destination_course_key = rerun_course(request.user, source_course_key, org, course, run, fields)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/cms/djangoapps/contentstore/views/course.py", line 1328, in rerun_course
    add_instructor(destination_course_key, user, user)
  File "/openedx/edx-platform/cms/djangoapps/contentstore/utils.py", line 115, in add_instructor
    CourseInstructorRole(course_key).add_users(new_instructor)
  File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 524, in add_users
    self._authz_add_users(users)
  File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 493, in _authz_add_users
    authz_add_role(
  File "/openedx/edx-platform/common/djangoapps/student/roles.py", line 69, in authz_add_role
    authz_api.assign_role_to_user_in_scope(
  File "/mnt/openedx-authz/openedx_authz/api/users.py", line 84, in assign_role_to_user_in_scope
    return assign_role_to_subject_in_scope(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/openedx-authz/openedx_authz/api/roles.py", line 232, in assign_role_to_subject_in_scope
    extended_rule = ExtendedCasbinRule.create_based_on_policy(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/openedx-authz/openedx_authz/models/core.py", line 229, in create_based_on_policy
    "scope": Scope.objects.get_or_create_for_external_key(scope),
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/openedx-authz/openedx_authz/models/core.py", line 77, in get_or_create_for_external_key
    return scope_class.get_or_create_for_external_key(scope_data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/openedx-authz/openedx_authz/models/scopes.py", line 140, in get_or_create_for_external_key
    course_overview = CourseOverview.get_from_id(course_key)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/openedx/core/lib/cache_utils.py", line 73, in decorator
    result = wrapped(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/openedx/core/djangoapps/content/course_overviews/models.py", line 431, in get_from_id
    return course_overview or cls.load_from_module_store(course_id)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/openedx/edx-platform/openedx/core/djangoapps/content/course_overviews/models.py", line 373, in load_from_module_store
    raise cls.DoesNotExist()
openedx.core.djangoapps.content.course_overviews.models.CourseOverview.DoesNotExist
```

**Files changed:**
- `cms/djangoapps/contentstore/views/course.py` — Conditional `add_instructor` skip + `created_user` visibility check
- `cms/djangoapps/contentstore/tasks.py` — `add_instructor` call after `clone_course`

## Testing instructions

> **Note:** To observe the in-process rerun status in Studio, you must test in a non-dev environment (e.g., one running with `tutor local launch` or a prod-like setup). In dev mode, Celery tasks run synchronously, so the in-progress status is never visible.

1. Enable the `authz.enable_course_authoring` flag globally.
2. Trigger a course rerun from Studio.
3. Verify the rerun initiates without a `CourseOverview.DoesNotExist` error.
4. Verify the in-process rerun status is visible on the Studio home page for the user who initiated it.
5. Verify the rerun completes successfully and the user has proper access to the new course.
6. Disable `authz.enable_course_authoring` and repeat steps 2–5 to confirm the legacy path still works correctly.

## Deadline

Verawood release

## Other information

- Coauthored by Kiro using Claude Opus 4.6 - Issue was replicated and researched manually, possible solutions were discussed with the agent and implemented by the agent. This description was partially generated by the agent and manually amended.
- No changes to openedx-authz are required.
- The `_legacy_add_users` path uses `get_or_create`, so calling `add_instructor` both pre-task and in-task (when the flag is disabled) does not produce duplicate `CourseAccessRole` records.
- The `created_user` check in `get_in_process_course_actions` is a minimal, safe addition — `CourseRerunState` already stores the initiating user, and this simply allows them to see their own rerun's status without requiring course-level permissions that can't yet exist.
