### PR TITLE
feat: replace enterprise_support import with DiscountEligibilityCheckRequested filter

### DIFF
--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -9,6 +9,7 @@ not other discounts like coupons or enterprise/program offers configured in ecom
 """
 
 
+import logging
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
@@ -17,6 +18,7 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from edx_toggles.toggles import WaffleFlag
+from openedx_filters.learning.filters import DiscountEligibilityCheckRequested
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.entitlements.models import CourseEntitlement
@@ -27,6 +29,8 @@ from lms.djangoapps.courseware.utils import is_mode_upsellable
 from lms.djangoapps.experiments.models import ExperimentData
 from lms.djangoapps.experiments.stable_bucketing import stable_bucketing_hash_group
 from openedx.features.discounts.models import DiscountPercentageConfig, DiscountRestrictionConfig
+
+log = logging.getLogger(__name__)
 
 # .. toggle_name: discounts.enable_first_purchase_discount_override
 # .. toggle_implementation: WaffleFlag
@@ -124,11 +128,13 @@ def can_show_streak_discount_coupon(user, course):
     if not is_mode_upsellable(user, enrollment):
         return False
 
-    # We can't import this at Django load time within the openedx tests settings context
-    from openedx.features.enterprise_support.utils import is_enterprise_learner
-
-    # Don't give discount to enterprise users
-    if is_enterprise_learner(user):
+    # Allow plugins to mark this user as ineligible for the discount.
+    try:
+        DiscountEligibilityCheckRequested.run_filter(
+            user=user, course_key=course.id,
+        )
+    except DiscountEligibilityCheckRequested.DiscountIneligible as exc:
+        log.info("User is ineligible for streak discount: %s", exc.message)
         return False
 
     return True
@@ -179,11 +185,13 @@ def can_receive_discount(user, course, discount_expiration_date=None):
     if CourseEntitlement.objects.filter(user=user).exists():
         return False
 
-    # We can't import this at Django load time within the openedx tests settings context
-    from openedx.features.enterprise_support.utils import is_enterprise_learner
-
-    # Don't give discount to enterprise users
-    if is_enterprise_learner(user):
+    # Allow plugins to mark this user as ineligible for the discount.
+    try:
+        DiscountEligibilityCheckRequested.run_filter(
+            user=user, course_key=course.id,
+        )
+    except DiscountEligibilityCheckRequested.DiscountIneligible as exc:
+        log.info("User is ineligible for discount: %s", exc.message)
         return False
 
     # Turn holdback on

--- a/openedx/features/discounts/tests/test_applicability.py
+++ b/openedx/features/discounts/tests/test_applicability.py
@@ -10,12 +10,13 @@ import pytest
 from django.contrib.sites.models import Site
 from django.utils.timezone import now
 from edx_toggles.toggles.testutils import override_waffle_flag
-from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
+from openedx_filters.learning.filters import DiscountEligibilityCheckRequested
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from common.djangoapps.entitlements.tests.factories import CourseEntitlementFactory
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
+from lms.djangoapps.courseware.toggles import COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT
 from lms.djangoapps.experiments.models import ExperimentData
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.features.discounts.models import DiscountRestrictionConfig
@@ -25,7 +26,12 @@ from xmodule.modulestore.tests.django_utils import (
 )
 from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable=wrong-import-order
 
-from ..applicability import DISCOUNT_APPLICABILITY_FLAG, _is_in_holdback_and_bucket, can_receive_discount
+from ..applicability import (
+    DISCOUNT_APPLICABILITY_FLAG,
+    _is_in_holdback_and_bucket,
+    can_receive_discount,
+    can_show_streak_discount_coupon,
+)
 
 
 @ddt.ddt
@@ -51,6 +57,13 @@ class TestApplicability(ModuleStoreTestCase):
         )
         self.mock_holdback = holdback_patcher.start()
         self.addCleanup(holdback_patcher.stop)
+
+        # By default, the filter does not raise, meaning the user is eligible.
+        discount_filter_patcher = patch(
+            'openedx.features.discounts.applicability.DiscountEligibilityCheckRequested.run_filter',
+        )
+        self.mock_discount_filter = discount_filter_patcher.start()
+        self.addCleanup(discount_filter_patcher.stop)
 
     def test_can_receive_discount(self):
         # Right now, no one should be able to receive the discount
@@ -136,17 +149,13 @@ class TestApplicability(ModuleStoreTestCase):
         assert applicability == (entitlement_mode is None)
 
     @override_waffle_flag(DISCOUNT_APPLICABILITY_FLAG, active=True)
-    def test_can_receive_discount_false_enterprise(self):
+    def test_can_receive_discount_false_when_filter_marks_ineligible(self):
         """
-        Ensure that enterprise users do not receive the discount.
+        Ensure that when the eligibility filter raises DiscountIneligible,
+        no discount is received.
         """
-        enterprise_customer = EnterpriseCustomer.objects.create(
-            name='Test EnterpriseCustomer',
-            site=self.site
-        )
-        EnterpriseCustomerUser.objects.create(
-            user_id=self.user.id,
-            enterprise_customer=enterprise_customer
+        self.mock_discount_filter.side_effect = DiscountEligibilityCheckRequested.DiscountIneligible(
+            message="test: user is ineligible for discount"
         )
 
         applicability = can_receive_discount(user=self.user, course=self.course)
@@ -180,3 +189,17 @@ class TestApplicability(ModuleStoreTestCase):
                 Mock(now=Mock(return_value=datetime(2020, 8, 1, 0, 1, tzinfo=ZoneInfo("UTC"))), wraps=datetime),
             ):
                 assert not _is_in_holdback_and_bucket(self.user)
+
+    @override_waffle_flag(COURSEWARE_MFE_MILESTONES_STREAK_DISCOUNT, active=True)
+    def test_can_show_streak_discount_coupon_false_when_filter_marks_ineligible(self):
+        """
+        Ensure that when the eligibility filter raises DiscountIneligible,
+        the streak discount coupon is not shown.
+        """
+        CourseEnrollmentFactory(is_active=True, course_id=self.course.id, user=self.user)
+        self.mock_discount_filter.side_effect = DiscountEligibilityCheckRequested.DiscountIneligible(
+            message="test: user is ineligible for streak discount"
+        )
+
+        applicability = can_show_streak_discount_coupon(user=self.user, course=self.course)
+        assert applicability is False


### PR DESCRIPTION
Backport of https://github.com/edx/edx-platform/pull/349 for [ENT-11564](https://2u-internal.atlassian.net/browse/ENT-11564)

Removes direct lazy imports of is_enterprise_learner from openedx.features.enterprise_support.utils in applicability.py and replaces them with calls to the DiscountEligibilityCheckRequested openedx-filter. Adds the filter to OPEN_EDX_FILTERS_CONFIG with the DiscountEligibilityStep pipeline step. Updates tests to mock the filter instead of using enterprise model factories.

Co-Authored-By: Claude Sonnet 4.6 [noreply@anthropic.com](mailto:noreply@anthropic.com)