### PR TITLE
refactor: migrate 10 more flags off FEATURES-as-dict (batch 3)

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -115,7 +115,7 @@ class CourseMetadata:
             exclude_list.append('video_upload_pipeline')
 
         # Do not show video auto advance if the feature is disabled
-        if not settings.FEATURES.get('ENABLE_AUTOADVANCE_VIDEOS'):
+        if not settings.ENABLE_AUTOADVANCE_VIDEOS:
             exclude_list.append('video_auto_advance')
 
         # Do not show social sharing url field if the feature is disabled.

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -346,7 +346,7 @@ class EnrollmentTest(OpenEdxEventsTestMixin, UrlResetMixin, ModuleStoreTestCase)
         resp = self._change_enrollment('unenroll', course_id="edx/")
         assert resp.status_code == 400
 
-    @patch.dict(settings.FEATURES, {'DISABLE_UNENROLLMENT': True})
+    @override_settings(DISABLE_UNENROLLMENT=True)
     def test_unenroll_when_unenrollment_disabled(self):
         """
         Tests that a user cannot unenroll when unenrollment has been disabled.

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -552,7 +552,7 @@ def student_dashboard(request):  # pylint: disable=too-many-statements
     )
     disable_unenrollment = configuration_helpers.get_value(
         'DISABLE_UNENROLLMENT',
-        settings.FEATURES.get('DISABLE_UNENROLLMENT')
+        settings.DISABLE_UNENROLLMENT
     )
 
     disable_course_limit = request and 'course_limit' in request.GET

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -472,7 +472,7 @@ def change_enrollment(request, check_access=True):
     elif action == "unenroll":
         if configuration_helpers.get_value(
             "DISABLE_UNENROLLMENT",
-            settings.FEATURES.get("DISABLE_UNENROLLMENT")
+            settings.DISABLE_UNENROLLMENT
         ):
             return HttpResponseBadRequest(_("Unenrollment is currently disabled"))
 

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -222,7 +222,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
 
     @patch('common.djangoapps.student.views.management.render_to_response', RENDER_MOCK)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', RENDER_MOCK)
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSE_DISCOVERY': False})
+    @override_settings(ENABLE_COURSE_DISCOVERY=False)
     def test_course_discovery_off(self):
         """
         Asserts that the Course Discovery UI elements follow the
