### PR TITLE
sandbox: test xblocks-contrib Problem Block JS ES6+ modernization (PR #262)

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1319,8 +1319,9 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.17.0
+xblocks-contrib @ git+https://github.com/irfanuddinahmad/xblocks-core.git@irfanuddinahmad/modernize-problem-block-js-438
     # via -r requirements/edx/bundled.in
+    # sandbox: testing PR #262 (modernize Problem Block JS to ES6+)
 xmlsec==1.3.14
     # via
     #   -c requirements/constraints.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2330,10 +2330,11 @@ xblock-utils==4.0.0
     #   -r requirements/edx/testing.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.17.0
+xblocks-contrib @ git+https://github.com/irfanuddinahmad/xblocks-core.git@irfanuddinahmad/modernize-problem-block-js-438
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
+    # sandbox: testing PR #262 (modernize Problem Block JS to ES6+)
 xmlsec==1.3.14
     # via
     #   -c requirements/constraints.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1659,8 +1659,9 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.17.0
+xblocks-contrib @ git+https://github.com/irfanuddinahmad/xblocks-core.git@irfanuddinahmad/modernize-problem-block-js-438
     # via -r requirements/edx/base.txt
+    # sandbox: testing PR #262 (modernize Problem Block JS to ES6+)
 xmlsec==1.3.14
     # via
     #   -c requirements/constraints.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1740,8 +1740,9 @@ xblock-utils==4.0.0
     #   -r requirements/edx/base.txt
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.17.0
+xblocks-contrib @ git+https://github.com/irfanuddinahmad/xblocks-core.git@irfanuddinahmad/modernize-problem-block-js-438
     # via -r requirements/edx/base.txt
+    # sandbox: testing PR #262 (modernize Problem Block JS to ES6+)
 xmlsec==1.3.14
     # via
     #   -c requirements/constraints.txt


### PR DESCRIPTION
## Summary

This is a **sandbox PR for CI testing only** — not intended to be merged.

Points `xblocks-contrib` at the ES6+ modernization branch under review at https://github.com/openedx/xblocks-core/pull/262 to verify end-to-end compatibility with the platform.

**Change:** Replaces `xblocks-contrib==0.17.0` with a direct git reference to the PR branch across all four compiled requirements files (`base.txt`, `testing.txt`, `development.txt`, `doc.txt`).

```
xblocks-contrib @ git+https://github.com/irfanuddinahmad/xblocks-core.git@irfanuddinahmad/modernize-problem-block-js-438
```

## What's being tested

The PR under review converts the three Problem Block JS files (`display.js`, `imageinput.js`, `schematic.js`) from legacy CoffeeScript-era IIFE patterns to ES6+ syntax (classes, `const`/`let`, template literals, proper imports/exports) and removes the `imports-loader` workarounds from webpack config.

## Do not merge

This branch will be deleted once the xblocks-core PR is merged and a new `xblocks-contrib` release is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)