### PR TITLE
feat(verawood): add show_email_preferences to v3 configurations API

### DIFF
--- a/openedx/core/djangoapps/notifications/tests/test_views.py
+++ b/openedx/core/djangoapps/notifications/tests/test_views.py
@@ -11,6 +11,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.test.utils import override_settings
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_flag
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
@@ -31,6 +32,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from ..base_notification import COURSE_NOTIFICATION_APPS, COURSE_NOTIFICATION_TYPES, get_default_values_of_preferences
+from ..config.waffle import DISABLE_EMAIL_NOTIFICATIONS
 from ..utils import exclude_inaccessible_preferences, get_notification_types_with_visibility_settings
 
 User = get_user_model()
@@ -742,6 +744,7 @@ class TestNotificationPreferencesViewV3(ModuleStoreTestCase):
         data = {
             "status": "success",
             "show_preferences": True,
+            "show_email_preferences": True,
             "message": "Notification preferences retrieved successfully.",
             "data": {
                 "discussion": {
@@ -887,6 +890,24 @@ class TestNotificationPreferencesViewV3(ModuleStoreTestCase):
             user__id=self.user.id
         )
         self.assertEqual(preference.web, True)  # noqa: PT009
+
+    def test_show_email_preferences_flag_disabled(self):
+        """
+        Test: show_email_preferences is True when DISABLE_EMAIL_NOTIFICATIONS flag is off.
+        """
+        with override_waffle_flag(DISABLE_EMAIL_NOTIFICATIONS, active=False):
+            response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
+        self.assertTrue(response.data['show_email_preferences'])  # noqa: PT009
+
+    def test_show_email_preferences_flag_enabled(self):
+        """
+        Test: show_email_preferences is False when DISABLE_EMAIL_NOTIFICATIONS flag is on.
+        """
+        with override_waffle_flag(DISABLE_EMAIL_NOTIFICATIONS, active=True):
+            response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
+        self.assertFalse(response.data['show_email_preferences'])  # noqa: PT009
 
     def test_update_preferences_non_grouped_email(self):
         """

--- a/openedx/core/djangoapps/notifications/utils.py
+++ b/openedx/core/djangoapps/notifications/utils.py
@@ -5,7 +5,7 @@ from typing import Dict, List  # noqa: UP035
 
 from common.djangoapps.student.models import CourseAccessRole
 from openedx.core.djangoapps.django_comment_common.models import Role
-from openedx.core.djangoapps.notifications.config.waffle import DISABLE_NOTIFICATIONS
+from openedx.core.djangoapps.notifications.config.waffle import DISABLE_EMAIL_NOTIFICATIONS, DISABLE_NOTIFICATIONS
 from openedx.core.djangoapps.notifications.models import NotificationPreference, create_notification_preference
 from openedx.core.lib.cache_utils import request_cached
 
@@ -15,6 +15,13 @@ def get_show_notifications_tray():
     Returns whether notifications tray is enabled via waffle flag
     """
     return not DISABLE_NOTIFICATIONS.is_enabled()
+
+
+def get_show_email_preferences():
+    """
+    Returns whether email notification preferences are enabled via waffle flag
+    """
+    return not DISABLE_EMAIL_NOTIFICATIONS.is_enabled()
 
 
 def get_list_in_batches(input_list, batch_size):

--- a/openedx/core/djangoapps/notifications/views.py
+++ b/openedx/core/djangoapps/notifications/views.py
@@ -35,6 +35,7 @@ from .serializers import (
 from .utils import (
     create_account_notification_pref_if_not_exists,
     exclude_inaccessible_preferences,
+    get_show_email_preferences,
     get_show_notifications_tray,
 )
 
@@ -305,6 +306,7 @@ class NotificationPreferencesViewV3(APIView):
             'status': 'success',
             'message': 'Notification preferences retrieved successfully.',
             'show_preferences': get_show_notifications_tray(),
+            'show_email_preferences': get_show_email_preferences(),
             'data': structured_preferences
         }, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
### Ticket
[issue-65](https://github.com/openedx/tutor-contrib-platform-notifications/issues/65)

### Summary

Adds `show_email_preferences` attribute to the `GET /api/notifications/v3/configurations/` response, indicating whether email notification preferences should be shown to the user.

### Changes

- **utils.py**: Added `get_show_email_preferences()` utility function that returns `not DISABLE_EMAIL_NOTIFICATIONS.is_enabled()`
- **views.py**: Imported and used `get_show_email_preferences()` in `NotificationPreferencesViewV3.get()` to include `show_email_preferences` in the response.

### API Response (updated)

```json
{
  "status": "success",
  "message": "Notification preferences retrieved successfully.",
  "show_preferences": true,
  "show_email_preferences": true,
  "data": { ... }
}
```