### PR TITLE
Implement PERSISTENT_SUBSECTION_GRADE_CHANGED event

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -466,7 +466,10 @@ class PersistentSubsectionGrade(TimeStampedModel):
         Wrapper for objects.update_or_create.
         """
         cls._prepare_params(params)
-        VisibleBlocks.cached_get_or_create(params['user_id'], params['visible_blocks'])
+        # Capture the BlockRecordList before it's removed from params below, so the
+        # event can be emitted without extra queries on grade.visible_blocks
+        visible_blocks = params['visible_blocks']
+        VisibleBlocks.cached_get_or_create(params['user_id'], visible_blocks)
         cls._prepare_params_visible_blocks_id(params)
 
         # TODO: do we NEED to pop these?
@@ -487,7 +490,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
             grade.save()
 
         cls._emit_grade_calculated_event(grade)
-        cls._emit_openedx_persistent_subsection_grade_changed_event(grade)
+        cls._emit_openedx_persistent_subsection_grade_changed_event(grade, visible_blocks)
         return grade
 
     @classmethod
@@ -501,16 +504,17 @@ class PersistentSubsectionGrade(TimeStampedModel):
         PersistentSubsectionGradeOverride.prefetch(user_id, course_key)
 
         list(map(cls._prepare_params, grade_params_iter))
-        VisibleBlocks.bulk_get_or_create(
-            user_id, course_key, [params['visible_blocks'] for params in grade_params_iter]
-        )
+        # Capture the BlockRecordLists (in order) before they're removed from params below,
+        # so events can be emitted without extra queries on grade.visible_blocks
+        visible_blocks_list = [params['visible_blocks'] for params in grade_params_iter]
+        VisibleBlocks.bulk_get_or_create(user_id, course_key, visible_blocks_list)
         list(map(cls._prepare_params_visible_blocks_id, grade_params_iter))
 
         grades = [PersistentSubsectionGrade(**params) for params in grade_params_iter]
         grades = cls.objects.bulk_create(grades)
-        for grade in grades:
+        for grade, visible_blocks in zip(grades, visible_blocks_list, strict=True):
             cls._emit_grade_calculated_event(grade)
-            cls._emit_openedx_persistent_subsection_grade_changed_event(grade)
+            cls._emit_openedx_persistent_subsection_grade_changed_event(grade, visible_blocks)
         return grades
 
     @classmethod
@@ -541,7 +545,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
         events.subsection_grade_calculated(grade)
 
     @staticmethod
-    def _emit_openedx_persistent_subsection_grade_changed_event(grade):
+    def _emit_openedx_persistent_subsection_grade_changed_event(grade, visible_blocks):
         """
         When called emits an event when a persistent subsection grade is created or updated.
         """
@@ -557,7 +561,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
                 exc_info=True,
             )
 
-        visible_blocks = [
+        xblocks_scoring_data = [
             XBlockWithScoringData(
                 usage_key=block.locator,
                 block_type=block.locator.block_type,
@@ -565,7 +569,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
                 raw_possible=block.raw_possible,
                 weight=block.weight,
             )
-            for block in grade.visible_blocks.blocks
+            for block in visible_blocks
         ]
 
         PERSISTENT_SUBSECTION_GRADE_CHANGED.send_event(
@@ -582,7 +586,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
                 weighted_total_earned=grade.earned_all,
                 weighted_total_possible=grade.possible_all,
                 first_attempted=grade.first_attempted,
-                visible_blocks=visible_blocks,
+                visible_blocks=xblocks_scoring_data,
                 visible_blocks_hash=str(grade.visible_blocks_id),
             )
         )

--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -461,7 +461,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
             )
 
     @classmethod
-    def update_or_create_grade(cls, **params):
+    def update_or_create_grade(cls, grading_policy_hash=None, **params):
         """
         Wrapper for objects.update_or_create.
         """
@@ -490,11 +490,11 @@ class PersistentSubsectionGrade(TimeStampedModel):
             grade.save()
 
         cls._emit_grade_calculated_event(grade)
-        cls._emit_openedx_persistent_subsection_grade_changed_event(grade, visible_blocks)
+        cls._emit_openedx_persistent_subsection_grade_changed_event(grade, visible_blocks, grading_policy_hash)
         return grade
 
     @classmethod
-    def bulk_create_grades(cls, grade_params_iter, user_id, course_key):
+    def bulk_create_grades(cls, grade_params_iter, user_id, course_key, grading_policy_hash=None):
         """
         Bulk creation of grades.
         """
@@ -514,7 +514,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
         grades = cls.objects.bulk_create(grades)
         for grade, visible_blocks in zip(grades, visible_blocks_list, strict=True):
             cls._emit_grade_calculated_event(grade)
-            cls._emit_openedx_persistent_subsection_grade_changed_event(grade, visible_blocks)
+            cls._emit_openedx_persistent_subsection_grade_changed_event(grade, visible_blocks, grading_policy_hash)
         return grades
 
     @classmethod
@@ -545,21 +545,26 @@ class PersistentSubsectionGrade(TimeStampedModel):
         events.subsection_grade_calculated(grade)
 
     @staticmethod
-    def _emit_openedx_persistent_subsection_grade_changed_event(grade, visible_blocks):
+    def _emit_openedx_persistent_subsection_grade_changed_event(grade, visible_blocks, grading_policy_hash=None):
         """
         When called emits an event when a persistent subsection grade is created or updated.
