### PR TITLE
feat: pdf block enabled by default

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -77,6 +77,7 @@ DEFAULT_ADVANCED_MODULES = [
     'google-calendar',
     'google-document',
     'lti_consumer',
+    'pdf',
     'poll',
     'split_test',
     'survey',

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -2806,6 +2806,7 @@ class TestComponentTemplates(CourseTestCase):
             "Google Calendar",
             "Google Document",
             "LTI Consumer",
+            "PDF",
             "Poll",
             "Content Experiment",
             "Survey",

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -938,7 +938,7 @@ ADVANCED_PROBLEM_TYPES = [
     {
         'component': 'staffgradedxblock',
         'boilerplate_name': None
-    }
+    },
 ]
 
 LIBRARY_BLOCK_TYPES = [


### PR DESCRIPTION
## Description

This PR enables the PDF block by default, [per the product proposal](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/5335908397/Proposal+Add+PDF+Block+to+Base+Installation?focusedCommentId=6556647439) where it was to be added.

## Testing instructions

1. Create a new course.
2. Don't modify the advanced modules for the course.
3. Create a unit and check the advanced dropdown. Add a PDF block for the course and verify it works as expected.
