### PR TITLE
fix: only auto-submit SSO registration form when provider returns an email

### DIFF
--- a/openedx/core/djangoapps/user_authn/api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/api/tests/test_views.py
@@ -176,6 +176,30 @@ class MFEContextViewTest(ThirdPartyAuthTestMixin, APITestCase):
         assert response.status_code == 200
         assert response.data == self.get_context(params, current_provider, current_backend, add_user_details)
 
+    @ddt.data(
+        ('test@test.com', True),
+        (None, False),
+    )
+    @ddt.unpack
+    def test_skip_registration_form_requires_email(self, email, expect_auto_submit):
+        """
+        Regression test for openedx/edx-platform#38780.
+
+        "Skip registration form" should only auto-submit the registration form when the
+        third-party provider actually returned an email claim. Some providers (e.g. Facebook,
+        Microsoft Entra ID) can complete authentication without an email, and blindly
+        auto-submitting in that case silently fails client-side validation in the authn MFE,
+        leaving the learner stuck on a partially-filled form with no explanation.
+        """
+        self.configure_facebook_provider(enabled=True, visible=True, skip_registration_form=True)
+
+        pipeline_target = 'openedx.core.djangoapps.user_authn.views.login_form.third_party_auth.pipeline'
+        with simulate_running_pipeline(pipeline_target, 'facebook', email=email):
+            response = self.client.get(self.url, self.query_params)
+
+        assert response.status_code == 200
+        assert response.data['contextData']['autoSubmitRegForm'] == expect_auto_submit
+
     def test_tpa_hint(self):
         """
         Test that if tpa_hint is provided, the context returns the third party auth provider

--- a/openedx/core/djangoapps/user_authn/views/utils.py
+++ b/openedx/core/djangoapps/user_authn/views/utils.py
@@ -93,8 +93,13 @@ def third_party_auth_context(request, redirect_to, tpa_hint=None):
                 context["finishAuthUrl"] = pipeline.get_complete_url(current_provider.backend_name)
                 context["syncLearnerProfileData"] = current_provider.sync_learner_profile_data
 
-                if current_provider.skip_registration_form:
-                    # As a reliable way of "skipping" the registration form, we just submit it automatically
+                if current_provider.skip_registration_form and (user_details or {}).get('email'):
+                    # As a reliable way of "skipping" the registration form, we just submit it automatically.
+                    # Only do this when the provider actually gave us an email: some providers (e.g. Facebook,
+                    # Microsoft Entra ID) can complete authentication without returning an email claim, and
+                    # auto-submitting in that case silently fails client-side validation, leaving the learner
+                    # stuck on a partially-filled form with no explanation. Falling back to the regular
+                    # registration form lets them fill in what's missing themselves.
                     context["autoSubmitRegForm"] = True
 
                 # Check if SAML provider wants to skip optional checkboxes


### PR DESCRIPTION
## Description

When a third-party auth (SSO) provider has **Skip registration form** enabled, `third_party_auth_context` set `autoSubmitRegForm=True` unconditionally. Some providers — Facebook (when the user denies the email permission) and Microsoft Entra ID (accounts without a confirmed email) — complete authentication without returning an email claim. In that case the authn MFE auto-submits a registration form whose required `email` field is empty; client-side validation silently blocks the submit, and the learner is left stuck on a partially-filled form with no explanation.

This gates the auto-submit on the provider actually returning an email. When no email is present, the learner falls back to the normal registration form and can fill in the missing field. The happy path (email present) is unchanged.

Fixes https://github.com/openedx/edx-platform/issues/38780

## How to reproduce

1. Configure an SSO provider with **Skip registration form** enabled that authenticates without an email claim (e.g. Facebook with the email permission denied, or Microsoft Entra ID).
2. Register/sign in via that provider and complete the external authentication.
3. **Before:** the registration form auto-submits and silently fails validation, leaving the learner stuck.
   **After:** the learner lands on the registration form with the email field empty and can complete it.

## Testing

Added a regression test `MFEContextViewTest.test_skip_registration_form_requires_email` covering both cases:
- provider returns an email → `autoSubmitRegForm` is `True` (unchanged happy path)
- provider returns no email → `autoSubmitRegForm` is `False` (learner keeps the form)