### PR TITLE
feat: configure drf-spectacular on LMS for enrollment API schema gene…

### DIFF
--- a/cms/lib/spectacular.py
+++ b/cms/lib/spectacular.py
@@ -12,9 +12,12 @@ def cms_api_filter(endpoints):
     CMS_PATH_PATTERN = re.compile(r"^/api/contentstore/v\d+/")
 
     for path, path_regex, method, callback in endpoints:
-        if CMS_PATH_PATTERN.match(path) or (
-            path.startswith("/api/courses/")
-            and "bulk_enable_disable_discussions" in path
+        if (
+            CMS_PATH_PATTERN.match(path)
+            or (
+                path.startswith("/api/courses/")
+                and "bulk_enable_disable_discussions" in path
+            )
         ):
             filtered.append((path, path_regex, method, callback))
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2040,6 +2040,7 @@ INSTALLED_APPS = [
 
     # API Documentation
     'drf_yasg',
+    'drf_spectacular',
 
     # edx-drf-extensions
     'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2126,6 +2126,18 @@ SWAGGER_SETTINGS = {
     'DEEP_LINKING': True,
 }
 
+###################### drf-spectacular (LMS enrollment schema) ######################
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'LMS Enrollment API',
+    'VERSION': '0.1.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+    'PREPROCESSING_HOOKS': ['lms.lib.spectacular.lms_api_filter'],
+    'SCHEMA_PATH_PREFIX': '/api/enrollment',
+    'SCHEMA_PATH_PREFIX_TRIM': '/api/enrollment',
+    # SERVERS is environment-specific (LMS_ROOT_URL differs per env) and is
+    # set in devstack.py / production.py.
+}
+
 ######################### MARKETING SITE ###############################
 
 MKTG_URL_LINK_MAP.update({  # noqa: F405

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -583,17 +583,9 @@ RETIREMENT_STATES = [
 ]
 
 ###################### drf-spectacular (LMS enrollment schema) ######################
-SPECTACULAR_SETTINGS = {
-    'TITLE': 'LMS Enrollment API',
-    'VERSION': '0.1.0',
-    'SERVE_INCLUDE_SCHEMA': False,
-    'PREPROCESSING_HOOKS': ['lms.lib.spectacular.lms_api_filter'],
-    'SCHEMA_PATH_PREFIX': '/api/enrollment',
-    'SCHEMA_PATH_PREFIX_TRIM': '/api/enrollment',
-    'SERVERS': [
-        {'url': LMS_ROOT_URL, 'description': 'Local'},  # noqa: F405
-    ],
-}
+SPECTACULAR_SETTINGS['SERVERS'] = [  # noqa: F405
+    {'url': LMS_ROOT_URL, 'description': 'Local'},  # noqa: F405
+]
 
 ################# New settings must go ABOVE this line #################
 ########################################################################

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -582,6 +582,19 @@ RETIREMENT_STATES = [
     'COMPLETE',
 ]
 
+###################### drf-spectacular (LMS enrollment schema) ######################
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'LMS Enrollment API',
+    'VERSION': '0.1.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+    'PREPROCESSING_HOOKS': ['lms.lib.spectacular.lms_api_filter'],
+    'SCHEMA_PATH_PREFIX': '/api/enrollment',
+    'SCHEMA_PATH_PREFIX_TRIM': '/api/enrollment',
+    'SERVERS': [
+        {'url': LMS_ROOT_URL, 'description': 'Local'},  # noqa: F405
+    ],
+}
+
 ################# New settings must go ABOVE this line #################
 ########################################################################
 # See if the developer has any local overrides.

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -398,17 +398,9 @@ MIDDLEWARE.extend(_YAML_TOKENS.get('EXTRA_MIDDLEWARE_CLASSES', []))  # noqa: F40
 
 
 ###################### drf-spectacular (LMS enrollment schema) ######################
-SPECTACULAR_SETTINGS = {
-    'TITLE': 'LMS Enrollment API',
-    'VERSION': '0.1.0',
-    'SERVE_INCLUDE_SCHEMA': False,
-    'PREPROCESSING_HOOKS': ['lms.lib.spectacular.lms_api_filter'],
-    'SCHEMA_PATH_PREFIX': '/api/enrollment',
-    'SCHEMA_PATH_PREFIX_TRIM': '/api/enrollment',
-    'SERVERS': [
-        {'url': LMS_ROOT_URL, 'description': 'Local'},  # noqa: F405
-    ],
-}
+SPECTACULAR_SETTINGS['SERVERS'] = [  # noqa: F405
+    {'url': LMS_ROOT_URL, 'description': 'Local'},  # noqa: F405
+]
 
 #######################################################################################################################
 #### DERIVE ANY DERIVED SETTINGS

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -397,6 +397,19 @@ ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS = set(ENTERPRISE_EXCLUDED_REGISTRATION_F
 MIDDLEWARE.extend(_YAML_TOKENS.get('EXTRA_MIDDLEWARE_CLASSES', []))  # noqa: F405
 
 
+###################### drf-spectacular (LMS enrollment schema) ######################
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'LMS Enrollment API',
+    'VERSION': '0.1.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+    'PREPROCESSING_HOOKS': ['lms.lib.spectacular.lms_api_filter'],
+    'SCHEMA_PATH_PREFIX': '/api/enrollment',
+    'SCHEMA_PATH_PREFIX_TRIM': '/api/enrollment',
+    'SERVERS': [
+        {'url': LMS_ROOT_URL, 'description': 'Local'},  # noqa: F405
+    ],
+}
+
 #######################################################################################################################
 #### DERIVE ANY DERIVED SETTINGS
 ####

--- a/lms/lib/spectacular.py
+++ b/lms/lib/spectacular.py
@@ -1,0 +1,17 @@
+"""Helper functions for drf-spectacular (LMS schema)."""
+
+import re
+
+
+def lms_api_filter(endpoints):
+    """
+    Pre-processing hook: keep only enrollment v2 endpoints tagged for the SDK.
+    """
+    filtered = []
+    ENROLLMENT_PATH_PATTERN = re.compile(r"^/api/enrollment/v\d+/")
+
+    for path, path_regex, method, callback in endpoints:
+        if ENROLLMENT_PATH_PATTERN.match(path):
+            filtered.append((path, path_regex, method, callback))
+
+    return filtered

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -10,6 +10,7 @@ from django.contrib.admin import autodiscover as django_autodiscover
 from django.urls import include, path, re_path
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import RedirectView
+from drf_spectacular.views import SpectacularAPIView
 from edx_api_doc_tools import make_docs_urls
 from edx_django_utils.plugins import get_plugin_url_patterns
 from submissions import urls as submissions_urls
@@ -1067,4 +1068,9 @@ urlpatterns += [
 
 urlpatterns += [
     path('xqueue/', include((submissions_urls, 'submissions'), namespace='submissions')),
+]
+
+# LMS API schema for openedx-platform-sdk generation.
+urlpatterns += [
+    path('lms-api/schema/', SpectacularAPIView.as_view(), name='lms-schema'),
 ]

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -836,6 +836,7 @@ REST_FRAMEWORK = {
         'registration_validation': '30/minute',
         'high_service_user': '2000/minute',
     },
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
 # .. setting_name: REGISTRATION_VALIDATION_RATELIMIT


### PR DESCRIPTION
Adds drf-spectacular support to LMS so the openedx-platform-sdk can generate enrollment v2 API bindings from a proper LMS schema rather than mounting enrollment URLs in CMS as a workaround.

Changes:
- openedx/envs/common.py: add DEFAULT_SCHEMA_CLASS to REST_FRAMEWORK so drf-spectacular's AutoSchema is used across all LMS environments
- lms/envs/common.py: add drf_spectacular to INSTALLED_APPS
- lms/lib/spectacular.py: preprocessing hook that filters to enrollment v2 endpoints only (/api/enrollment/v\d+/)
- lms/envs/devstack.py, lms/envs/production.py: SPECTACULAR_SETTINGS with path prefix trim and enrollment-only title
- lms/urls.py: expose schema at /lms-api/schema/ via SpectacularAPIView
- cms/lib/spectacular.py: revert enrollment URL workaround (no longer needed)

related SDK PR: https://github.com/edly-io/openedx-platform-sdk/pull/1