### PR TITLE
fix: keep unmigrated legacy roles working under the authz authoring flag

### DIFF
--- a/cms/djangoapps/contentstore/asset_storage_handlers.py
+++ b/cms/djangoapps/contentstore/asset_storage_handlers.py
@@ -26,6 +26,7 @@ from openedx_authz.constants.permissions import (
 from openedx_filters.content_authoring.filters import LMSPageURLRequested
 from pymongo import ASCENDING, DESCENDING
 
+from common.djangoapps.student.roles import enable_authz_course_authoring
 from common.djangoapps.util.date_utils import get_default_time_display
 from common.djangoapps.util.json_request import JsonResponse
 from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
@@ -33,7 +34,6 @@ from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.models import UserPreference
-from openedx.core.toggles import enable_authz_course_authoring
 from xmodule.contentstore.content import StaticContent  # pylint: disable=wrong-import-order
 from xmodule.contentstore.django import contentstore  # pylint: disable=wrong-import-order
 from xmodule.exceptions import NotFoundError  # pylint: disable=wrong-import-order

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/course_waffle_flags.py
@@ -5,7 +5,7 @@ API Serializers for course waffle flags
 from rest_framework import serializers
 
 from cms.djangoapps.contentstore import toggles
-from openedx.core import toggles as core_toggles
+from common.djangoapps.student.roles import enable_authz_course_authoring
 
 
 class CourseWaffleFlagsSerializer(serializers.Serializer):
@@ -225,4 +225,4 @@ class CourseWaffleFlagsSerializer(serializers.Serializer):
         Method to get the authz.enable_course_authoring waffle flag
         """
         course_key = self.get_course_key()
-        return core_toggles.enable_authz_course_authoring(course_key)
+        return enable_authz_course_authoring(course_key)

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -15,7 +15,6 @@ from django.test.client import RequestFactory
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
-from openedx_authz.constants.roles import COURSE_EDITOR
 from organizations.api import add_organization, get_course_organizations, get_organization_by_short_name
 from organizations.exceptions import InvalidOrganizationException
 from organizations.models import Organization
@@ -386,96 +385,28 @@ class TestCourseListing(ModuleStoreTestCase):
             )
 
 
-class TestCourseHandlerAuthz(
-    CourseAuthoringAuthzTestMixin,
-    ModuleStoreTestCase,
-):
+class TestCourseHandlerStaffAccess(ModuleStoreTestCase):
     """
-    AuthZ integration tests for course_handler using real RBAC (no mocks).
+    Tests that global staff can create a course through course_handler with no
+    course-specific role, covering the GlobalStaff bypass in user_has_role. Course
+    creation doesn't check AuthZ (see ADR 0027), so this doesn't use the AuthZ mixin.
     """
 
     def setUp(self):
         super().setUp()
-
         self.url = reverse("course_handler")
+        self.staff_user = AdminFactory()
+        self.staff_client = AjaxEnabledTestClient()
+        self.staff_client.login(username=self.staff_user.username, password=self.TEST_PASSWORD)
 
-        # Create a base course to extract org
-        self.course = CourseFactory.create()
-        self.course_key = self.course.id
-        self.org = self.course_key.org
-
-        # If your policy expects this format, keep it
-        self.org_key = f"course-v1:{self.org}+*"
-
-        self.authorized_client = AjaxEnabledTestClient()
-        self.authorized_client.login(
-            username=self.authorized_user.username,
-            password=self.password,
-        )
-
-        self.unauthorized_client = AjaxEnabledTestClient()
-        self.unauthorized_client.login(
-            username=self.unauthorized_user.username,
-            password=self.password,
-        )
-        self.authorized_staff_client = AjaxEnabledTestClient()
-        self.authorized_staff_client.login(
-            username=self.staff_user.username,
-            password=self.password,
-        )
-
-    # ------------------------------------------------------------
-    # CREATE COURSE -- Non-staff users and existing Organization
-    # ------------------------------------------------------------
-    @override_settings(DISABLE_COURSE_CREATION=False)
-    def test_create_course_unauthorized(self):
-        """
-        User without role cannot create course.
-        """
-
-        response = self.unauthorized_client.ajax_post(self.url, {
-            "org": self.org,
-            "number": "CS101",
-            "display_name": "Authz Course",
-            "run": "2026_T1",
-        })
-
-        assert response.status_code == 403
-
-    @override_settings(DISABLE_COURSE_CREATION=False)
-    def test_create_course_unauthorized_with_role(self):
-        """
-        User with role but without required permission cannot create course.
-        """
-
-        self.add_user_to_role_in_course(
-            self.unauthorized_user,
-            COURSE_EDITOR.external_key,
-            "course-v1:someotherorg+*",
-        )
-
-        response = self.unauthorized_client.ajax_post(self.url, {
-            "org": self.org,
-            "number": "CS101",
-            "display_name": "Authz Course",
-            "run": "2026_T1",
-        })
-
-        assert response.status_code == 403
-
-    # ------------------------------------------------------------
-    # CREATE COURSE -- Staff users
-    # Only staff users can create course, and they can do it
-    # without an org role.
-    # ------------------------------------------------------------
     def test_create_course_staff(self):
         """
-        Staff user can create course.
+        Staff user can create a course with no prior course-specific role.
         """
-        response = self.authorized_staff_client.ajax_post(self.url, {
-            "org": self.org,
+        response = self.staff_client.ajax_post(self.url, {
+            "org": "StaffOrg",
             "number": "CS101",
-            "display_name": "Authz Course",
+            "display_name": "Staff Course",
             "run": "2026_T1",
         })
 

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -481,24 +481,6 @@ class TestCourseHandlerAuthz(
 
         assert response.status_code == 200
 
-    # ------------------------------------------------------------
-    # FEATURE FLAG
-    # ------------------------------------------------------------
-    @override_settings(DISABLE_COURSE_CREATION=True)
-    def test_create_course_disabled_by_flag(self):
-        """
-        Even authorized users cannot create course if feature flag is off.
-        """
-
-        response = self.authorized_staff_client.ajax_post(self.url, {
-            "org": self.org,
-            "number": "CS101",
-            "display_name": "Authz Course",
-            "run": "2026_T1",
-        })
-
-        assert response.status_code == 403
-
 
 class TestCourseRerunAuthz(
     CourseAuthoringAuthzTestMixin,

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -13,6 +13,7 @@ from django.http import HttpRequest
 from django.test import override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_flag
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
 from organizations.api import add_organization, get_course_organizations, get_organization_by_short_name
@@ -33,6 +34,7 @@ from common.djangoapps.student.models import CourseAccessRole
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, OrgContentCreatorRole
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
 from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
+from openedx.core.toggles import AUTHZ_COURSE_AUTHORING_FLAG
 from xmodule.course_block import CourseFields
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -385,6 +387,7 @@ class TestCourseListing(ModuleStoreTestCase):
             )
 
 
+@ddt.ddt
 class TestCourseHandlerStaffAccess(ModuleStoreTestCase):
     """
     Tests that global staff can create a course through course_handler with no
@@ -399,16 +402,19 @@ class TestCourseHandlerStaffAccess(ModuleStoreTestCase):
         self.staff_client = AjaxEnabledTestClient()
         self.staff_client.login(username=self.staff_user.username, password=self.TEST_PASSWORD)
 
-    def test_create_course_staff(self):
+    @ddt.data(True, False)
+    def test_create_course_staff(self, authz_enabled):
         """
-        Staff user can create a course with no prior course-specific role.
+        Staff user can create a course with no prior course-specific role, whether
+        the AuthZ course-authoring flag is on or off.
         """
-        response = self.staff_client.ajax_post(self.url, {
-            "org": "StaffOrg",
-            "number": "CS101",
-            "display_name": "Staff Course",
-            "run": "2026_T1",
-        })
+        with override_waffle_flag(AUTHZ_COURSE_AUTHORING_FLAG, active=authz_enabled):
+            response = self.staff_client.ajax_post(self.url, {
+                "org": "StaffOrg",
+                "number": "CS101",
+                "display_name": "Staff Course",
+                "run": "2026_T1",
+            })
 
         assert response.status_code == 200
 

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -858,7 +858,7 @@ def _get_course_keys_from_platform_scope() -> set[CourseKey]:
     if core_toggles.AUTHZ_COURSE_AUTHORING_FLAG.is_enabled():
         return set(course_keys)
 
-    return {course_key for course_key in course_keys if core_toggles.enable_authz_course_authoring(course_key)}
+    return {course_key for course_key in course_keys if enable_authz_course_authoring(course_key)}
 
 
 def _get_course_keys_from_scopes(authz_scopes: list[ScopeData]) -> set[CourseKey]:

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1345,7 +1345,7 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
     # is implemented (pre-assigning roles without a CourseOverview). Once resolved,
     # add_instructor can be called unconditionally here and the created_user fallback
     # in get_in_process_course_actions can be removed.
-    if not core_toggles.enable_authz_course_authoring(destination_course_key):
+    if not enable_authz_course_authoring(destination_course_key):
         add_instructor(destination_course_key, user, user)
 
     # Mark the action as initiated

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -74,6 +74,7 @@ from common.djangoapps.student.roles import (
     GlobalStaff,
     OrgStaffRole,
     UserBasedRole,
+    enable_authz_course_authoring,
     strict_role_checking,
 )
 from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadRequest, expect_json
@@ -888,7 +889,7 @@ def _get_course_keys_from_scopes(authz_scopes: list[ScopeData]) -> set[CourseKey
 
     for access in authz_scopes:
         if isinstance(access, CourseOverviewData) and access.course_key:
-            if core_toggles.enable_authz_course_authoring(access.course_key):
+            if enable_authz_course_authoring(access.course_key):
                 course_keys.add(access.course_key)
         elif isinstance(access, OrgCourseOverviewGlobData) and access.org:
             org_keys.add(access.org)
@@ -896,7 +897,7 @@ def _get_course_keys_from_scopes(authz_scopes: list[ScopeData]) -> set[CourseKey
     if org_keys:
         course_keys.update(
             key for key in _get_course_keys_for_org_scope(org_keys)
-            if core_toggles.enable_authz_course_authoring(key)
+            if enable_authz_course_authoring(key)
         )
 
     return course_keys

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -26,6 +26,7 @@ from common.djangoapps.student.roles import (
     OrgInstructorRole,
     OrgLibraryUserRole,
     OrgStaffRole,
+    enable_authz_course_authoring,
     strict_role_checking,
 )
 from openedx.core import toggles as core_toggles
@@ -244,8 +245,11 @@ def is_content_creator(user, org):
         - When AuthZ is disabled, this falls back to legacy Django role checks.
         - Course creation may still be blocked by global feature flags (e.g.,
           DISABLE_COURSE_CREATION), which are enforced downstream.
+        - course_creator_group has no migrated AuthZ equivalent yet (see ADR 0027), so
+          role=CourseCreatorRole.ROLE keeps this on the legacy path even when the AuthZ flag
+          is enabled.
     """
-    if core_toggles.AUTHZ_COURSE_AUTHORING_FLAG.is_enabled():
+    if enable_authz_course_authoring(role=CourseCreatorRole.ROLE):
         return _has_content_creator_access(user, org)
     return _has_legacy_content_creator_access(user, org)
 

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from opaque_keys.edx.locator import LibraryLocator
 from openedx_authz import api as authz_api
-from openedx_authz.constants.permissions import COURSES_CREATE_COURSE, COURSES_MANAGE_ADVANCED_SETTINGS
+from openedx_authz.constants.permissions import COURSES_MANAGE_ADVANCED_SETTINGS
 
 from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
@@ -26,7 +26,6 @@ from common.djangoapps.student.roles import (
     OrgInstructorRole,
     OrgLibraryUserRole,
     OrgStaffRole,
-    enable_authz_course_authoring,
     strict_role_checking,
 )
 from openedx.core import toggles as core_toggles
@@ -228,9 +227,9 @@ def is_content_creator(user, org):
     """
     Determine whether a user is allowed to create course content for a given organization.
 
-    This function abstracts the permission check for course creation. Depending on the
-    state of the AuthZ feature flag, it delegates the evaluation to either the AuthZ-based
-    RBAC system or the legacy role-based permission system.
+    Neither CourseCreatorRole nor OrgContentCreatorRole has a migrated AuthZ equivalent yet
+    (see ADR 0027), so this always checks the legacy role-based permission system. Once
+    either role gets a migrated equivalent, this should also check AuthZ, gated on that role.
 
     Args:
         user (User): The user whose permissions are being evaluated.
@@ -239,39 +238,8 @@ def is_content_creator(user, org):
     Returns:
         bool: True if the user has permission to create course content in the given
         organization, False otherwise.
-
-    Notes:
-        - When AuthZ is enabled, this checks permissions via RBAC policies.
-        - When AuthZ is disabled, this falls back to legacy Django role checks.
-        - Course creation may still be blocked by global feature flags (e.g.,
-          DISABLE_COURSE_CREATION), which are enforced downstream.
-        - course_creator_group has no migrated AuthZ equivalent yet (see ADR 0027), so
-          role=CourseCreatorRole.ROLE keeps this on the legacy path even when the AuthZ flag
-          is enabled.
     """
-    if enable_authz_course_authoring(role=CourseCreatorRole.ROLE):
-        return _has_content_creator_access(user, org)
     return _has_legacy_content_creator_access(user, org)
-
-
-def _has_content_creator_access(user, org):
-    """
-    Check if the user has content creator access based on AuthZ permissions.
-
-    Returns:
-        bool: True if the user has platform-wide or org-scoped course creation permission.
-    """
-    if getattr(settings, 'DISABLE_COURSE_CREATION', False):
-        return False
-
-    scope_keys = (
-        authz_api.PlatformCourseOverviewGlobData.build_external_key(),
-        authz_api.OrgCourseOverviewGlobData.build_external_key(org),
-    )
-    return any(
-        authz_api.is_user_allowed(user.username, COURSES_CREATE_COURSE.identifier, scope_key)
-        for scope_key in scope_keys
-    )
 
 
 def _has_legacy_content_creator_access(user, org):

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -21,7 +21,7 @@ from openedx_authz.constants import roles as authz_roles
 from common.djangoapps.student.models import CourseAccessRole
 from common.djangoapps.student.signals.signals import emit_course_access_role_added, emit_course_access_role_removed
 from openedx.core.lib.cache_utils import get_cache
-from openedx.core.toggles import enable_authz_course_authoring
+from openedx.core.toggles import AUTHZ_COURSE_AUTHORING_FLAG
 
 log = logging.getLogger(__name__)
 
@@ -41,6 +41,24 @@ def get_authz_role_from_legacy_role(legacy_role: str) -> str:
 
 def get_legacy_role_from_authz_role(authz_role: str) -> str:
     return next((k for k, v in authz_roles.LEGACY_COURSE_ROLE_EQUIVALENCES.items() if v == authz_role), None)
+
+
+def enable_authz_course_authoring(course_key: CourseKey | None = None, role: str | None = None) -> bool:
+    """
+    True only if the authz.enable_course_authoring waffle flag is enabled and, when `role` is
+    given, that role has a migrated authz equivalent.
+
+    The migration only covers a subset of legacy roles (see LEGACY_COURSE_ROLE_EQUIVALENCES
+    and ADR 0027), so an unmigrated role must keep resolving to the legacy path even with the
+    flag on. Most callers have no specific role in scope and can omit `role`. Pass it when
+    acting on a specific legacy role, so a role like course_creator_group falls back to legacy
+    instead of crashing or being denied by authz (see openedx-authz#353, #354).
+    """
+    if not AUTHZ_COURSE_AUTHORING_FLAG.is_enabled(course_key):
+        return False
+    if role is not None and get_authz_role_from_legacy_role(role) is None:
+        return False
+    return True
 
 
 def authz_add_role(user: User, authz_role: str, course_key: str):
@@ -520,7 +538,7 @@ class RoleBase(AccessRole):
         """
         Add the supplied django users to this role.
         """
-        if enable_authz_course_authoring(self.course_key):
+        if enable_authz_course_authoring(self.course_key, role=self._role_name):
             self._authz_add_users(users)
         else:
             self._legacy_add_users(users)
@@ -561,7 +579,7 @@ class RoleBase(AccessRole):
         """
         Remove the supplied django users from this role.
         """
-        if enable_authz_course_authoring(self.course_key):
+        if enable_authz_course_authoring(self.course_key, role=self._role_name):
             self._authz_remove_users(users)
         else:
             self._legacy_remove_users(users)
@@ -599,7 +617,7 @@ class RoleBase(AccessRole):
         """
         Return a django QuerySet for all of the users with this role
         """
-        if enable_authz_course_authoring(self.course_key):
+        if enable_authz_course_authoring(self.course_key, role=self._role_name):
             return self._authz_users_with_role()
         else:
             return self._legacy_users_with_role()
@@ -628,7 +646,7 @@ class RoleBase(AccessRole):
         """
         Returns a list of org short names for the user with given role.
         """
-        if enable_authz_course_authoring(self.course_key):
+        if enable_authz_course_authoring(self.course_key, role=self._role_name):
             return self._authz_get_orgs_for_user(user)
         else:
             return self._legacy_get_orgs_for_user(user)
@@ -642,7 +660,7 @@ class RoleBase(AccessRole):
             org: optional org to check against access to role,
                 if not specified, will return True if the user has access to at least one org
         """
-        if enable_authz_course_authoring(self.course_key):
+        if enable_authz_course_authoring(self.course_key, role=self._role_name):
             orgs_with_role = self.get_orgs_for_user(user)
             if org:
                 return org in orgs_with_role

--- a/common/djangoapps/student/tests/test_authz.py
+++ b/common/djangoapps/student/tests/test_authz.py
@@ -9,12 +9,14 @@ from ccx_keys.locator import CCXLocator
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase, override_settings
+from edx_toggles.toggles.testutils import override_waffle_flag
 from opaque_keys.edx.locator import CourseLocator
 
 from common.djangoapps.student.auth import (
     add_users,
     has_studio_read_access,
     has_studio_write_access,
+    is_content_creator,
     remove_users,
     update_org_role,
     user_has_role,
@@ -28,6 +30,7 @@ from common.djangoapps.student.roles import (
     OrgContentCreatorRole,
 )
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
+from openedx.core.toggles import AUTHZ_COURSE_AUTHORING_FLAG
 
 
 class CreatorGroupTest(TestCase):
@@ -75,6 +78,42 @@ class CreatorGroupTest(TestCase):
         # remove first user from the group and verify that CourseCreatorRole().has_user now returns false
         remove_users(self.admin, CourseCreatorRole(), self.user)
         assert not user_has_role(self.user, CourseCreatorRole())
+
+    @override_waffle_flag(AUTHZ_COURSE_AUTHORING_FLAG, active=True)
+    def test_is_content_creator_true_for_legacy_grant_with_authz_flag_enabled(self):
+        """
+        Tests that a legacy course creator grant still authorizes course creation when the
+        AuthZ course-authoring flag is enabled.
+        """
+        with mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_CREATOR_GROUP": True}):
+            add_users(self.admin, CourseCreatorRole(), self.user)
+
+            result = is_content_creator(self.user, "TestOrg")
+
+            assert result
+
+    @override_waffle_flag(AUTHZ_COURSE_AUTHORING_FLAG, active=True)
+    def test_creator_group_add_and_remove_users_bypass_authz_writes(self):
+        """
+        Tests that add_users/remove_users for course_creator_group write to the legacy table
+        and never call the AuthZ write API, even when the AuthZ flag is enabled.
+        """
+        role = CourseCreatorRole()
+
+        with mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_CREATOR_GROUP": True}):
+            with mock.patch("common.djangoapps.student.roles.authz_add_role") as mock_authz_add_role:
+                add_users(self.admin, role, self.user)
+
+            assert user_has_role(self.user, role)
+            mock_authz_add_role.assert_not_called()
+
+            with mock.patch(
+                "common.djangoapps.student.roles.authz_api.batch_unassign_role_from_users"
+            ) as mock_authz_unassign:
+                remove_users(self.admin, role, self.user)
+
+            assert not user_has_role(self.user, role)
+            mock_authz_unassign.assert_not_called()
 
     @override_settings(ENABLE_CREATOR_GROUP=True, DISABLE_COURSE_CREATION=True)
     def test_course_creation_disabled(self):
@@ -345,4 +384,16 @@ class CourseOrgGroupTest(TestCase):
         """
         assert not user_has_role(self.user, OrgContentCreatorRole(self.org))
         update_org_role(self.global_admin, OrgContentCreatorRole, self.user, [self.org])
+        assert user_has_role(self.user, OrgContentCreatorRole(self.org))
+
+    @override_waffle_flag(AUTHZ_COURSE_AUTHORING_FLAG, active=True)
+    def test_update_org_role_permission_survives_authz_flag(self):
+        """
+        Tests that granting org_course_creator_group still works through the legacy path
+        when the AuthZ course-authoring flag is enabled.
+        """
+        assert not user_has_role(self.user, OrgContentCreatorRole(self.org))
+
+        update_org_role(self.global_admin, OrgContentCreatorRole, self.user, [self.org])
+
         assert user_has_role(self.user, OrgContentCreatorRole(self.org))

--- a/common/djangoapps/student/tests/test_authz.py
+++ b/common/djangoapps/student/tests/test_authz.py
@@ -80,19 +80,20 @@ class CreatorGroupTest(TestCase):
         assert not user_has_role(self.user, CourseCreatorRole())
 
     @override_waffle_flag(AUTHZ_COURSE_AUTHORING_FLAG, active=True)
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_is_content_creator_true_for_legacy_grant_with_authz_flag_enabled(self):
         """
         Tests that a legacy course creator grant still authorizes course creation when the
         AuthZ course-authoring flag is enabled.
         """
-        with mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_CREATOR_GROUP": True}):
-            add_users(self.admin, CourseCreatorRole(), self.user)
+        add_users(self.admin, CourseCreatorRole(), self.user)
 
-            result = is_content_creator(self.user, "TestOrg")
+        result = is_content_creator(self.user, "TestOrg")
 
-            assert result
+        assert result
 
     @override_waffle_flag(AUTHZ_COURSE_AUTHORING_FLAG, active=True)
+    @override_settings(ENABLE_CREATOR_GROUP=True)
     def test_creator_group_add_and_remove_users_bypass_authz_writes(self):
         """
         Tests that add_users/remove_users for course_creator_group write to the legacy table
@@ -100,20 +101,19 @@ class CreatorGroupTest(TestCase):
         """
         role = CourseCreatorRole()
 
-        with mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_CREATOR_GROUP": True}):
-            with mock.patch("common.djangoapps.student.roles.authz_add_role") as mock_authz_add_role:
-                add_users(self.admin, role, self.user)
+        with mock.patch("common.djangoapps.student.roles.authz_add_role") as mock_authz_add_role:
+            add_users(self.admin, role, self.user)
 
-            assert user_has_role(self.user, role)
-            mock_authz_add_role.assert_not_called()
+        assert user_has_role(self.user, role)
+        mock_authz_add_role.assert_not_called()
 
-            with mock.patch(
-                "common.djangoapps.student.roles.authz_api.batch_unassign_role_from_users"
-            ) as mock_authz_unassign:
-                remove_users(self.admin, role, self.user)
+        with mock.patch(
+            "common.djangoapps.student.roles.authz_api.batch_unassign_role_from_users"
+        ) as mock_authz_unassign:
+            remove_users(self.admin, role, self.user)
 
-            assert not user_has_role(self.user, role)
-            mock_authz_unassign.assert_not_called()
+        assert not user_has_role(self.user, role)
+        mock_authz_unassign.assert_not_called()
 
     @override_settings(ENABLE_CREATOR_GROUP=True, DISABLE_COURSE_CREATION=True)
     def test_course_creation_disabled(self):

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -30,6 +30,7 @@ from common.djangoapps.student.roles import (
     AuthzCompatCourseAccessRole,
     CourseAccessRole,
     CourseBetaTesterRole,
+    CourseCreatorRole,
     CourseDataResearcherRole,
     CourseFinanceAdminRole,
     CourseInstructorRole,
@@ -235,6 +236,28 @@ class RolesTestCase(TestCase):
             role.add_users(self.student)
             role.remove_users(self.student)
             assert not role.has_user(self.student)
+
+    @override_waffle_flag(AUTHZ_COURSE_AUTHORING_FLAG, active=True)
+    def test_add_and_remove_users_falls_back_to_legacy_for_unmigrated_role(self):
+        """
+        Tests that add_users/remove_users fall back to the legacy path for an unmigrated
+        role (course_creator_group), instead of writing to AuthZ, even with the flag enabled.
+        """
+        role = CourseCreatorRole()
+
+        with patch("common.djangoapps.student.roles.authz_add_role") as mock_authz_add_role:
+            role.add_users(self.student)
+
+        assert role.has_user(self.student)
+        mock_authz_add_role.assert_not_called()
+
+        with patch(
+            "common.djangoapps.student.roles.authz_api.batch_unassign_role_from_users"
+        ) as mock_authz_unassign:
+            role.remove_users(self.student)
+
+        assert not role.has_user(self.student)
+        mock_authz_unassign.assert_not_called()
 
     def test_get_orgs_for_user(self):
         """

--- a/docs/decisions/0027-dual-path-course-authoring-migration.rst
+++ b/docs/decisions/0027-dual-path-course-authoring-migration.rst
@@ -39,6 +39,8 @@ Consequences
 
 - This is meant as a stopgap, not a permanent shape for the code. Once every legacy role has an authz equivalent, the role check, and eventually the flag itself, can be removed.
 
+- Course creation itself (``is_content_creator``) skips this check entirely and always uses the course creator role directly, since neither role has an authz equivalent yet. It'll need updating once openedx-authz supports the role.
+
 References
 **********
 

--- a/docs/decisions/0027-dual-path-course-authoring-migration.rst
+++ b/docs/decisions/0027-dual-path-course-authoring-migration.rst
@@ -1,0 +1,46 @@
+Dual Code Paths During Course-Authoring AuthZ Migration
+#########################################################
+
+**Status**: Accepted
+**Date**: 2026-07-07
+
+-----
+
+Context
+*******
+
+``AUTHZ_COURSE_AUTHORING_FLAG`` gates the migration from legacy ``CourseAccessRole`` to openedx-authz. That migration is not finished yet since only some legacy roles have an authz equivalent so far (see ``LEGACY_COURSE_ROLE_EQUIVALENCES`` in openedx-authz and its ADR 0011). ``course_creator_group`` and ``org_course_creator_group`` don't have one yet.
+
+When first implemented, the code deciding whether to use authz or legacy only looked at the waffle flag. It never checked whether the specific role being handled had actually been migrated. With the flag on, this broke course creation for those two roles. We observed it two ways:
+
+- Granting course creator access through Django admin crashed with a 500 (`openedx-authz#353 <https://github.com/openedx/openedx-authz/issues/353>`_).
+- A user with an existing legacy course creator grant got a 403 on course creation (`openedx-authz#354 <https://github.com/openedx/openedx-authz/issues/354>`_).
+
+Both trace back to the same root cause - the code was trying to use authz for a role that doesn't have an authz equivalent yet.
+
+Decision
+********
+
+``enable_authz_course_authoring`` now takes an optional ``role`` argument to contextualize the decision. If a role is passed in, the function checks whether that role has an authz equivalent:
+
+- When that role has no migrated authz equivalent, the function returns false and sticks to the legacy path, no matter what the flag says.
+- When that role has an authz equivalent, the function returns the flag's value, as before.
+
+Callers that act on a specific role, like granting or revoking it, should pass that role in to get the correct behavior. Callers that don't care about a specific role, like generic permission checks, can leave it out and just follow the flag as before.
+
+The role check only runs when the flag is on, since the function returns early otherwise. When the flag is off, it always returns false and never evaluates the role.
+
+Consequences
+************
+
+- Roles without an authz equivalent keep working once the flag is on, instead of crashing or being denied access. Callers that don't need role-level distinction don't pay any extra cost, since ``role`` is optional and defaults to the old behavior.
+
+- The main risk is a future caller that acts on a specific role but forgets to pass it in. That would quietly bring back the exact bug this decision fixes, so new callers touching a specific role need to remember this.
+
+- This is meant as a stopgap, not a permanent shape for the code. Once every legacy role has an authz equivalent, the role check, and eventually the flag itself, can be removed.
+
+References
+**********
+
+* `openedx-authz ADR 0011 <https://docs.openedx.org/projects/openedx-authz/en/latest/decisions/0011-course-authoring-migration-process.html>`_ (role mapping table).
+* ``common/djangoapps/student/roles.py``: ``enable_authz_course_authoring``, ``get_authz_role_from_legacy_role``.

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -33,6 +33,7 @@ from common.djangoapps.student.roles import (
     OrgInstructorRole,
     OrgStaffRole,
     SupportStaffRole,
+    enable_authz_course_authoring,
 )
 from common.djangoapps.util import (  # pylint: disable=useless-import-alias
     milestones_helpers as milestones_helpers,
@@ -64,7 +65,6 @@ from lms.djangoapps.courseware.access_utils import (
 from lms.djangoapps.courseware.masquerade import get_masquerade_role, is_masquerading_as_student
 from lms.djangoapps.courseware.toggles import course_is_invitation_only
 from lms.djangoapps.mobile_api.models import IgnoreMobileAvailableFlagConfig
-from openedx.core import toggles as core_toggles
 from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
 from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -484,7 +484,7 @@ def _has_access_course(user, action, courselike):
         if (
             user
             and not user.is_anonymous
-            and core_toggles.enable_authz_course_authoring(courselike.id)
+            and enable_authz_course_authoring(courselike.id)
             and user_has_course_permission(
                 user, COURSES_VIEW_COURSE.identifier, courselike.id, LegacyAuthoringPermission.READ
             )

--- a/openedx/core/djangoapps/authz/decorators.py
+++ b/openedx/core/djangoapps/authz/decorators.py
@@ -9,7 +9,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from openedx_authz import api as authz_api
 from rest_framework import status
 
-from openedx.core import toggles as core_toggles
+from common.djangoapps.student.roles import enable_authz_course_authoring
 from openedx.core.djangoapps.authz.constants import LEGACY_PERMISSION_HANDLER_MAP, LegacyAuthoringPermission
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 
@@ -66,7 +66,7 @@ def user_has_course_permission(
     Checks if the user has the specified AuthZ permission for the course,
     with optional fallback to legacy permissions.
     """
-    if core_toggles.enable_authz_course_authoring(course_key):
+    if enable_authz_course_authoring(course_key):
         # If AuthZ is enabled for this course, check the permission via AuthZ only.
         is_user_allowed = authz_api.is_user_allowed(user.username, authz_permission, str(course_key))
         log.info(

--- a/openedx/core/djangoapps/authz/tests/test_decorators.py
+++ b/openedx/core/djangoapps/authz/tests/test_decorators.py
@@ -57,7 +57,7 @@ class AuthzPermissionRequiredDecoratorTests(TestCase):
         mock_view = Mock(return_value="success")
 
         with patch(
-            "openedx.core.djangoapps.authz.decorators.core_toggles.enable_authz_course_authoring",
+            "openedx.core.djangoapps.authz.decorators.enable_authz_course_authoring",
             return_value=False,
         ), patch(
             "openedx.core.djangoapps.authz.decorators.authz_api.is_user_allowed",
@@ -83,7 +83,7 @@ class AuthzPermissionRequiredDecoratorTests(TestCase):
         mock_view = Mock(return_value="success")
 
         with patch(
-            "openedx.core.djangoapps.authz.decorators.core_toggles.enable_authz_course_authoring",
+            "openedx.core.djangoapps.authz.decorators.enable_authz_course_authoring",
             return_value=False,
         ), patch(
             "openedx.core.djangoapps.authz.decorators.authz_api.is_user_allowed",

--- a/openedx/core/djangoapps/content_tagging/auth.py
+++ b/openedx/core/djangoapps/content_tagging/auth.py
@@ -9,7 +9,7 @@ from openedx_authz import api as authz_api
 from openedx_authz.constants.permissions import COURSES_EXPORT_TAGS
 from openedx_tagging import rules as oel_tagging_rules
 
-from openedx.core import toggles as core_toggles
+from common.djangoapps.student.roles import enable_authz_course_authoring
 
 from .utils import get_context_key_from_key_string
 
@@ -30,7 +30,7 @@ def has_view_object_tags_access(user, object_id):
     except InvalidKeyError:
         pass
 
-    if course_key and core_toggles.enable_authz_course_authoring(course_key):
+    if course_key and enable_authz_course_authoring(course_key):
         return authz_api.is_user_allowed(
             user.username, COURSES_EXPORT_TAGS.identifier, str(course_key)
         )
@@ -66,7 +66,7 @@ def should_use_course_authz_for_object(object_id) -> tuple[bool, CourseKey | Non
         return False, None
 
     # Check if toggle is active
-    if not core_toggles.enable_authz_course_authoring(context_key):
+    if not enable_authz_course_authoring(context_key):
         return False, None
 
     # Authz should be used for this course object

--- a/openedx/core/djangoapps/discussions/permissions.py
+++ b/openedx/core/djangoapps/discussions/permissions.py
@@ -9,9 +9,13 @@ from openedx_authz.constants.permissions import (
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import BasePermission
 
-from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, GlobalStaff
+from common.djangoapps.student.roles import (
+    CourseInstructorRole,
+    CourseStaffRole,
+    GlobalStaff,
+    enable_authz_course_authoring,
+)
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
-from openedx.core import toggles as core_toggles
 from openedx.core.lib.api.view_utils import validate_course_key
 
 DEFAULT_MESSAGE = "You're not authorized to perform this operation."
@@ -47,7 +51,7 @@ class HasPagesAndResourcesAccess(BasePermission):
         course_key_string = view.kwargs.get('course_key_string')
         course_key = validate_course_key(course_key_string)
 
-        if core_toggles.enable_authz_course_authoring(course_key):
+        if enable_authz_course_authoring(course_key):
             if request.method == 'GET':
                 authz_perm = COURSES_VIEW_PAGES_AND_RESOURCES.identifier
             else:

--- a/openedx/core/toggles.py
+++ b/openedx/core/toggles.py
@@ -28,10 +28,3 @@ ENTRANCE_EXAMS = SettingToggle(
 # .. toggle_target_removal_date: 2027-06-09
 # .. toggle_tickets: https://github.com/openedx/openedx-platform/issues/37927
 AUTHZ_COURSE_AUTHORING_FLAG = CourseWaffleFlag('authz.enable_course_authoring', __name__)
-
-
-def enable_authz_course_authoring(course_key):
-    """
-    Returns a boolean if the AuthZ for course authoring feature is enabled for the given course.
-    """
-    return AUTHZ_COURSE_AUTHORING_FLAG.is_enabled(course_key)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Granting and exercising course creator access crashed once the waffle flag `authz.enable_course_authoring` was on. The `courses.create_course` permission was implemented in AuthZ, but the course creator role itself was never migrated there. The code deciding whether to use the AuthZ path only checked the flag's state, not whether the specific role had actually been migrated, so unmigrated roles like course creator still used the AuthZ path and crashed. `enable_authz_course_authoring` now takes an optional role and falls back to the course creator role's own check for any role without a migrated AuthZ equivalent, regardless of the flag. See [ADR 0027](https://github.com/openedx/openedx-platform/blob/80d3f4598af5e599c968f6f82610b4fce4bb9b2f/docs/decisions/0027-dual-path-course-authoring-migration.rst) for details.

## Supporting information

Fixes https://github.com/openedx/openedx-authz/issues/353
Fixes https://github.com/openedx/openedx-authz/issues/354
Related previous PR introducing `course.create_course`: https://github.com/openedx/openedx-platform/pull/38259

## Testing instructions

### openedx-authz#353 (500 on granting course creator via Django admin)

1. Enable the `authz.enable_course_authoring` waffle flag.
2. Log in to Studio as a user with no course creator access, and request it from Studio.
3. Log in as a Django admin, go to `/admin/course_creators/coursecreator/<id>/change/`.
4. Set the request to Granted and save.
5. Before this fix a 500 error (`InvalidKeyError` trying to parse `course_key=None`) was raised.

### openedx-authz#354 (403 on course creation despite a legacy grant)

1. With the flag still on, grant a non-admin user course creator access for all organizations via Django admin (`/admin/course_creators/coursecreator/`).
2. Log in to Studio as that user, open the New Course form, fill it in, and submit.
3. Before this fix, `POST /course/` returns 403 (`User does not have the permission to create courses in this organization or course creation is disabled`).


## Deadline

Verawood since it's a release blocker

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
