### PR TITLE
fix: throttle cache key fixed for same scoped classes

### DIFF
--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -8,8 +8,9 @@ from unittest import TestCase
 
 import ddt
 import pytest
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
-from django.test import RequestFactory
+from django.test import RequestFactory, SimpleTestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from edx_django_utils.cache import RequestCache
@@ -33,7 +34,7 @@ from openedx.features.course_duration_limits.models import CourseDurationLimitCo
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from ..views import CourseDetailView, CourseListUserThrottle, LazyPageNumberPagination
+from ..views import CourseDetailView, CourseIdListUserThrottle, CourseListUserThrottle, LazyPageNumberPagination
 from .mixins import TEST_PASSWORD, CourseApiFactoryMixin
 
 
@@ -673,3 +674,48 @@ class LazyPageNumberPaginationTestCase(TestCase):  # pylint: disable=missing-cla
             paginated_queryset = pagination.paginate_queryset(even_numbers_lazy_sequence, request)
             pagination.get_paginated_response(paginated_queryset)
             assert 'Invalid page' in exc.exception
+
+
+@ddt.ddt
+class CourseThrottleCacheKeyTests(SimpleTestCase):
+    """
+    Regression tests ensuring the course list / id throttles each store their
+    rate-limit counters in isolated cache buckets, so they do not share a bucket
+    with each other or with other throttles using the same ``staff`` scope
+    (e.g. the enrollment API). See ``CourseListUserThrottle.get_cache_key``.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        # Unsaved instance is enough: get_cache_key only reads ``pk`` and
+        # ``is_authenticated``, so no database access is required.
+        self.user = get_user_model()(pk=42, username="service_worker", is_staff=True)
+
+    def _staff_request(self):
+        request = self.factory.get("/")
+        request.user = self.user
+        return request
+
+    @ddt.data(
+        (CourseListUserThrottle, "course_list."),
+        (CourseIdListUserThrottle, "course_id_list."),
+    )
+    @ddt.unpack
+    def test_cache_key_is_namespaced(self, throttle_class, expected_prefix):
+        throttle = throttle_class()
+        throttle.scope = "staff"
+        cache_key = throttle.get_cache_key(self._staff_request(), view=None)
+        assert cache_key.startswith(expected_prefix)
+
+    def test_throttles_with_same_scope_use_distinct_buckets(self):
+        request = self._staff_request()
+        keys = []
+        for throttle_class in (CourseListUserThrottle, CourseIdListUserThrottle):
+            throttle = throttle_class()
+            throttle.scope = "staff"
+            keys.append(throttle.get_cache_key(request, view=None))
+        # The raw, un-namespaced bucket these would otherwise share.
+        shared_bucket = CourseListUserThrottle.cache_format % {"scope": "staff", "ident": self.user.pk}
+        keys.append(shared_bucket)
+        assert len(set(keys)) == len(keys)

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -165,6 +165,14 @@ class CourseListUserThrottle(UserRateThrottle):
 
         return super().allow_request(request, view)
 
+    def get_cache_key(self, request, view):
+        # Namespace this throttle's cache key so it does not share a rate-limit
+        # bucket with other throttles that happen to use the same scope name.
+        cache_key = super().get_cache_key(request, view)
+        if cache_key:
+            cache_key = f"course_list.{cache_key}"
+        return cache_key
+
 
 class LazyPageNumberPagination(NamespacedPageNumberPagination):
     """
@@ -391,6 +399,14 @@ class CourseIdListUserThrottle(UserRateThrottle):
             self.num_requests, self.duration = self.parse_rate(self.rate)
 
         return super().allow_request(request, view)
