### PR TITLE
feat: expose proctoring provider capability flags in instructor v2 API

### DIFF
--- a/lms/djangoapps/instructor/docs/references/instructor-v2-special-exams-api-spec.yaml
+++ b/lms/djangoapps/instructor/docs/references/instructor-v2-special-exams-api-spec.yaml
@@ -522,6 +522,16 @@ definitions:
         type: boolean
       enable_proctored_exams:
         type: boolean
+      supports_onboarding:
+        type: boolean
+        description: >-
+          Whether the course's proctoring backend supports onboarding exams.
+          Used by the instructor dashboard to gate the Student Onboarding Status section.
+      review_dashboard_available:
+        type: boolean
+        description: >-
+          Whether the course's proctoring backend exposes a review dashboard.
+          Used by the instructor dashboard to gate the Review Dashboard section.
 
   ProctoringSettingsUpdate:
     type: object

--- a/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
@@ -322,6 +322,26 @@ class ProctoringSettingsViewTest(ModuleStoreTestCase):
         data = response.json()
         assert data['enable_proctored_exams'] is True
 
+    def test_get_settings_capability_flags_default_false(self):
+        """The 'null' backend supports neither onboarding nor a review dashboard."""
+        response = self.client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['supports_onboarding'] is False
+        assert data['review_dashboard_available'] is False
+
+    @patch('lms.djangoapps.instructor.views.api_v2.is_backend_dashboard_available', return_value=True)
+    @patch('lms.djangoapps.instructor.views.api_v2.does_backend_support_onboarding', return_value=True)
+    def test_get_settings_capability_flags_supported(self, mock_onboarding, mock_dashboard):
+        """Capability flags surface the proctoring backend's onboarding/dashboard support."""
+        response = self.client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['supports_onboarding'] is True
+        assert data['review_dashboard_available'] is True
+        assert mock_onboarding.called
+        assert mock_dashboard.called
+
     def test_patch_settings(self):
         response = self.client.patch(
             self._url(),

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -30,12 +30,14 @@ from django.views.decorators.cache import cache_control
 from django_filters.rest_framework import DjangoFilterBackend
 from edx_proctoring.api import (
     add_allowance_for_user,
+    does_backend_support_onboarding,
     get_all_exam_attempts,
     get_all_exams_for_course,
     get_allowances_for_course,
     get_exam_by_id,
     get_filtered_exam_attempts,
     get_user_attempts_by_exam_id,
+    is_backend_dashboard_available,
     remove_allowance_for_user,
     remove_exam_attempt,
 )
@@ -4282,6 +4284,26 @@ class SpecialExamAttemptsView(DeveloperErrorViewMixin, ListAPIView):
         ]
 
 
