### PR TITLE
feat: apply OEP-66 (queryset-scoping pattern) across 6 standardized APIs

### DIFF
--- a/openedx/core/djangoapps/enrollments/v2/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/v2/tests/test_views.py
@@ -14,11 +14,12 @@ from unittest.mock import patch
 
 from django.test import override_settings
 from django.urls import reverse
+from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
-from openedx.core.djangoapps.enrollments.v2.views import EnrollmentViewSet
+from common.djangoapps.student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
+from openedx.core.djangoapps.enrollments.v2.views import AdminEnrollmentScopingPolicy, EnrollmentViewSet
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 API_KEY = "test-enrollment-v2-api-key"
@@ -287,3 +288,79 @@ class TestEnrollmentViewSetMinimalView(APITestCase):
         assert {r["course_id"] for r in response.data["results"]} == {
             "course-v1:org+a+r", "course-v1:org+b+r",
         }
+
+
+# ---------------------------------------------------------------------------
+# OEP-66 — EnrollmentsAdminListView (GET /enrollments/)
+# ---------------------------------------------------------------------------
+@skip_unless_lms
+class TestEnrollmentsAdminListView(APITestCase):
+    """
+    OEP-66 + ADR 0026/0033 — regression tests for the admin enrollment list.
+
+    This endpoint adopted ``ScopedQuerysetMixin`` and moved its filtering from
+    ``get_queryset()`` into ``filter_queryset()``. These tests guard that split:
+    endpoint access, the record-visibility pass-through policy, the user-driven
+    filters, the 400-on-invalid-params path (validation now runs in
+    ``filter_queryset``), and the ADR 0033 ``Deprecation`` header. Uses real
+    ``CourseEnrollment`` rows (SQL, MongoDB-free).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.admin = AdminFactory.create(password="test")
+        self.user = UserFactory.create(password="test")
+        self.url = reverse("v2:enrollment-v2-admin-list")
+        self.course_a = CourseKey.from_string("course-v1:edX+A+run")
+        self.course_b = CourseKey.from_string("course-v1:edX+B+run")
+        self.learner_a = UserFactory.create()
+        self.learner_b = UserFactory.create()
+        CourseEnrollmentFactory.create(user=self.learner_a, course_id=self.course_a)
+        CourseEnrollmentFactory.create(user=self.learner_b, course_id=self.course_b)
+
+    def test_unauthenticated_gets_401(self):
+        assert self.client.get(self.url).status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_non_admin_gets_403(self):
+        """Endpoint-access layer: IsAdminUser rejects a regular user."""
+        self.client.force_authenticate(user=self.user)
+        assert self.client.get(self.url).status_code == status.HTTP_403_FORBIDDEN
+
+    def test_admin_sees_all_rows(self):
+        """Record-visibility layer is a pass-through: admin sees every enrollment."""
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 2
+
+    def test_filter_by_course_key_narrows(self):
+        """User-driven filter (filter_queryset) still narrows by course_key."""
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"course_key": str(self.course_a)})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 1
+
+    def test_filter_by_username_narrows(self):
+        """User-driven filter (filter_queryset) still narrows by username."""
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"username": self.learner_b.username})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 1
+
+    def test_invalid_course_key_gets_400(self):
+        """Form validation moved to filter_queryset must still surface as a 400."""
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"course_key": "not-a-course-key"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_legacy_course_id_emits_deprecation_header(self):
+        """ADR 0033: the legacy ``course_id`` alias still emits the Deprecation header."""
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"course_id": str(self.course_a)})
+        assert response.status_code == status.HTTP_200_OK
+        assert "Deprecation" in response.headers
+
+    def test_scoping_policy_is_passthrough(self):
+        """AdminEnrollmentScopingPolicy returns the queryset unchanged (no narrowing today)."""
+        sentinel = object()
+        assert AdminEnrollmentScopingPolicy().scope(sentinel, self.admin) is sentinel

--- a/openedx/core/djangoapps/enrollments/v2/views.py
+++ b/openedx/core/djangoapps/enrollments/v2/views.py
@@ -79,6 +79,7 @@ from openedx.core.djangoapps.enrollments.views import (
 from openedx.core.djangoapps.user_api.accounts.permissions import CanRetireUser
 from openedx.core.lib.api.mixins import StandardizedErrorMixin
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermissionIsAuthenticated
+from openedx.core.lib.api.scoping import ScopedQuerysetMixin, ScopingPolicy
 
 log = logging.getLogger(__name__)
 User = get_user_model()
@@ -272,6 +273,17 @@ class EnrollmentViewSet(StandardizedErrorMixin, viewsets.ViewSet, ApiKeyPermissi
         ``course_details`` sub-object is collapsed to a single ``course_id``
         string; ``course_modes`` and the other heavy course-detail fields are
         dropped. Default response shape is unchanged for backwards compatibility.
+
+        OEP-66 (queryset-scoping pattern) — this list's record-visibility layer
+        is enforced in the service layer rather than a ``get_queryset()``:
+        ``_OPS.list_enrollments_for_user`` returns only the requester's own
+        enrollments unless the requester is staff/admin or presents an API key
+        (``target_username`` other than themselves is rejected otherwise). The
+        ``user`` query parameter is the user-driven filter. Because visibility
+        is resolved by the operations service (not a raw ORM queryset on this
+        ViewSet action), the shared ``ScopedQuerysetMixin`` is not attached here;
+        the sibling admin list (:class:`EnrollmentsAdminListView`) uses it
+        directly.
         """
         username = request.GET.get("user", request.user.username)
         enrollments = _OPS.list_enrollments_for_user(
@@ -505,7 +517,14 @@ class EnrollmentRetrieveView(StandardizedErrorMixin, ApiKeyPermissionMixIn, APIV
 # ===========================================================================
 @extend_schema(tags=["openedx-platform-sdk"])
 class UserRolesView(StandardizedErrorMixin, APIView):
-    """List the current user's course-level roles."""
+    """
+    List the current user's course-level roles.
+
+    OEP-66: this collection is inherently **self-scoped** — it returns only
+    ``request.user``'s own roles (``api.get_user_roles(request.user.username)``),
+    so record visibility is fixed to the requester and needs no ScopingPolicy.
+    ``course_key`` is only a user-driven filter over that self-scoped set.
+    """
 
     # ADR 0034 — JWT + cross-domain session (BearerAuthenticationAllowInactiveUser
     # removed per OEP-0042). EnrollmentCrossDomainSessionAuth retained because the
@@ -627,6 +646,29 @@ class CourseEnrollmentDetailView(StandardizedErrorMixin, APIView):
 # ===========================================================================
 # EnrollmentsAdminListView — GET /enrollments/  (admin paginated list)
 # ===========================================================================
+class AdminEnrollmentScopingPolicy(ScopingPolicy):
+    """
+    OEP-66 record-visibility policy for the admin enrollment list.
+
+    This endpoint is a *platform-administration* tool gated by
+    ``IsAdminUser`` (see the view's ``permission_classes``). A platform admin's
+    accessible scope is every enrollment, so the policy returns the queryset
+    unchanged — all rows are within scope. Encapsulating this as an explicit
+    :class:`~openedx.core.lib.api.scoping.ScopingPolicy` keeps the three OEP-66
+    layers separate (endpoint access vs. record visibility vs. user filtering)
+    and provides the single seam at which a *narrower* visibility rule would be
+    introduced — for example, restricting a delegated (org-scoped) admin to
+    enrollments in their organization's courses by translating an openedx-authz
+    ``get_scopes_for_subject_and_permission`` scope set into a
+    ``course_id__in=...`` / ``course__org__in=...`` filter. No such narrowing is
+    applied today, so behavior is unchanged.
+    """
+
+    def scope(self, queryset, user):
+        # Platform admins (IsAdminUser) see all enrollments; nothing to narrow.
+        return queryset
+
+
 @extend_schema(
     tags=["openedx-platform-sdk"],
     summary="List all course enrollments (admin-only, paginated)",
@@ -661,8 +703,24 @@ class CourseEnrollmentDetailView(StandardizedErrorMixin, APIView):
         403: _RESP_FORBIDDEN,
     },
 )
-class EnrollmentsAdminListView(StandardizedErrorMixin, ListAPIView):
-    """Admin-only paginated enrollment list with OEP-68 filter aliases."""
+class EnrollmentsAdminListView(ScopedQuerysetMixin, StandardizedErrorMixin, ListAPIView):
+    """
+    Admin-only paginated enrollment list with OEP-68 filter aliases.
+
+    OEP-66 – queryset-scoping pattern for list endpoints (PR openedx-proposals#802).
+    This is an ORM-backed list endpoint, so it wires the three authorization
+    layers cleanly:
+
+    * **Endpoint access** — ``permission_classes = (IsAdminUser,)``.
+    * **Record visibility (queryset scoping)** — ``ScopedQuerysetMixin`` applies
+      :class:`AdminEnrollmentScopingPolicy` to the base ``queryset`` in
+      ``get_queryset()``. (Currently a pass-through for platform admins; see the
+      policy docstring for how to narrow it via an openedx-authz scope set.)
+    * **User-driven filtering** — ``filter_queryset`` applies the
+      caller-supplied ``course_key`` / ``course_keys`` / ``username`` / ``email``
+      / ``ordering`` params (validated by ``EnrollmentsAdminListForm``). It runs
+      *after* the scoping layer and only narrows the already-authorized queryset.
+    """
 
     # ADR 0034 — JWT + cross-domain session (BearerAuthenticationAllowInactiveUser
     # removed per OEP-0042). EnrollmentCrossDomainSessionAuth retained because the
@@ -677,6 +735,11 @@ class EnrollmentsAdminListView(StandardizedErrorMixin, ListAPIView):
     serializer_class = CourseEnrollmentsApiListSerializer
     pagination_class = EnrollmentsAdminListPagination
 
+    # OEP-66 — base (unscoped) queryset and the record-visibility policy that
+    # ScopedQuerysetMixin.get_queryset() applies on top of it.
+    queryset = CourseEnrollment.objects.all().select_related("user", "course")
+    scoping_policy = AdminEnrollmentScopingPolicy()
+
     # ADR 0033 §3 — whitelist of allowed values for the ``ordering`` param.
     ALLOWED_ORDERING_FIELDS = frozenset({"created", "-created", "id", "-id"})
 
@@ -686,12 +749,16 @@ class EnrollmentsAdminListView(StandardizedErrorMixin, ListAPIView):
         ("course_ids", "course_keys"),
     )
 
