### PR TITLE
refactor: migrate more flags off FEATURES-as-dict

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -826,7 +826,7 @@ class CourseMode(models.Model):
         """
         ineligible_modes = [cls.AUDIT]
 
-        if settings.FEATURES.get('DISABLE_HONOR_CERTIFICATES', False):
+        if getattr(settings, 'DISABLE_HONOR_CERTIFICATES', False):
             # Adding check so that we can regenerate the certificate for learners who have
             # already earned the certificate using honor mode
             from lms.djangoapps.certificates.data import CertificateStatuses

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -444,7 +444,7 @@ class CourseModeModelTest(TestCase):
     @ddt.unpack
     def test_eligible_for_cert(self, disable_honor_cert, mode_slug, expected_eligibility):
         """Verify that non-audit modes are eligible for a cert."""
-        with override_settings(FEATURES={'DISABLE_HONOR_CERTIFICATES': disable_honor_cert}):
+        with override_settings(DISABLE_HONOR_CERTIFICATES=disable_honor_cert):
             assert CourseMode.is_eligible_for_certificate(mode_slug) == expected_eligibility
 
     @ddt.data(

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -352,11 +352,11 @@ class AllowlistTests(ModuleStoreTestCase):
         CertificateAllowlistFactory.create(course_id=course_run_key, user=self.user)
 
         # Enable Honor Certificates and verify we can generate an AllowList certificate
-        with override_settings(FEATURES={**settings.FEATURES, 'DISABLE_HONOR_CERTIFICATES': False}):
+        with override_settings(DISABLE_HONOR_CERTIFICATES=False):
             assert _can_generate_allowlist_certificate(self.user, course_run_key, enrollment_mode)
 
         # Disable Honor Certificates and verify we cannot generate an AllowList certificate
-        with override_settings(FEATURES={**settings.FEATURES, 'DISABLE_HONOR_CERTIFICATES': True}):
+        with override_settings(DISABLE_HONOR_CERTIFICATES=True):
             assert not _can_generate_allowlist_certificate(self.user, course_run_key, enrollment_mode)
 
 
@@ -794,11 +794,11 @@ class CertificateTests(ModuleStoreTestCase):
         # Enable Honor Certificates and verify we can generate a certificate
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
                 mock.patch(PASSING_GRADE_METHOD, return_value=True), \
-                override_settings(FEATURES={**settings.FEATURES, 'DISABLE_HONOR_CERTIFICATES': False}):
+                override_settings(DISABLE_HONOR_CERTIFICATES=False):
             assert _can_generate_regular_certificate(self.user, course_run_key, enrollment_mode, grade)
 
         # Disable Honor Certificates and verify we cannot generate a certificate
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
                 mock.patch(PASSING_GRADE_METHOD, return_value=True), \
-                override_settings(FEATURES={**settings.FEATURES, 'DISABLE_HONOR_CERTIFICATES': True}):
+                override_settings(DISABLE_HONOR_CERTIFICATES=True):
             assert not _can_generate_regular_certificate(self.user, course_run_key, enrollment_mode, grade)

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -216,7 +216,7 @@ def setup_masquerade(request, course_key, staff_access=False, reset_masquerade_d
     """
     if (
         request.user is None or
-        not settings.FEATURES.get('ENABLE_MASQUERADE', False) or
+        not settings.ENABLE_MASQUERADE or
         not staff_access
     ):
         return None, request.user

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -3,7 +3,6 @@ Tests use cases related to LMS Entrance Exam behavior, such as gated content acc
 """
 
 
-from unittest.mock import patch
 
 from crum import set_current_request
 from django.test import override_settings
@@ -316,7 +315,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         )
         assert user_has_passed_entrance_exam(self.request.user, course)
 
-    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_MASQUERADE': False})
+    @override_settings(ENABLE_MASQUERADE=False)
     def test_entrance_exam_xblock_response(self):
         """
         Tests entrance exam xblock has `entrance_exam_passed` key in json response.

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import ddt
 import pytest
 from django.conf import settings
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from pytz import UTC
 from xblock.runtime import DictKeyValueStore
@@ -195,7 +195,7 @@ class TestMasqueradeLearnerOptions(StaffMasqueradeTestCase):
     """
 
     @ddt.data(True, False)
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_MASQUERADE': True})
+    @override_settings(ENABLE_MASQUERADE=True)
     def test_masquerade_options_for_learner(self, partitions_enabled):
         """
         If there are partitions, then the View as Learner should NOT be available