@@ -246,7 +246,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
 
     @patch('common.djangoapps.student.views.management.render_to_response', RENDER_MOCK)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', RENDER_MOCK)
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSE_DISCOVERY': True})
+    @override_settings(ENABLE_COURSE_DISCOVERY=True)
     def test_course_discovery_on(self):
         """
         Asserts that the Course Discovery UI elements follow the
@@ -268,7 +268,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
 
     @patch('common.djangoapps.student.views.management.render_to_response', RENDER_MOCK)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', RENDER_MOCK)
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSE_DISCOVERY': False})
+    @override_settings(ENABLE_COURSE_DISCOVERY=False)
     def test_course_cards_sorted_by_default_sorting(self):
         response = self.client.get('/')
         assert response.status_code == 200
@@ -294,7 +294,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
     @patch('common.djangoapps.student.views.management.render_to_response', RENDER_MOCK)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', RENDER_MOCK)
     @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSE_SORTING_BY_START_DATE': False})
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSE_DISCOVERY': False})
+    @override_settings(ENABLE_COURSE_DISCOVERY=False)
     def test_course_cards_sorted_by_start_date_disabled(self):
         response = self.client.get('/')
         assert response.status_code == 200

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -585,7 +585,7 @@ def prepare_runtime_for_user(
 
     user_is_staff = bool(has_access(user, 'staff', course_id))
 
-    if settings.FEATURES.get('DISPLAY_DEBUG_INFO_TO_STAFF'):
+    if settings.DISPLAY_DEBUG_INFO_TO_STAFF:
         if user_is_staff or is_masquerading_as_specific_student(user, course_id):
             # When masquerading as a specific student, we want to show the debug button
             # unconditionally to enable resetting the state of the student we are masquerading as.

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -215,7 +215,7 @@ class BaseStudentModuleHistory(models.Model):
 
         history_entries = []
 
-        if settings.FEATURES.get('ENABLE_CSMH_EXTENDED'):
+        if settings.ENABLE_CSMH_EXTENDED:
             from lms.djangoapps.coursewarehistoryextended.models import StudentModuleHistoryExtended
             history_entries += StudentModuleHistoryExtended.objects.filter(
                 # Django will sometimes try to join to courseware_studentmodule
@@ -314,7 +314,7 @@ class StudentModuleHistory(BaseStudentModuleHistory):
     # When the extended studentmodulehistory table exists, don't save
     # duplicate history into courseware_studentmodulehistory, just retain
     # data for reading.
-    if not settings.FEATURES.get('ENABLE_CSMH_EXTENDED'):
+    if not settings.ENABLE_CSMH_EXTENDED:
         post_save.connect(save_history, sender=StudentModule)
 
 

--- a/lms/djangoapps/courseware/plugins.py
+++ b/lms/djangoapps/courseware/plugins.py
@@ -15,7 +15,7 @@ from xmodule.tabs import CourseTabList
 
 User = get_user_model()
 
-TEXTBOOK_ENABLED = settings.FEATURES.get("ENABLE_TEXTBOOK", False)
+TEXTBOOK_ENABLED = settings.ENABLE_TEXTBOOK
 
 
 class ProgressCourseApp(CourseApp):

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -134,7 +134,7 @@ class TextbookTabs(TextbookTabsBase):
     @classmethod
     def is_enabled(cls, course, user=None):
         parent_is_enabled = super().is_enabled(course, user)
-        return settings.FEATURES.get('ENABLE_TEXTBOOK') and parent_is_enabled
+        return settings.ENABLE_TEXTBOOK and parent_is_enabled
 
     @classmethod
     def items(cls, course):

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -1726,7 +1726,8 @@ class DetachedXBlock(XBlock):
         return frag
 
 
-@patch.dict('django.conf.settings.FEATURES', {'DISPLAY_DEBUG_INFO_TO_STAFF': True, 'DISPLAY_HISTOGRAMS_TO_STAFF': True})
+@patch.dict('django.conf.settings.FEATURES', {'DISPLAY_DEBUG_INFO_TO_STAFF': True})
+@override_settings(DISPLAY_HISTOGRAMS_TO_STAFF=True)
 @patch('lms.djangoapps.courseware.block_render.has_access', Mock(return_value=True, autospec=True))
 class TestStaffDebugInfo(SharedModuleStoreTestCase):
     """Tests to verify that Staff Debug Info panel and histograms are displayed to staff."""
@@ -1846,7 +1847,7 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
         result_fragment = block.render(STUDENT_VIEW)
         assert 'Staff Debug' not in result_fragment.content
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISPLAY_HISTOGRAMS_TO_STAFF': False})
+    @override_settings(DISPLAY_HISTOGRAMS_TO_STAFF=False)
     def test_histogram_disabled(self):
         block = render.get_block(
             self.user,

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -1726,8 +1726,7 @@ class DetachedXBlock(XBlock):
         return frag
 
 
-@patch.dict('django.conf.settings.FEATURES', {'DISPLAY_DEBUG_INFO_TO_STAFF': True})
-@override_settings(DISPLAY_HISTOGRAMS_TO_STAFF=True)
+@override_settings(DISPLAY_DEBUG_INFO_TO_STAFF=True, DISPLAY_HISTOGRAMS_TO_STAFF=True)
 @patch('lms.djangoapps.courseware.block_render.has_access', Mock(return_value=True, autospec=True))
 class TestStaffDebugInfo(SharedModuleStoreTestCase):
     """Tests to verify that Staff Debug Info panel and histograms are displayed to staff."""
@@ -1765,7 +1764,7 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
             self.block
         )
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISPLAY_DEBUG_INFO_TO_STAFF': False})
+    @override_settings(DISPLAY_DEBUG_INFO_TO_STAFF=False)
     def test_staff_debug_info_disabled(self):
         block = render.get_block(
             self.user,

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -217,7 +217,7 @@ class TextbooksTestCase(TabTestCase):
         ])
         self.num_textbooks = self.num_textbook_tabs * len(self.books)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_TEXTBOOK": True})
+    @override_settings(ENABLE_TEXTBOOK=True)
     def test_textbooks_enabled(self):
 
         type_to_reverse_name = {'textbook': 'book', 'pdftextbook': 'pdf_book', 'htmltextbook': 'html_book'}
@@ -486,7 +486,7 @@ class TextBookCourseViewsTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
                 num_of_textbooks_found += 1
         assert num_of_textbooks_found == self.num_textbooks
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_TEXTBOOK": False})
+    @override_settings(ENABLE_TEXTBOOK=False)
     def test_textbooks_disabled(self):
         tab = xmodule_tabs.CourseTab.load('textbooks')
         assert not tab.is_enabled(self.course, self.user)

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -2469,8 +2469,6 @@ class TestAutoAdvanceVideo(TestVideo):  # pylint: disable=test-inherits-tests
     maxDiff = None
     CATEGORY = "video"
     METADATA = {}
-    # Use temporary FEATURES in this test without affecting the original
-    FEATURES = dict(settings.FEATURES)
 
     def prepare_expected_context(self, autoadvanceenabled_flag, autoadvance_flag):
         """