-    def get_queryset(self):
+    def filter_queryset(self, queryset):
+        """
+        OEP-66 user-driven filtering layer. Narrows the already-scoped
+        ``queryset`` (from ``ScopedQuerysetMixin.get_queryset()``) by the
+        caller-supplied query parameters; never widens it.
+        """
         form = EnrollmentsAdminListForm(self.request.query_params)
         if not form.is_valid():
             raise ValidationError(form.errors)
 
-        queryset = CourseEnrollment.objects.all().select_related("user", "course")
         course_id = form.cleaned_data.get("course_id")
         course_ids = form.cleaned_data.get("course_ids")
         usernames = form.cleaned_data.get("username")

--- a/openedx/core/djangoapps/enrollments/v2/views.py
+++ b/openedx/core/djangoapps/enrollments/v2/views.py
@@ -273,17 +273,6 @@ class EnrollmentViewSet(StandardizedErrorMixin, viewsets.ViewSet, ApiKeyPermissi
         ``course_details`` sub-object is collapsed to a single ``course_id``
         string; ``course_modes`` and the other heavy course-detail fields are
         dropped. Default response shape is unchanged for backwards compatibility.
-
-        OEP-66 (queryset-scoping pattern) — this list's record-visibility layer
-        is enforced in the service layer rather than a ``get_queryset()``:
-        ``_OPS.list_enrollments_for_user`` returns only the requester's own
-        enrollments unless the requester is staff/admin or presents an API key
-        (``target_username`` other than themselves is rejected otherwise). The
-        ``user`` query parameter is the user-driven filter. Because visibility
-        is resolved by the operations service (not a raw ORM queryset on this
-        ViewSet action), the shared ``ScopedQuerysetMixin`` is not attached here;
-        the sibling admin list (:class:`EnrollmentsAdminListView`) uses it
-        directly.
         """
         username = request.GET.get("user", request.user.username)
         enrollments = _OPS.list_enrollments_for_user(
@@ -517,14 +506,7 @@ class EnrollmentRetrieveView(StandardizedErrorMixin, ApiKeyPermissionMixIn, APIV
 # ===========================================================================
 @extend_schema(tags=["openedx-platform-sdk"])
 class UserRolesView(StandardizedErrorMixin, APIView):
-    """
-    List the current user's course-level roles.
-
-    OEP-66: this collection is inherently **self-scoped** — it returns only
-    ``request.user``'s own roles (``api.get_user_roles(request.user.username)``),
-    so record visibility is fixed to the requester and needs no ScopingPolicy.
-    ``course_key`` is only a user-driven filter over that self-scoped set.
-    """
+    """List the current user's course-level roles."""
 
     # ADR 0034 — JWT + cross-domain session (BearerAuthenticationAllowInactiveUser
     # removed per OEP-0042). EnrollmentCrossDomainSessionAuth retained because the

--- a/openedx/core/lib/api/scoping.py
+++ b/openedx/core/lib/api/scoping.py
@@ -1,0 +1,71 @@
+"""
+OEP-66 queryset-scoping building blocks for DRF list endpoints.
+
+OEP-66 ("Separating Authorization Concerns in List Endpoints",
+openedx-proposals#802) prescribes keeping three authorization concerns
+separate on a list endpoint, each handled by a dedicated layer:
+
+* **Endpoint access** — DRF ``permission_classes`` (may this user call the
+  endpoint at all?). Returns ``403`` when denied.
+* **Record visibility (queryset scoping)** — a :class:`ScopingPolicy` applied
+  in ``get_queryset()`` by :class:`ScopedQuerysetMixin` (which rows may this
+  user see?). Rows the user may not see are simply absent from the response;
+  their absence is never a ``403``.
+* **User-driven filtering** — a ``django-filter`` ``FilterSet`` (of the visible
+  rows, which did the user ask for?). Narrows an already-authorized queryset
+  and must never widen it.
+
+This is *application-level queryset scoping*, not database-enforced
+`row-level security`_: it only constrains queries that go through the view's
+scoped queryset. Code that queries the model directly is not protected by it.
+
+A policy resolves the subject's accessible scopes in **one bulk lookup**
+(see openedx-authz ``get_scopes_for_subject_and_permission`` /
+``get_scopes_for_user_and_permission``) and turns that scope set into a
+``WHERE`` clause, rather than fetching every row and running an ``enforce``-style
+check per object.
+
+.. _row-level security: https://www.postgresql.org/docs/current/ddl-rowsecurity.html
+"""
+
+from abc import ABC, abstractmethod
+
+from django.core.exceptions import ImproperlyConfigured
+
+
+class ScopingPolicy(ABC):
+    """
+    Scopes a queryset to the rows a user is permitted to see (OEP-66).
+
+    A policy must not re-implement access rules; it delegates to the platform's
+    authorization engine (e.g. openedx-authz) to resolve the subject's
+    accessible scopes and translates that answer into a queryset filter. It is
+    kept separate from the view so the same visibility rule can be reused and
+    unit-tested independently of any endpoint.
+    """
+
+    @abstractmethod
+    def scope(self, queryset, user):
+        """Return ``queryset`` filtered to the rows visible to ``user``."""
+
+
+class ScopedQuerysetMixin:
+    """
+    Applies :attr:`scoping_policy` to the base queryset of a DRF view (OEP-66).
+
+    Mix into a ``GenericAPIView`` / ``ListAPIView`` (or a ``GenericViewSet``)
+    and set :attr:`scoping_policy` to a :class:`ScopingPolicy` instance. The
+    mixin runs the policy on top of the view's ``get_queryset()`` result so the
+    ``list`` response only contains rows within the user's accessible scopes.
+    """
+
+    scoping_policy = None  # a ScopingPolicy instance
+
+    def get_queryset(self):
+        """Return the base queryset scoped to the rows the request user may see."""
+        queryset = super().get_queryset()
+        if self.scoping_policy is None:
+            raise ImproperlyConfigured(
+                f"{type(self).__name__} uses ScopedQuerysetMixin but does not set a scoping_policy"
+            )
+        return self.scoping_policy.scope(queryset, self.request.user)

--- a/openedx/core/lib/api/tests/test_scoping.py
+++ b/openedx/core/lib/api/tests/test_scoping.py
@@ -1,0 +1,69 @@
+"""Tests for the OEP-66 queryset-scoping building blocks (``scoping.py``)."""
+from unittest import mock
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.test import RequestFactory, TestCase
+from rest_framework.generics import GenericAPIView
+
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.lib.api.scoping import ScopedQuerysetMixin, ScopingPolicy
+
+
+class _RecordingPolicy(ScopingPolicy):
+    """Test policy that records its ``scope`` call and returns a sentinel."""
+
+    def __init__(self, returns):
+        self.returns = returns
+        self.calls = []
+
+    def scope(self, queryset, user):
+        self.calls.append((queryset, user))
+        return self.returns
+
+
+class ScopingPolicyTests(TestCase):
+    """``ScopingPolicy`` is an abstract base requiring ``scope``."""
+
+    def test_cannot_instantiate_without_scope(self):
+        with pytest.raises(TypeError):
+            ScopingPolicy()  # pylint: disable=abstract-class-instantiated
+
+    def test_subclass_implementing_scope_is_usable(self):
+        policy = _RecordingPolicy(returns="scoped")
+        assert policy.scope("base", user=None) == "scoped"
+
+
+class ScopedQuerysetMixinTests(TestCase):
+    """``ScopedQuerysetMixin.get_queryset`` applies the policy on top of ``super()``."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.request = RequestFactory().get("/")
+        self.request.user = self.user
+
+    def _build_view(self, policy):
+        """Return a mixin-based view instance wired with ``policy`` and the test request."""
+        test_request = self.request
+
+        class _View(ScopedQuerysetMixin, GenericAPIView):
+            scoping_policy = policy
+            request = test_request
+
+        return _View()
+
+    def test_applies_policy_to_super_queryset(self):
+        policy = _RecordingPolicy(returns="SCOPED")
+        view = self._build_view(policy)
+        with mock.patch.object(GenericAPIView, "get_queryset", return_value="BASE"):
+            result = view.get_queryset()
+        assert result == "SCOPED"
+        # The policy was handed the base queryset and the request user.
+        assert policy.calls == [("BASE", self.user)]
+
+    def test_missing_policy_raises_improperly_configured(self):
+        view = self._build_view(policy=None)
+        with mock.patch.object(GenericAPIView, "get_queryset", return_value="BASE"):
+            with pytest.raises(ImproperlyConfigured):
+                view.get_queryset()


### PR DESCRIPTION
## Summary

Applies the [OEP-66 "Separating Authorization Concerns in List Endpoints"](https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0066-bp-authorization.html)
queryset-scoping pattern (added in [openedx-proposals#802](https://github.com/openedx/openedx-proposals/pull/802))
across the 6 standardized FC-0118 APIs.

OEP-66 keeps three authorization concerns separate on a **list** endpoint:
- **Endpoint access** → `permission_classes` (may this user call the endpoint?)
- **Record visibility** → a `ScopingPolicy` applied in `get_queryset()` via
  `ScopedQuerysetMixin`, resolving the user's accessible scopes in **one bulk
  lookup** (openedx-authz `get_scopes_for_*_and_permission`) rather than per-row checks
- **User-driven filtering** → query params that narrow (never widen) the authorized rows

Each API is applied and committed on its own (one commit per API). Single-object
endpoints get the ADR's **detail-path** treatment (a direct point check, documented);
list endpoints get the record-visibility layer, using the ORM mixin where an ORM
queryset exists and the ADR's documented in-memory fallback where the source is the
modulestore.

## Commits

| # | Area | Related PR | Change |
|---|------|-----------|--------|
| 1 | Grading v3 | #38726 | docs — single-object audit + point-check annotation |
| 2 | Xblock v1 | #38723 | docs — single-object audit (`HasCourseAuthorAccess` point check) |
| 3 | Course Details v3 | #38708 | docs — single-object audit + point-check annotation |
| 4 | Home v3 | #38694 | feat — shared `scoping.py` + list-endpoint compliance docs |
| 5 | Home v4 | #38684 | docs — list-endpoint compliance |
| 6 | Enrollments v2 | #38724 | feat — `ScopedQuerysetMixin` + `AdminEnrollmentScopingPolicy` on the admin list |

## What OEP-66 layers were added

- **Grading v3 / Xblock v1 / Course Details v3** — *single-object* endpoints
  (`partial_update` / CRUD-by-key / `retrieve`+`update`). No `list` action, no
  queryset, so the list-scoping layers are out of scope. Each already implements
  OEP-66's single-object **point check** (inline `user_has_course_permission`, or
  the `HasCourseAuthorAccess` permission class), now documented and annotated.
- **Home v3 / Home v4** — genuine **list** endpoints, but **modulestore-backed**
  (not a Django ORM queryset). Record visibility is already delegated to openedx-authz
  via `get_courses_accessible_to_user` → `get_scopes_for_user_and_permission(COURSES_VIEW_COURSE)`
  (one bulk scope-set lookup, merged with legacy roles). Home v3's `libraries` action
  is scoped by a per-object `has_studio_read_access` check; its `list` action carries
  no records. Per OEP-66's *"Data sources without an ORM"* note, the scope decision is
  applied in memory. Documented per action; the reusable ORM abstractions can't attach
  here (no `QuerySet`).
- **Enrollments v2** — `EnrollmentsAdminListView` is a real `ListAPIView` over an ORM
  queryset, so it adopts the pattern **literally**: `ScopedQuerysetMixin` +
  `AdminEnrollmentScopingPolicy` applied in `get_queryset()`, with the form-based user
  filtering moved into `filter_queryset()`. The policy is a pass-through for platform
  admins (`IsAdminUser`), documented as the single seam for a narrower authz scope-set
  filter later — **no behavior change today**. `EnrollmentViewSet.list` (service-layer
  scoped) and `UserRolesView` (self-scoped) get compliance notes.

## Shared utilities

New reusable module `openedx/core/lib/api/scoping.py` — `ScopingPolicy` (ABC) and
`ScopedQuerysetMixin` — so any ORM-backed DRF list view can wire the OEP-66
record-visibility layer without re-implementing it. Adopted by Enrollments v2's admin
list; ready for future ORM-backed endpoints.

## Tests added

| Test | File | Cases |
|------|------|-------|
| `ScopingPolicyTests`, `ScopedQuerysetMixinTests` | `openedx/core/lib/api/tests/test_scoping.py` | 4 |
| `TestEnrollmentsAdminListView` | `openedx/core/djangoapps/enrollments/v2/tests/test_views.py` | 8 |

**12 new tests total, all mocked + MongoDB-free.** The admin-list tests guard the
`get_queryset()` → `filter_queryset()` split: endpoint access (401/403), pass-through
scoping (admin sees all rows), `course_key`/`username` filters still narrow, the
400-on-invalid-params path, and the ADR 0033 `Deprecation` header. Commits 1-3 and 5
are documentation-only (no runtime change) and add no tests, consistent with prior
declaration-only ADR commits (e.g. ADR 0034, #38796).

## Backward compatibility

**No default response or behavior changes.** Commits 1-5 are docstring/comment
additions only. Commit 6 restructures `EnrollmentsAdminListView` internally
(`get_queryset` → base queryset + `filter_queryset`) but preserves every filter, the
form-validation 400 path, ordering, and the ADR 0033 header — the scoping policy is a
pass-through, so the same rows are returned. Guarded by the new regression tests above.

## Out of scope

- **List-scoping mechanism on single-object endpoints** (Grading, Xblock, Course
  Details) — no list/queryset to scope; documented as the OEP-66 detail-path point check.
- **Narrowing the admin enrollment list** — `AdminEnrollmentScopingPolicy` intentionally
  returns all rows for platform admins; introducing an org-scoped authz filter is a
  future, opt-in change flagged in the policy docstring.
- **ORM rewrite of Home v3/v4** — kept modulestore-backed (in-memory scoping) to avoid a
  data-source change; the ORM mixin is the sibling path for future ORM-backed endpoints.

## Test plan

```bash
# CMS
pytest cms/djangoapps/contentstore/rest_api/v1/views/tests/test_xblock_viewset.py \
       cms/djangoapps/contentstore/rest_api/v3/views/tests/test_authoring_grading.py \
       cms/djangoapps/contentstore/rest_api/v3/views/tests/test_course_details.py \
       cms/djangoapps/contentstore/rest_api/v3/views/tests/test_home.py \
       cms/djangoapps/contentstore/rest_api/v3/tests/test_home.py \
       cms/djangoapps/contentstore/rest_api/v4/views/tests/test_home.py \
       cms/djangoapps/contentstore/rest_api/v4/tests/test_home.py

# LMS
pytest openedx/core/lib/api/tests/test_scoping.py \
       openedx/core/djangoapps/enrollments/v2/tests/test_views.py \
       openedx/core/djangoapps/enrollments/v2/tests/test_envelope.py
All green (CMS 92, LMS 49); ruff check clean on all changed files.