+
+        ``grading_policy_hash`` should be supplied by callers that already have the course's
+        block structure loaded, so it can be reused instead of loading the course from the
+        modulestore (an extra query per event).  When not provided, it is computed here.
         """
         # .. event_implemented_name: PERSISTENT_SUBSECTION_GRADE_CHANGED
         # .. event_type: org.openedx.learning.course.persistent_subsection_grade.changed.v1
-        try:
-            grading_policy_hash = GradesCourseData(user=None, course_key=grade.course_id).grading_policy_hash
-        except Exception:  # pylint: disable=broad-except
-            grading_policy_hash = ""
-            log.debug(
-                "Unable to compute grading_policy_hash for course %s",
-                grade.course_id,
-                exc_info=True,
-            )
+        if grading_policy_hash is None:
+            try:
+                grading_policy_hash = GradesCourseData(user=None, course_key=grade.course_id).grading_policy_hash
+            except Exception:  # pylint: disable=broad-except
+                grading_policy_hash = ""
+                log.debug(
+                    "Unable to compute grading_policy_hash for course %s",
+                    grade.course_id,
+                    exc_info=True,
+                )
 
         xblocks_scoring_data = [
             XBlockWithScoringData(

--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -21,12 +21,21 @@ from lazy import lazy
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from openedx_events.learning.data import CourseData, PersistentCourseGradeData
-from openedx_events.learning.signals import PERSISTENT_GRADE_SUMMARY_CHANGED
+from openedx_events.learning.data import (
+    CourseData,
+    PersistentCourseGradeData,
+    PersistentSubsectionGradeData,
+    XBlockWithScoringData,
+)
+from openedx_events.learning.signals import (
+    PERSISTENT_GRADE_SUMMARY_CHANGED,
+    PERSISTENT_SUBSECTION_GRADE_CHANGED,
+)
 from simple_history.models import HistoricalRecords
 
 from lms.djangoapps.courseware.fields import UnsignedBigIntAutoField
 from lms.djangoapps.grades import events  # pylint: disable=unused-import
+from lms.djangoapps.grades.course_data import CourseData as GradesCourseData
 from lms.djangoapps.grades.signals.signals import (
     COURSE_GRADE_PASSED_FIRST_TIME,
     COURSE_GRADE_PASSED_UPDATE_IN_LEARNER_PATHWAY,
@@ -478,6 +487,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
             grade.save()
 
         cls._emit_grade_calculated_event(grade)
+        cls._emit_openedx_persistent_subsection_grade_changed_event(grade)
         return grade
 
     @classmethod
@@ -500,6 +510,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
         grades = cls.objects.bulk_create(grades)
         for grade in grades:
             cls._emit_grade_calculated_event(grade)
+            cls._emit_openedx_persistent_subsection_grade_changed_event(grade)
         return grades
 
     @classmethod
@@ -528,6 +539,53 @@ class PersistentSubsectionGrade(TimeStampedModel):
     @staticmethod
     def _emit_grade_calculated_event(grade):
         events.subsection_grade_calculated(grade)
+
+    @staticmethod
+    def _emit_openedx_persistent_subsection_grade_changed_event(grade):
+        """
+        When called emits an event when a persistent subsection grade is created or updated.
+        """
+        # .. event_implemented_name: PERSISTENT_SUBSECTION_GRADE_CHANGED
+        # .. event_type: org.openedx.learning.course.persistent_subsection_grade.changed.v1
+        try:
+            grading_policy_hash = GradesCourseData(user=None, course_key=grade.course_id).grading_policy_hash
+        except Exception:  # pylint: disable=broad-except
+            grading_policy_hash = ""
+            log.debug(
+                "Unable to compute grading_policy_hash for course %s",
+                grade.course_id,
+                exc_info=True,
+            )
+
+        visible_blocks = [
+            XBlockWithScoringData(
+                usage_key=block.locator,
+                block_type=block.locator.block_type,
+                graded=block.graded,
+                raw_possible=block.raw_possible,
+                weight=block.weight,
+            )
+            for block in grade.visible_blocks.blocks
+        ]
+
+        PERSISTENT_SUBSECTION_GRADE_CHANGED.send_event(
+            grade=PersistentSubsectionGradeData(
+                user_id=grade.user_id,
+                course=CourseData(
+                    course_key=grade.course_id,
+                ),
+                subsection_edited_timestamp=grade.subtree_edited_timestamp,
+                grading_policy_hash=grading_policy_hash,
+                usage_key=grade.usage_key,
+                weighted_graded_earned=grade.earned_graded,
+                weighted_graded_possible=grade.possible_graded,
+                weighted_total_earned=grade.earned_all,
+                weighted_total_possible=grade.possible_all,
+                first_attempted=grade.first_attempted,
+                visible_blocks=visible_blocks,
+                visible_blocks_hash=str(grade.visible_blocks_id),
+            )
+        )
 
     @classmethod
     def _cache_key(cls, course_id):

--- a/lms/djangoapps/grades/subsection_grade.py
+++ b/lms/djangoapps/grades/subsection_grade.py
@@ -281,12 +281,17 @@ class CreateSubsectionGrade(NonZeroSubsectionGrade):
 
         super().__init__(subsection, all_total, graded_total)
 
-    def update_or_create_model(self, student, score_deleted=False, force_update_subsections=False):
+    def update_or_create_model(
+        self, student, score_deleted=False, force_update_subsections=False, grading_policy_hash=None
+    ):
         """
         Saves or updates the subsection grade in a persisted model.
         """
         if self._should_persist_per_attempted(score_deleted, force_update_subsections):
-            model = PersistentSubsectionGrade.update_or_create_grade(**self._persisted_model_params(student))
+            model = PersistentSubsectionGrade.update_or_create_grade(
+                grading_policy_hash=grading_policy_hash,
+                **self._persisted_model_params(student),
+            )
 
             if hasattr(model, 'override'):
                 # When we're doing an update operation, the PersistentSubsectionGrade model
@@ -299,7 +304,7 @@ class CreateSubsectionGrade(NonZeroSubsectionGrade):
             return model
 
     @classmethod
-    def bulk_create_models(cls, student, subsection_grades, course_key):
+    def bulk_create_models(cls, student, subsection_grades, course_key, grading_policy_hash=None):
         """
         Saves the subsection grade in a persisted model.
         """
@@ -309,7 +314,9 @@ class CreateSubsectionGrade(NonZeroSubsectionGrade):
             if subsection_grade
             if subsection_grade._should_persist_per_attempted()  # pylint: disable=protected-access
         ]
-        return PersistentSubsectionGrade.bulk_create_grades(params, student.id, course_key)
+        return PersistentSubsectionGrade.bulk_create_grades(
+            params, student.id, course_key, grading_policy_hash=grading_policy_hash
+        )
 
     def _should_persist_per_attempted(self, score_deleted=False, force_update_subsections=False):
         """