@@ -234,7 +234,7 @@ class TestMasqueradeOptionsNoContentGroups(StaffMasqueradeTestCase):
 
     @ddt.data(['Cohort Group 1', True], ['Content Group 1', False])
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_MASQUERADE': True})
+    @override_settings(ENABLE_MASQUERADE=True)
     def testMasqueradeCohortAvailable(self, target, expected):
         """
         Args:

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -100,9 +100,6 @@ from xmodule.modulestore.tests.factories import BlockFactory, CourseFactory, che
 
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES + AUTHZ_TABLES
 
-FEATURES_WITH_DISABLE_HONOR_CERTIFICATE = settings.FEATURES.copy()
-FEATURES_WITH_DISABLE_HONOR_CERTIFICATE['DISABLE_HONOR_CERTIFICATES'] = True
-
 
 @ddt.ddt
 class TestJumpTo(ModuleStoreTestCase):
@@ -1477,7 +1474,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         self.assertNotContains(response, bannerText, html=True)
 
     @patch('lms.djangoapps.courseware.views.views.is_course_passed', PropertyMock(return_value=True))
-    @override_settings(FEATURES=FEATURES_WITH_DISABLE_HONOR_CERTIFICATE)
+    @override_settings(DISABLE_HONOR_CERTIFICATES=True)
     @ddt.data(CourseMode.AUDIT, CourseMode.HONOR)
     def test_message_for_ineligible_mode(self, course_mode):
         """ Verify that message appears on progress page, if learner is enrolled
@@ -1514,7 +1511,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         assert response.cert_status == 'invalidated'
         assert response.title == 'Your certificate has been invalidated'
 
-    @override_settings(FEATURES=FEATURES_WITH_DISABLE_HONOR_CERTIFICATE)
+    @override_settings(DISABLE_HONOR_CERTIFICATES=True)
     def test_downloadable_get_cert_data(self):
         """
         Verify that downloadable cert data is returned if cert is downloadable even

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -70,7 +70,7 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/5670
     settings.ALLOW_AUTOMATED_SIGNUPS = False
 
-    # .. toggle_name: FEATURES['ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS']
+    # .. toggle_name: ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: When True, the CSV file that contains a list of

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -49,7 +49,7 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/11286
     settings.ENABLE_GRADE_DOWNLOADS = False
 
-    # .. toggle_name: FEATURES['ALLOW_COURSE_STAFF_GRADE_DOWNLOADS']
+    # .. toggle_name: ALLOW_COURSE_STAFF_GRADE_DOWNLOADS
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Enable to give course staff unrestricted access to grade downloads;

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -59,7 +59,7 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/1750
     settings.ALLOW_COURSE_STAFF_GRADE_DOWNLOADS = False
 
-    # .. toggle_name: FEATURES['ALLOW_AUTOMATED_SIGNUPS']
+    # .. toggle_name: ALLOW_AUTOMATED_SIGNUPS
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Enable to show a section in the membership tab of the instructor

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -100,7 +100,7 @@ def plugin_settings(settings):
     # .. toggle_creation_date: 2025-11-19
     settings.ENABLE_CERTIFICATES_INSTRUCTOR_MANAGE = False
 
-    # .. toggle_name: FEATURES['BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT']
+    # .. toggle_name: BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
     # .. toggle_description: Controls if the "Notify users by email" checkbox in the batch

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -19,7 +19,7 @@ def plugin_settings(settings):
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/5838
     settings.DISPLAY_ANALYTICS_ENROLLMENTS = True
 
-    # .. toggle_name: FEATURES['ENABLE_CCX_ANALYTICS_DASHBOARD_URL']
+    # .. toggle_name: ENABLE_CCX_ANALYTICS_DASHBOARD_URL
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Display the 'Analytics' tab in the instructor dashboard for CCX courses.

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -9,7 +9,7 @@ def plugin_settings(settings):
     ### Analytics Dashboard (Insights) settings
     settings.ANALYTICS_DASHBOARD_URL = ""
     settings.ANALYTICS_DASHBOARD_NAME = _('Your Platform Insights')
-    # .. toggle_name: FEATURES['DISPLAY_ANALYTICS_ENROLLMENTS']
+    # .. toggle_name: DISPLAY_ANALYTICS_ENROLLMENTS
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
     # .. toggle_description: Enable display of enrollment counts in instructor dashboard and

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -38,7 +38,7 @@ def plugin_settings(settings):
     #   courses will have disabled buttons at the instructor dashboard.
     settings.MAX_ENROLLMENT_INSTR_BUTTONS = 200
 
-    # .. toggle_name: FEATURES['ENABLE_GRADE_DOWNLOADS']
+    # .. toggle_name: ENABLE_GRADE_DOWNLOADS
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Enable grade CSV downloads from the instructor dashboard. Grade

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -600,7 +600,7 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
             )
 
 
-@patch.dict(settings.FEATURES, {'ALLOW_AUTOMATED_SIGNUPS': True})
+@override_settings(ALLOW_AUTOMATED_SIGNUPS=True)
 @ddt.ddt
 class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -960,7 +960,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
             password = generate_unique_password(generated_password, 12)
             assert password != 'first'
 
-    @patch.dict(settings.FEATURES, {'ALLOW_AUTOMATED_SIGNUPS': False})
+    @override_settings(ALLOW_AUTOMATED_SIGNUPS=False)
     def test_allow_automated_signups_flag_not_set(self):
         csv_content = b"test_student1@example.com,test_student_1,tester1,USA"
         uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
@@ -970,7 +970,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         manual_enrollments = ManualEnrollmentAudit.objects.all()
         assert manual_enrollments.count() == 0
 
-    @patch.dict(settings.FEATURES, {'ALLOW_AUTOMATED_SIGNUPS': True})
+    @override_settings(ALLOW_AUTOMATED_SIGNUPS=True)
     def test_audit_enrollment_mode(self):
         """
         Test that enrollment mode for audit courses (paid courses) is 'audit'.