@@ -2542,7 +2540,8 @@ class TestAutoAdvanceVideo(TestVideo):  # pylint: disable=test-inherits-tests
         return context
 
     def assert_content_matches_expectations(
-        self, autoadvanceenabled_must_be, autoadvance_must_be, mock_render_django_template
+        self, autoadvanceenabled_must_be, autoadvance_must_be, mock_render_django_template,
+        enable_autoadvance_videos=False,
     ):
         """
         Check (assert) that loading video.html produces content that corresponds
@@ -2550,7 +2549,7 @@ class TestAutoAdvanceVideo(TestVideo):  # pylint: disable=test-inherits-tests
         Helper function to avoid code repetition.
         """
 
-        with override_settings(FEATURES=self.FEATURES):
+        with override_settings(ENABLE_AUTOADVANCE_VIDEOS=enable_autoadvance_videos):
             self.block.student_view(None)
 
         expected_context = self.prepare_expected_context(
@@ -2595,11 +2594,11 @@ class TestAutoAdvanceVideo(TestVideo):  # pylint: disable=test-inherits-tests
         - in that case (when the controls are visible) the video will autoadvance
           (because that's the default), in other cases it won't
         """
-        self.FEATURES.update({"ENABLE_AUTOADVANCE_VIDEOS": global_setting})
         self.change_course_setting_autoadvance(new_value=course_setting)
 
         self.assert_content_matches_expectations(
             autoadvanceenabled_must_be=(global_setting and course_setting),
             autoadvance_must_be=(global_setting and course_setting),
             mock_render_django_template=mock_render_django_template,
+            enable_autoadvance_videos=global_setting,
         )

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -303,7 +303,7 @@ def courses(request):
     courses_list = []
     course_discovery_meanings = getattr(settings, 'COURSE_DISCOVERY_MEANINGS', {})
     set_default_filter = ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER.is_enabled()
-    if not settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
+    if not settings.ENABLE_COURSE_DISCOVERY:
         courses_list = get_courses(
             request.user,
             filter_={"catalog_visibility": CATALOG_VISIBILITY_CATALOG_AND_ABOUT},

--- a/lms/djangoapps/coursewarehistoryextended/tests.py
+++ b/lms/djangoapps/coursewarehistoryextended/tests.py
@@ -13,12 +13,13 @@ from unittest.mock import patch
 from django.conf import settings
 from django.db import connections
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule, StudentModuleHistory
 from lms.djangoapps.courseware.tests.factories import COURSE_KEY, LOCATION, StudentModuleFactory
 
 
-@skipUnless(settings.FEATURES["ENABLE_CSMH_EXTENDED"], "CSMH Extended needs to be enabled")
+@skipUnless(settings.ENABLE_CSMH_EXTENDED, "CSMH Extended needs to be enabled")
 class TestStudentModuleHistoryBackends(TestCase):
     """ Tests of data in CSMH and CSMHE """
     # Tell Django to clean out all databases, not just default
@@ -42,7 +43,7 @@ class TestStudentModuleHistoryBackends(TestCase):
                                         max_grade=csm.max_grade)
             csmh.save()
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CSMH_EXTENDED": True})
+    @override_settings(ENABLE_CSMH_EXTENDED=True)
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": True})
     def test_get_history_true_true(self):
         student_module = StudentModule.objects.all()
@@ -55,7 +56,7 @@ class TestStudentModuleHistoryBackends(TestCase):
         assert {'type': 'csmh', 'order': 2} == json.loads(history[4].state)
         assert {'type': 'csmh', 'order': 1} == json.loads(history[5].state)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CSMH_EXTENDED": True})
+    @override_settings(ENABLE_CSMH_EXTENDED=True)
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": False})
     def test_get_history_true_false(self):
         student_module = StudentModule.objects.all()
@@ -65,7 +66,7 @@ class TestStudentModuleHistoryBackends(TestCase):
         assert {'type': 'csmhe', 'order': 2} == json.loads(history[1].state)
         assert {'type': 'csmhe', 'order': 1} == json.loads(history[2].state)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CSMH_EXTENDED": False})
+    @override_settings(ENABLE_CSMH_EXTENDED=False)
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": True})
     def test_get_history_false_true(self):
         student_module = StudentModule.objects.all()
@@ -75,7 +76,7 @@ class TestStudentModuleHistoryBackends(TestCase):
         assert {'type': 'csmh', 'order': 2} == json.loads(history[1].state)
         assert {'type': 'csmh', 'order': 1} == json.loads(history[2].state)
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CSMH_EXTENDED": False})
+    @override_settings(ENABLE_CSMH_EXTENDED=False)
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": False})
     def test_get_history_false_false(self):
         student_module = StudentModule.objects.all()

--- a/lms/djangoapps/discussion/plugins.py
+++ b/lms/djangoapps/discussion/plugins.py
@@ -26,7 +26,7 @@ class DiscussionTab(TabFragmentViewMixin, EnrolledTab):
     priority = 40
     view_name = 'forum_form_discussion'
     fragment_view_name = 'lms.djangoapps.discussion.views.DiscussionBoardFragmentView'
-    is_hideable = settings.FEATURES.get('ALLOW_HIDING_DISCUSSION_TAB', False)
+    is_hideable = settings.ALLOW_HIDING_DISCUSSION_TAB
     is_default = False
     body_class = 'discussion'
     online_help_token = 'discussions'

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -86,7 +86,7 @@ def get_legacy_config() -> dict:
             "course_about_twitter_account", settings.PLATFORM_TWITTER_ACCOUNT
         ),
         "NON_BROWSABLE_COURSES": not settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
-        "ENABLE_COURSE_DISCOVERY": settings.FEATURES["ENABLE_COURSE_DISCOVERY"],
+        "ENABLE_COURSE_DISCOVERY": settings.ENABLE_COURSE_DISCOVERY,
     }
 
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -768,6 +768,15 @@ ENABLE_CROSS_DOMAIN_CSRF_COOKIE = False
 # .. toggle_warning: Requires configuration of third party auth
 ENABLE_REQUIRE_THIRD_PARTY_AUTH = False
 
+# .. toggle_name: ENABLE_AUTO_GENERATED_USERNAME
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Set to True to enable auto-generation of usernames.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2024-02-20
+# .. toggle_warning: Changing this setting may affect user authentication, account management and discussions experience.
+ENABLE_AUTO_GENERATED_USERNAME = False
+
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API
 # Should be a list of tuples of (block_type, field_name), where block_type can also be "*" for all block types.
 # e.g. COURSE_BLOCKS_API_EXTRA_FIELDS = [  ('course', 'other_course_settings'), ("problem", "weight")  ]

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -819,7 +819,7 @@ if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
         path('admin/', admin.site.urls),
     ]
 
-if configuration_helpers.get_value('ENABLE_BULK_ENROLLMENT_VIEW', settings.FEATURES.get('ENABLE_BULK_ENROLLMENT_VIEW')):
+if configuration_helpers.get_value('ENABLE_BULK_ENROLLMENT_VIEW', settings.ENABLE_BULK_ENROLLMENT_VIEW):
     urlpatterns += [
         path('api/bulk_enroll/v1/', include('lms.djangoapps.bulk_enroll.urls')),
     ]

--- a/openedx/core/djangoapps/user_authn/toggles.py
+++ b/openedx/core/djangoapps/user_authn/toggles.py
@@ -26,19 +26,10 @@ def should_redirect_to_authn_microfrontend():
     )
 
 
-# .. toggle_name: ENABLE_AUTO_GENERATED_USERNAME
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Set to True to enable auto-generation of usernames.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2024-02-20
-# .. toggle_warning: Changing this setting may affect user authentication, account management and discussions experience.
-
-
 def is_auto_generated_username_enabled():
     """
     Checks if auto-generated username should be enabled.
     """
     return configuration_helpers.get_value(
-        'ENABLE_AUTO_GENERATED_USERNAME', settings.FEATURES.get('ENABLE_AUTO_GENERATED_USERNAME')
+        'ENABLE_AUTO_GENERATED_USERNAME', getattr(settings, 'ENABLE_AUTO_GENERATED_USERNAME', False)
     )

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -252,7 +252,7 @@ def create_account_with_params(request, params):  # pylint: disable=too-many-sta
         redirect_url = get_redirect_url_with_host(root_url, redirect_to)
         compose_and_send_activation_email(user, profile, registration, redirect_url, True)
 
-    if settings.FEATURES.get('ENABLE_DISCUSSION_EMAIL_DIGEST'):
+    if getattr(settings, 'ENABLE_DISCUSSION_EMAIL_DIGEST', False):
         try:
             enable_notifications(user)
         except Exception:  # pylint: disable=broad-except

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -66,9 +66,6 @@ from openedx.core.djangoapps.user_api.tests.test_views import UserAPITestCase
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.lib.api import test_utils
 
-ENABLE_AUTO_GENERATED_USERNAME = settings.FEATURES.copy()
-ENABLE_AUTO_GENERATED_USERNAME['ENABLE_AUTO_GENERATED_USERNAME'] = True
-
 
 @ddt.ddt
 @skip_unless_lms
@@ -1834,7 +1831,7 @@ class RegistrationViewTestV1(
             response = self.client.post(self.url, {"email": self.EMAIL, "username": self.USERNAME})
             assert response.status_code == 403
 
-    @override_settings(FEATURES=ENABLE_AUTO_GENERATED_USERNAME)
+    @override_settings(ENABLE_AUTO_GENERATED_USERNAME=True)
     def test_register_with_auto_generated_username(self):
         """
         Test registration functionality with auto-generated username.
@@ -1866,7 +1863,7 @@ class RegistrationViewTestV1(
         response = self.client.get(reverse("dashboard"))
         self.assertHttpOK(response)
 
-    @override_settings(FEATURES=ENABLE_AUTO_GENERATED_USERNAME)
+    @override_settings(ENABLE_AUTO_GENERATED_USERNAME=True)
     def test_register_with_empty_name(self):
         """
         Test registration field validations when ENABLE_AUTO_GENERATED_USERNAME is enabled.
@@ -1890,7 +1887,7 @@ class RegistrationViewTestV1(
             }
         )
 
-    @override_settings(FEATURES=ENABLE_AUTO_GENERATED_USERNAME)
+    @override_settings(ENABLE_AUTO_GENERATED_USERNAME=True)
     @mock.patch('openedx.core.djangoapps.user_authn.views.utils._get_username_prefix')
     @mock.patch('openedx.core.djangoapps.user_authn.views.utils.random.choices')
     @mock.patch('openedx.core.djangoapps.user_authn.views.utils.datetime')

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -282,7 +282,7 @@ def add_staff_markup(user, disable_staff_debug_info, block, view, frag, context)
         return frag
 
     block_id = block.location
-    if block.has_score and settings.FEATURES.get('DISPLAY_HISTOGRAMS_TO_STAFF'):
+    if block.has_score and getattr(settings, 'DISPLAY_HISTOGRAMS_TO_STAFF', False):
         histogram = grade_histogram(block_id)
         render_histogram = len(histogram) > 0
     else:

--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -384,7 +384,7 @@ class _BuiltInVideoBlock(
         # video will autoadvance or not.
         # For autoadvance controls to be shown, both the feature flag and the course setting must be true.
         # This allows to enable the feature for certain courses only.
-        autoadvance_enabled = settings.FEATURES.get('ENABLE_AUTOADVANCE_VIDEOS', False) and \
+        autoadvance_enabled = settings.ENABLE_AUTOADVANCE_VIDEOS and \
             getattr(self, 'video_auto_advance', False)
 
         # This is the current status of auto-advance (not the control visibility).


### PR DESCRIPTION
## Summary

Migrates 11 more feature flags off `settings.FEATURES['X']` dict-style access onto flat settings (`settings.X`) with `@override_settings(X=Y)` in tests. Follows the pattern established in #38772.

Each commit migrates a single flag:

- ENABLE_TEXTBOOK
- ENABLE_COURSE_DISCOVERY
- DISPLAY_HISTOGRAMS_TO_STAFF
- ALLOW_HIDING_DISCUSSION_TAB
- ENABLE_AUTOADVANCE_VIDEOS
- ENABLE_CSMH_EXTENDED
- ENABLE_BULK_ENROLLMENT_VIEW
- ENABLE_AUTO_GENERATED_USERNAME (also adds the flag + annotation to `lms/envs/common.py`)
- ENABLE_DISCUSSION_EMAIL_DIGEST
- DISABLE_UNENROLLMENT
- DISPLAY_DEBUG_INFO_TO_STAFF