+
+    def get_cache_key(self, request, view):
+        # Namespace this throttle's cache key so it does not share a rate-limit
+        # bucket with other throttles that use the same scope name.
+        cache_key = super().get_cache_key(request, view)
+        if cache_key:
+            cache_key = f"course_id_list.{cache_key}"
+        return cache_key
 
 
 @view_auth_classes()

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -14,10 +14,11 @@ import ddt
 import httpretty
 import pytest
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.core.handlers.wsgi import WSGIRequest
-from django.test import Client
+from django.test import Client, RequestFactory, SimpleTestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from freezegun import freeze_time
@@ -2028,3 +2029,42 @@ class EnrollmentAllowedViewTest(APITestCase):
         self.client.post(self.url, self.data)
         response = self.client.delete(self.url, delete_data)
         assert response.status_code == expected_result
+
+
+class EnrollmentUserThrottleCacheKeyTests(SimpleTestCase):
+    """
+    Regression tests ensuring ``EnrollmentUserThrottle`` stores its rate-limit
+    counter in an isolated cache bucket.
+
+    DRF's default cache key is ``throttle_{scope}_{ident}``. Several endpoints
+    (e.g. the course list / id APIs) also use a ``staff`` scope, so without a
+    per-throttle prefix a single service user's traffic to one endpoint would
+    consume the rate-limit allowance of the others. See
+    ``EnrollmentUserThrottle.get_cache_key``.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        # Unsaved instance is enough: get_cache_key only reads ``pk`` and
+        # ``is_authenticated``, so no database access is required.
+        self.user = get_user_model()(pk=42, username="service_worker", is_staff=True)
+
+    def _staff_request(self):
+        request = self.factory.get("/")
+        request.user = self.user
+        return request
+
+    def test_cache_key_is_prefixed_with_enrollment(self):
+        throttle = EnrollmentUserThrottle()
+        throttle.scope = "staff"
+        cache_key = throttle.get_cache_key(self._staff_request(), view=None)
+        assert cache_key.startswith("enrollment.")
+
+    def test_cache_key_differs_from_unprefixed_same_scope_bucket(self):
+        throttle = EnrollmentUserThrottle()
+        throttle.scope = "staff"
+        cache_key = throttle.get_cache_key(self._staff_request(), view=None)
+        shared_bucket = throttle.cache_format % {"scope": "staff", "ident": self.user.pk}
+        assert cache_key != shared_bucket
+        assert cache_key == f"enrollment.{shared_bucket}"

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -115,6 +115,14 @@ class EnrollmentUserThrottle(UserRateThrottle, ApiKeyPermissionMixIn):
 
         return self.has_api_key_permissions(request) or super().allow_request(request, view)
 
+    def get_cache_key(self, request, view):
+        # Namespace this throttle's cache key so it does not share a rate-limit
+        # bucket with other throttles that use the same scope name.
+        cache_key = super().get_cache_key(request, view)
+        if cache_key:
+            cache_key = f"enrollment.{cache_key}"
+        return cache_key
+
 
 @can_disable_rate_limit
 class EnrollmentView(APIView, ApiKeyPermissionMixIn):


### PR DESCRIPTION
## Description
This pull request introduces namespacing to the cache keys used by custom throttling classes in API views. By prefixing each throttle's cache key, it ensures that rate-limiting buckets are unique to each throttle, preventing unintended sharing of rate limits across different API endpoints that might use the same scope name.

**Improvements to throttling cache key namespacing:**

* Added a `get_cache_key` method to the custom throttle class in `lms/djangoapps/course_api/views.py` to prefix the cache key with `course_list.`, ensuring isolation of rate-limiting buckets for the course list API.
* Added a `get_cache_key` method to the custom throttle class in `lms/djangoapps/course_api/views.py` to prefix the cache key with `course_id_list.`, ensuring isolation of rate-limiting buckets for the course ID list API.
* Added a `get_cache_key` method to the custom throttle class in `openedx/core/djangoapps/enrollments/views.py` to prefix the cache key with `enrollment.`, ensuring isolation of rate-limiting buckets for the enrollment API.


## Supporting information
https://github.com/mitodl/hq/issues/11918 (MIT Internal)

## Testing instructions

1. Calling any API from following should not add throttle count for other API
    - /api/enrollment/v1/enrollment/
    - /api/courses/v1/courses/
    - /api/courses/v1/course_ids/