@@ -996,7 +996,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         for enrollment in manual_enrollments:
             assert enrollment.enrollment.mode == CourseMode.AUDIT
 
-    @patch.dict(settings.FEATURES, {'ALLOW_AUTOMATED_SIGNUPS': True})
+    @override_settings(ALLOW_AUTOMATED_SIGNUPS=True)
     def test_honor_enrollment_mode(self):
         """
         Test that enrollment mode for unpaid honor courses is 'honor'.
@@ -5361,7 +5361,7 @@ class TestInstructorCertificateExceptions(SharedModuleStoreTestCase):
         )
 
 
-@patch.dict(settings.FEATURES, {'ALLOW_AUTOMATED_SIGNUPS': True})
+@override_settings(ALLOW_AUTOMATED_SIGNUPS=True)
 class TestOauthInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test endpoints using Oauth2 authentication.

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -417,7 +417,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url)
         self.assert_no_xss(response, '<script>alert("XSS")</script>')
 
-    @patch.dict(settings.FEATURES, {'DISPLAY_ANALYTICS_ENROLLMENTS': False})
+    @override_settings(DISPLAY_ANALYTICS_ENROLLMENTS=False)
     @override_settings(ANALYTICS_DASHBOARD_URL='')
     def test_no_enrollments(self):
         """
@@ -427,7 +427,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         # no enrollment information should be visible
         self.assertNotContains(response, '<h3 class="hd hd-3">Enrollment Information</h3>')
 