+def _build_proctoring_settings_data(course, course_id):
+    """
+    Assemble a course's proctoring settings along with the provider-capability flags
+    the instructor dashboard needs to decide which special-exam sections to show.
+
+    ``supports_onboarding`` mirrors whether the proctoring backend has onboarding exams,
+    and ``review_dashboard_available`` mirrors whether it exposes a review dashboard.
+    These gate the Student Onboarding Status and Review Dashboard sections respectively.
+    """
+    provider = getattr(course, 'proctoring_provider', None)
+    return {
+        'proctoring_provider': provider,
+        'proctoring_escalation_email': getattr(course, 'proctoring_escalation_email', None),
+        'create_zendesk_tickets': getattr(course, 'create_zendesk_tickets', False),
+        'enable_proctored_exams': getattr(course, 'enable_proctored_exams', False),
+        'supports_onboarding': does_backend_support_onboarding(provider),
+        'review_dashboard_available': is_backend_dashboard_available(course_id),
+    }
+
+
 class ProctoringSettingsView(DeveloperErrorViewMixin, APIView):
     """
     Retrieve or update proctoring configuration for a course.
@@ -4314,12 +4336,7 @@ class ProctoringSettingsView(DeveloperErrorViewMixin, APIView):
         """Retrieve proctoring configuration for the course."""
         course_key = CourseKey.from_string(course_id)
         course = get_course_by_id(course_key)
-        settings_data = {
-            'proctoring_provider': getattr(course, 'proctoring_provider', None),
-            'proctoring_escalation_email': getattr(course, 'proctoring_escalation_email', None),
-            'create_zendesk_tickets': getattr(course, 'create_zendesk_tickets', False),
-            'enable_proctored_exams': getattr(course, 'enable_proctored_exams', False),
-        }
+        settings_data = _build_proctoring_settings_data(course, course_id)
         serializer = ProctoringSettingsSerializer(settings_data)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
@@ -4358,12 +4375,7 @@ class ProctoringSettingsView(DeveloperErrorViewMixin, APIView):
         if updated:
             modulestore().update_item(course, request.user.id)
 
-        settings_data = {
-            'proctoring_provider': getattr(course, 'proctoring_provider', None),
-            'proctoring_escalation_email': getattr(course, 'proctoring_escalation_email', None),
-            'create_zendesk_tickets': getattr(course, 'create_zendesk_tickets', False),
-            'enable_proctored_exams': getattr(course, 'enable_proctored_exams', False),
-        }
+        settings_data = _build_proctoring_settings_data(course, course_id)
         serializer = ProctoringSettingsSerializer(settings_data)
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/lms/djangoapps/instructor/views/serializers_v2.py
+++ b/lms/djangoapps/instructor/views/serializers_v2.py
@@ -1263,6 +1263,10 @@ class ProctoringSettingsSerializer(serializers.Serializer):
     proctoring_escalation_email = serializers.CharField(allow_null=True, required=False)
     create_zendesk_tickets = serializers.BooleanField()
     enable_proctored_exams = serializers.BooleanField()
+    # Provider-capability flags used by the instructor dashboard to decide whether to
+    # show the Student Onboarding Status and Review Dashboard special-exam sections.
+    supports_onboarding = serializers.BooleanField()
+    review_dashboard_available = serializers.BooleanField()
 
 
 class ProctoringSettingsUpdateSerializer(serializers.Serializer):


### PR DESCRIPTION
## Description

Adds two provider-capability flags to the instructor **v2** `proctoring_settings` endpoint so the
instructor dashboard MFE can decide whether to show the Student Onboarding Status and Review
Dashboard special-exam sections:

- `supports_onboarding` — wraps `edx_proctoring.api.does_backend_support_onboarding(provider)`
- `review_dashboard_available` — wraps `edx_proctoring.api.is_backend_dashboard_available(course_id)`

Both are computed in a small shared helper used by the endpoint's `GET` and `PATCH`. This is the same
information the legacy instructor dashboard used server-side (`show_onboarding` / `show_dashboard` in
`_section_special_exams`), now exposed via the v2 API. No proctoring logic is reimplemented — these
are thin wrappers over existing edx-proctoring helpers.

**Impacted user roles:** **Developers** consuming the v2 API (two new read-only boolean fields);
**Operators** indirectly (the MFE gates UI on these). No behavior change for learners.

Closes #<upstream-issue-number>

## Supporting information

- Consumed by the `frontend-app-instructor-dashboard` PR https://github.com/openedx/frontend-app-instructor-dashboard/pull/219
-  Internal tracking: https://github.com/mitodl/hq/issues/11865
- API spec updated: `lms/djangoapps/instructor/docs/references/instructor-v2-special-exams-api-spec.yaml`.

## Testing instructions

1. `GET /api/instructor/v2/courses/{course_id}/proctoring_settings` as course staff.
2. For a course whose proctoring backend supports onboarding / a review dashboard, confirm the
   response includes `"supports_onboarding": true` and/or `"review_dashboard_available": true`.
3. For a course on the `null` backend, confirm both are `false`.
4. Run: `pytest lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py::ProctoringSettingsViewTest`

## Other information

- Additive, backward-compatible: two new response fields, no changes to existing fields, no migrations.
- `is_backend_dashboard_available` inspects the course's active exams; cost is comparable to the
  existing course-wide special-exam endpoints.