--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -57,7 +57,10 @@ class SubsectionGradeFactory:
                 if read_only:
                     self._unsaved_subsection_grades[subsection_grade.location] = subsection_grade
                 else:
-                    grade_model = subsection_grade.update_or_create_model(self.student)
+                    grade_model = subsection_grade.update_or_create_model(
+                        self.student,
+                        grading_policy_hash=self.course_data.grading_policy_hash,
+                    )
                     self._update_saved_subsection_grade(subsection.location, grade_model)
         return subsection_grade
 
@@ -66,7 +69,8 @@ class SubsectionGradeFactory:
         Bulk creates all the unsaved subsection_grades to this point.
         """
         CreateSubsectionGrade.bulk_create_models(
-            self.student, list(self._unsaved_subsection_grades.values()), self.course_data.course_key
+            self.student, list(self._unsaved_subsection_grades.values()), self.course_data.course_key,
+            grading_policy_hash=self.course_data.grading_policy_hash,
         )
         self._unsaved_subsection_grades.clear()
 
@@ -100,7 +104,8 @@ class SubsectionGradeFactory:
             grade_model = calculated_grade.update_or_create_model(
                 self.student,
                 score_deleted,
-                force_update_subsections
+                force_update_subsections,
+                grading_policy_hash=self.course_data.grading_policy_hash,
             )
             self._update_saved_subsection_grade(subsection.location, grade_model)
 

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -2754,6 +2754,12 @@ EVENT_BUS_PRODUCER_CONFIG = {
             "enabled": Derived(should_send_learning_badge_events),
         },
     },
+    "org.openedx.learning.course.persistent_subsection_grade.changed.v1": {
+        "learning-subsection-grade": {
+            "event_key_field": "grade.course.course_key",
+            "enabled": True,
+        },
+    },
 }
 
 ### event tracking

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -850,7 +850,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==3.1.2
     # via -r requirements/edx/kernel.in
-openedx-events==11.2.0
+git+https://github.com/openedx/openedx-events.git@bmtcril/subsection-grade
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1401,7 +1401,7 @@ openedx-django-wiki==3.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-events==11.2.0
+git+https://github.com/openedx/openedx-events.git@bmtcril/subsection-grade
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1030,7 +1030,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.2
     # via -r requirements/edx/base.txt
-openedx-events==11.2.0
+git+https://github.com/openedx/openedx-events.git@bmtcril/subsection-grade
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -115,7 +115,7 @@ openedx-atlas                       # CLI tool to manage translations
 openedx-calc                        # Library supporting mathematical calculations for Open edX
 openedx-core
 openedx-django-require
-openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
+git+https://github.com/openedx/openedx-events.git@bmtcril/subsection-grade                     # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
 openedx-forum                       # Open edX forum v2 application
 openedx-django-wiki

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1070,7 +1070,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.2
     # via -r requirements/edx/base.txt
-openedx-events==11.2.0
+git+https://github.com/openedx/openedx-events.git@bmtcril/subsection-grade
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
## Description

This dusts off @mgwozdz-unicon 's #37978 for testing https://github.com/openedx/openedx-events/pull/587 . It adds a new Openedx Event `PERSISTENT_SUBSECTION_GRADE_CHANGED` in order to support CBE's need to assess student competency at a skill.

In draft until I can replace the branch references in requirements with a new release of openedx-events.

Current test failures are all query count. Mostly going from 47 to 48, one went from 44 to 48. I'm going to take a look at that one to try and understand if there are things we can do to improve it.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

If you are set up with an event bus configuration you can test all the way through by completing a problem in a graded subsection. The lms-worker should attempt to serialize and send the event. I've tested this path locally, and it worked, though I can't guarantee it will work with every problem currently.