-    @patch.dict(settings.FEATURES, {'DISPLAY_ANALYTICS_ENROLLMENTS': True})
+    @override_settings(DISPLAY_ANALYTICS_ENROLLMENTS=True)
     @override_settings(ANALYTICS_DASHBOARD_URL='')
     def test_show_enrollments_data(self):
         """
@@ -445,7 +445,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         # dashboard link hidden
         self.assertNotContains(response, self.get_dashboard_enrollment_message())
 
-    @patch.dict(settings.FEATURES, {'DISPLAY_ANALYTICS_ENROLLMENTS': True})
+    @override_settings(DISPLAY_ANALYTICS_ENROLLMENTS=True)
     @override_settings(ANALYTICS_DASHBOARD_URL='')
     def test_show_enrollment_data_for_prof_ed(self):
         # Create both "professional" (meaning professional + verification)
@@ -459,7 +459,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         # Check that the number of professional enrollments is two
         self.assertContains(response, '<th scope="row">Professional</th><td>2</td>')
 
-    @patch.dict(settings.FEATURES, {'DISPLAY_ANALYTICS_ENROLLMENTS': False})
+    @override_settings(DISPLAY_ANALYTICS_ENROLLMENTS=False)
     @override_settings(ANALYTICS_DASHBOARD_URL='http://example.com')
     @override_settings(ANALYTICS_DASHBOARD_NAME='Example')
     def test_show_dashboard_enrollment_message(self):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -284,7 +284,7 @@ class RegisterAndEnrollStudents(APIView):
         """
         if not configuration_helpers.get_value(
             'ALLOW_AUTOMATED_SIGNUPS',
-            settings.FEATURES.get('ALLOW_AUTOMATED_SIGNUPS', False),
+            settings.ALLOW_AUTOMATED_SIGNUPS,
         ):
             return HttpResponseForbidden()
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -340,7 +340,7 @@ class RegisterAndEnrollStudents(APIView):
             already_warned_not_cohorted = False
             extra_fields_is_enabled = configuration_helpers.get_value(
                 'ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS',
-                settings.FEATURES.get('ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS', False),
+                settings.ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS,
             )
 
             # Iterate each student in the uploaded csv file.

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -105,7 +105,7 @@ def show_analytics_dashboard_message(course_key):
         course_key (CourseLocator): The course locator to display the analytics dashboard message on.
     """
     if hasattr(course_key, 'ccx'):
-        ccx_analytics_enabled = settings.FEATURES.get('ENABLE_CCX_ANALYTICS_DASHBOARD_URL', False)
+        ccx_analytics_enabled = settings.ENABLE_CCX_ANALYTICS_DASHBOARD_URL
         return settings.ANALYTICS_DASHBOARD_URL and ccx_analytics_enabled
 
     return settings.ANALYTICS_DASHBOARD_URL

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -488,7 +488,7 @@ def _section_course_info(course, access):
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': str(course_key)}),
     }
 
-    if settings.FEATURES.get('DISPLAY_ANALYTICS_ENROLLMENTS'):
+    if settings.DISPLAY_ANALYTICS_ENROLLMENTS:
         section_data['enrollment_count'] = CourseEnrollment.objects.enrollment_counts(course_key)
 
     if show_analytics_dashboard_message(course_key):

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -699,7 +699,7 @@ if settings.ENABLE_TEAMS:
     ]
 
 # allow course staff to change to student view of courseware
-if settings.FEATURES.get('ENABLE_MASQUERADE'):
+if settings.ENABLE_MASQUERADE:
     urlpatterns += [
         re_path(
             r'^courses/{}/masquerade$'.format(  # noqa: UP032

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -396,7 +396,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         ('credit', True),
     )
     @ddt.unpack
-    @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_HONOR_CERTIFICATES': True})
+    @override_settings(DISABLE_HONOR_CERTIFICATES=True)
     def test_can_access_proctored_exams(self, mode, result):
         CourseEnrollment.enroll(self.user, self.course.id, mode)
         response = self.client.get(self.url)
@@ -411,7 +411,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
         (3, True),
     )
     @ddt.unpack
-    @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_HONOR_CERTIFICATES': True})
+    @override_settings(DISABLE_HONOR_CERTIFICATES=True)
     def test_can_access_proctored_exams_masquerading(self, masquerade_group_id, result):
         self.user.is_staff = True
         self.user.save()

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -557,7 +557,7 @@ class DeactivateLogoutView(APIView):
 
         # Ensure the account deletion is not disable
         enable_account_deletion = configuration_helpers.get_value(
-            "ENABLE_ACCOUNT_DELETION", settings.FEATURES.get("ENABLE_ACCOUNT_DELETION", False)
+            "ENABLE_ACCOUNT_DELETION", settings.ENABLE_ACCOUNT_DELETION
         )
 
         if not enable_account_deletion:


### PR DESCRIPTION
Follow-on to #38772 (merged). Migrates another batch of flags off \`settings.FEATURES['X']\` onto flat \`settings.X\` / \`@override_settings(X=…)\`.

Companion #38876 (temp diagnostic) surfaces the remaining flags via better warning-caller reporting.

## Flags migrated in this batch

- \`DISPLAY_ANALYTICS_ENROLLMENTS\`
- \`ENABLE_CCX_ANALYTICS_DASHBOARD_URL\`
- \`ALLOW_AUTOMATED_SIGNUPS\`
- \`ENABLE_AUTOMATED_SIGNUPS_EXTRA_FIELDS\`
- \`DISABLE_HONOR_CERTIFICATES\`
- \`ENABLE_ACCOUNT_DELETION\`
- \`ENABLE_MASQUERADE\`

## Annotation-only fixes

Three flags already had readers using \`settings.X\` — only their toggle-annotation \`toggle_name:\` was still pointed at the \`FEATURES['X']\` form:

- \`ENABLE_GRADE_DOWNLOADS\`
- \`ALLOW_COURSE_STAFF_GRADE_DOWNLOADS\`
- \`BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT\`

## \`settings.X\` vs \`getattr(settings, 'X', <default>)\`

Same rule as #38772: bare \`settings.X\` when the caller only runs in a process where the flat setting is defined; \`getattr\` when the caller lives under \`common/\` or \`openedx/core/djangoapps/\` and can be reached from the process the flag isn't defined in. \`DISABLE_HONOR_CERTIFICATES\` is the notable case in this batch — production reader in \`common/djangoapps/course_modes/models.py\` keeps a \`getattr\` fallback because \`course_modes\` is in CMS INSTALLED_APPS but the flat setting is LMS-only.