### PR TITLE
refactor: migrate 12 more flags off FEATURES-as-dict (batch 4)

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/mixins.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/mixins.py
@@ -3,9 +3,9 @@ Common mixins for module.
 """
 import json
 import logging
-from unittest.mock import patch
 
 from django.http import Http404
+from django.test.utils import override_settings
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey
 from rest_framework import status
@@ -36,7 +36,7 @@ class PermissionAccessMixin:
         self.assertEqual(error, "Authentication credentials were not provided.")  # noqa: PT009
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)  # noqa: PT009
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_ADVANCED_SETTINGS": True})
+    @override_settings(DISABLE_ADVANCED_SETTINGS=True)
     def test_permissions_unauthorized(self):
         """
         Test that an error is returned if the user is unauthorised.

--- a/cms/djangoapps/contentstore/rest_api/v1/views/grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/grading.py
@@ -94,7 +94,7 @@ class CourseGradingView(DeveloperErrorViewMixin, APIView):
         ```
         """
         with modulestore().bulk_operations(course_key):
-            credit_eligibility_enabled = settings.FEATURES.get("ENABLE_CREDIT_ELIGIBILITY", False)
+            credit_eligibility_enabled = settings.ENABLE_CREDIT_ELIGIBILITY
             show_credit_eligibility = is_credit_course(course_key) and credit_eligibility_enabled
 
             grading_context = get_course_grading(course_key)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_grading.py
@@ -5,6 +5,7 @@ import json
 from unittest.mock import patch
 
 import ddt
+from django.test.utils import override_settings
 from django.urls import reverse
 from openedx_authz.constants.roles import COURSE_DATA_RESEARCHER, COURSE_STAFF
 from rest_framework import status
@@ -63,7 +64,7 @@ class CourseGradingViewTest(CourseTestCase, PermissionAccessMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
         self.assertEqual(['A', 'B'], response.data["default_grade_designations"])  # noqa: PT009
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CREDIT_ELIGIBILITY": True})
+    @override_settings(ENABLE_CREDIT_ELIGIBILITY=True)
     def test_credit_eligibility_setting(self):
         """
         Make sure if the feature flag is enabled we have enabled values in response.

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_proctoring.py
@@ -439,9 +439,7 @@ class CourseProctoringErrorsViewTest(CourseTestCase, PermissionAccessMixin):
         If this feature is enabled, only Django Staff/Superuser should be able to see the proctoring errors.
         For non-staff users the proctoring errors should be unavailable.
         """
-        with override_settings(
-            FEATURES={"DISABLE_ADVANCED_SETTINGS": disable_advanced_settings}
-        ):
+        with override_settings(DISABLE_ADVANCED_SETTINGS=disable_advanced_settings):
             response = self.non_staff_client.get(self.url)
             self.assertEqual(  # noqa: PT009
                 response.status_code, 403 if disable_advanced_settings else 200
@@ -469,7 +467,7 @@ class CourseProctoringErrorsViewTest(CourseTestCase, PermissionAccessMixin):
     @patch('common.djangoapps.student.auth.authz_api.is_user_allowed')
     def test_authz_with_disable_advanced_settings_staff_allowed(self, mock_is_user_allowed, mock_flag):
         """Staff user can access when DISABLE_ADVANCED_SETTINGS is enabled, bypassing authz."""
-        with override_settings(FEATURES={"DISABLE_ADVANCED_SETTINGS": True}):
+        with override_settings(DISABLE_ADVANCED_SETTINGS=True):
             response = self.client.get(self.url)
             self.assertEqual(response.status_code, 200)  # noqa: PT009
             mock_is_user_allowed.assert_not_called()
@@ -478,7 +476,7 @@ class CourseProctoringErrorsViewTest(CourseTestCase, PermissionAccessMixin):
     @patch('common.djangoapps.student.auth.authz_api.is_user_allowed')
     def test_authz_with_disable_advanced_settings_non_staff_denied(self, mock_is_user_allowed, mock_flag):
         """Non-staff user is denied when DISABLE_ADVANCED_SETTINGS is enabled, bypassing authz."""
-        with override_settings(FEATURES={"DISABLE_ADVANCED_SETTINGS": True}):
+        with override_settings(DISABLE_ADVANCED_SETTINGS=True):
             response = self.non_staff_client.get(self.url)
             self.assertEqual(response.status_code, 403)  # noqa: PT009
             mock_is_user_allowed.assert_not_called()

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_settings.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import ddt
 from django.conf import settings
+from django.test.utils import override_settings
 from django.urls import reverse
 from openedx_authz.constants.roles import COURSE_EDITOR
 from rest_framework import status
@@ -62,7 +63,7 @@ class CourseSettingsViewTest(CourseTestCase, PermissionAccessMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
         self.assertDictEqual(expected_response, response.data)  # noqa: PT009
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CREDIT_ELIGIBILITY": True})
+    @override_settings(ENABLE_CREDIT_ELIGIBILITY=True)
     def test_credit_eligibility_setting(self):
         """
         Make sure if the feature flag is enabled we have updated the dict keys in response.
@@ -134,7 +135,7 @@ class CourseSettingsAuthzViewTest(CourseAuthoringAuthzTestMixin, CourseTestCase)
         response = self.unauthorized_client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_CREDIT_ELIGIBILITY": True})
+    @override_settings(ENABLE_CREDIT_ELIGIBILITY=True)
     def test_credit_eligibility_setting_with_authz(self):
         """
         Ensure feature flags still affect response under AuthZ.

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -164,9 +164,10 @@ class CourseAdvanceSettingViewTest(CourseTestCase, MilestonesTestCaseMixin):
         When DISABLE_ADVANCED_SETTINGS is enabled, non-staff users should receive
         a 403 on the advanced settings URL; staff users should always be redirected.
         """
-        with override_settings(FEATURES={
-            'DISABLE_ADVANCED_SETTINGS': disable_advanced_settings,
-        }, COURSE_AUTHORING_MICROFRONTEND_URL='https://mfe.example'):
+        with override_settings(
+            DISABLE_ADVANCED_SETTINGS=disable_advanced_settings,
+            COURSE_AUTHORING_MICROFRONTEND_URL='https://mfe.example',
+        ):
             response = self.non_staff_client.get_html(self.course_setting_url)
             self.assertEqual(response.status_code, 403 if disable_advanced_settings else 302)  # noqa: PT009
 

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1377,7 +1377,7 @@ def get_course_settings(request, course_key, course_block):
 
     from .views.course import _process_courses_list, get_courses_accessible_to_user
 
-    credit_eligibility_enabled = settings.FEATURES.get('ENABLE_CREDIT_ELIGIBILITY', False)
+    credit_eligibility_enabled = settings.ENABLE_CREDIT_ELIGIBILITY
     upload_asset_url = reverse_course_url('assets_handler', course_key)
 
     # see if the ORG of this course can be attributed to a defined configuration . In that case, the

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -87,7 +87,7 @@ def _user_can_create_library_for_org(user, org=None):
         return False
     else:
         # EDUCATOR-1924: DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION, if present.
-        disable_library_creation = settings.FEATURES.get('DISABLE_LIBRARY_CREATION', None)
+        disable_library_creation = settings.DISABLE_LIBRARY_CREATION
         disable_course_creation = getattr(settings, 'DISABLE_COURSE_CREATION', False)
         if disable_library_creation is not None:
             return not disable_library_creation

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -133,12 +133,11 @@ class UnitTestLibraries(CourseTestCase):
         """
         _, nostaff_user = self.create_non_staff_authed_user_client()
         with mock.patch("cms.djangoapps.contentstore.toggles.libraries_v1_enabled", True):
-            with override_settings(DISABLE_COURSE_CREATION=disable_course):
-                with mock.patch.dict(
-                    "django.conf.settings.FEATURES",
-                    {"DISABLE_LIBRARY_CREATION": disable_library}
-                ):
-                    self.assertEqual(user_can_create_library(nostaff_user, 'SomEOrg'), expected_status)  # noqa: PT009
+            with override_settings(
+                DISABLE_COURSE_CREATION=disable_course,
+                DISABLE_LIBRARY_CREATION=disable_library,
+            ):
+                self.assertEqual(user_can_create_library(nostaff_user, 'SomEOrg'), expected_status)  # noqa: PT009
 
     @override_settings(DISABLE_COURSE_CREATION=True)
     @mock.patch("cms.djangoapps.contentstore.toggles.libraries_v1_enabled", True)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -182,6 +182,13 @@ DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO = True
 # .. toggle_warning: Another toggle DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION, if present.
 DISABLE_COURSE_CREATION = False
 
+# .. setting_name: DISABLE_LIBRARY_CREATION
+# .. setting_default: None
+# .. setting_description: If set to True, disables library creation for users without a staff role and hides the
+#   "New Library" button in Studio. If set to False, enables library creation independently of DISABLE_COURSE_CREATION.
+#   If None (the default), DISABLE_COURSE_CREATION is used to decide whether library creation is disabled.
+DISABLE_LIBRARY_CREATION = None
+
 # .. toggle_name: settings.ENABLE_LTI_PII_ACKNOWLEDGEMENT
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -163,7 +163,7 @@ def has_studio_advanced_settings_access(user):
     By default, this feature is disabled.
     """
     return (
-        not settings.FEATURES.get('DISABLE_ADVANCED_SETTINGS', False)
+        not getattr(settings, 'DISABLE_ADVANCED_SETTINGS', False)
         or user.is_staff
         or user.is_superuser
     )
@@ -205,7 +205,7 @@ def check_course_advanced_settings_access(user, course_key, access_type='read'):
         # For feature_restricted access type, check DISABLE_ADVANCED_SETTINGS feature
         if (
             access_type == 'feature_restricted'
-            and settings.FEATURES.get('DISABLE_ADVANCED_SETTINGS', False)
+            and getattr(settings, 'DISABLE_ADVANCED_SETTINGS', False)
         ):
             # When feature is disabled, only staff/superuser can access (bypass authz)
             return user.is_staff or user.is_superuser

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -676,7 +676,7 @@ def do_create_account(form, custom_form=None):
     # Check if ALLOW_PUBLIC_ACCOUNT_CREATION flag turned off to restrict user account creation
     if not configuration_helpers.get_value(
             'ALLOW_PUBLIC_ACCOUNT_CREATION',
-            settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION', True)
+            settings.ALLOW_PUBLIC_ACCOUNT_CREATION
     ):
         raise PermissionDenied()
 

--- a/common/djangoapps/student/tests/test_credit.py
+++ b/common/djangoapps/student/tests/test_credit.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import ddt
-from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 
@@ -28,7 +27,7 @@ TEST_CREDIT_PROVIDER_SECRET_KEY = "931433d583c84ca7ba41784bad3232e6"
 @override_settings(CREDIT_PROVIDER_SECRET_KEYS={
     "hogwarts": TEST_CREDIT_PROVIDER_SECRET_KEY,
 })
-@patch.dict(settings.FEATURES, {"ENABLE_CREDIT_ELIGIBILITY": True})
+@override_settings(ENABLE_CREDIT_ELIGIBILITY=True)
 @ddt.ddt
 class CreditCourseDashboardTest(ModuleStoreTestCase):
     """

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -379,7 +379,7 @@ def credit_statuses(user, course_enrollments):
     from openedx.core.djangoapps.credit import api as credit_api
 
     # Feature flag off
-    if not settings.FEATURES.get("ENABLE_CREDIT_ELIGIBILITY"):
+    if not settings.ENABLE_CREDIT_ELIGIBILITY:
         return {}
 
     request_status_by_course = {

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -166,7 +166,7 @@ def index(request, extra_context=None, user=AnonymousUser()):  # noqa: B008
 
     if configuration_helpers.get_value(
         "ENABLE_COURSE_SORTING_BY_START_DATE",
-        settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"],
+        settings.ENABLE_COURSE_SORTING_BY_START_DATE,
     ):
         courses = sort_by_start_date(courses)
     else:

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -293,8 +293,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
 
     @patch('common.djangoapps.student.views.management.render_to_response', RENDER_MOCK)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', RENDER_MOCK)
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSE_SORTING_BY_START_DATE': False})
-    @override_settings(ENABLE_COURSE_DISCOVERY=False)
+    @override_settings(ENABLE_COURSE_SORTING_BY_START_DATE=False, ENABLE_COURSE_DISCOVERY=False)
     def test_course_cards_sorted_by_start_date_disabled(self):
         response = self.client.get('/')
         assert response.status_code == 200

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -104,7 +104,7 @@ def courses(request):
     if enable_mktg_site:
         return redirect(marketing_link('COURSES'), permanent=True)
 
-    if not settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
+    if not settings.COURSES_ARE_BROWSABLE:
         raise Http404
 
     #  we do not expect this case to be reached in cases where

--- a/lms/djangoapps/course_wiki/middleware.py
+++ b/lms/djangoapps/course_wiki/middleware.py
@@ -109,7 +109,7 @@ class WikiAccessMiddleware(MiddlewareMixin):
 
             # Check to see if we don't allow top-level access to the wiki via the /wiki/xxxx/yyy/zzz URLs
             # this will help prevent people from writing pell-mell to the Wiki in an unstructured way
-            if not settings.FEATURES.get('ALLOW_WIKI_ROOT_ACCESS', False):
+            if not settings.ALLOW_WIKI_ROOT_ACCESS:
                 raise PermissionDenied()
 
             return self._redirect_from_referrer(request, wiki_path)

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -5,6 +5,7 @@ Tests for course wiki
 
 from unittest.mock import patch
 
+from django.test.utils import override_settings
 from django.urls import reverse
 from openedx_filters.learning.filters import CoursewareViewStarted
 
@@ -34,7 +35,7 @@ class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
             self.activate_user(email)
             self.logout()
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     def test_wiki_redirect(self):
         """
         Test that requesting wiki URLs redirect properly to or out of classes.
@@ -70,7 +71,7 @@ class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         assert resp.status_code == 302
         assert resp['Location'] == destination
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': False})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=False)
     def test_wiki_no_root_access(self):
         """
         Test to verify that normally Wiki's cannot be browsed from the /wiki/xxxx/yyy/zz URLs
@@ -114,7 +115,7 @@ class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.assertContains(resp, "Home")
         self.assertContains(resp, "Course")
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     def test_course_navigator(self):
         """"
         Test that going from a course page to a wiki page contains the course navigator.
@@ -131,7 +132,7 @@ class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
 
         self.has_course_navigator(resp)
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     def test_wiki_not_accessible_when_not_enrolled(self):
         """
         Test that going from a course page to a wiki page when not enrolled
@@ -156,7 +157,7 @@ class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         target_url, __ = resp.redirect_chain[-1]
         assert target_url.endswith(reverse('about_course', args=[str(self.toy.id)]))
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     def test_redirect_when_not_logged_in(self):
         """
         Test that attempting to reach a course wiki page when not logged in
@@ -174,7 +175,7 @@ class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         target_url, __ = resp.redirect_chain[-1]
         assert reverse('signin_user') in target_url
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     def test_create_wiki_with_long_course_id(self):
         """
         Tests that the wiki is successfully created for courses that have
@@ -204,7 +205,7 @@ class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         resp = self.client.get(course_wiki_page, follow=True, HTTP_REFERER=referer)
         assert resp.status_code == 200
 
-    @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
+    @override_settings(ALLOW_WIKI_ROOT_ACCESS=True)
     @patch('openedx_filters.learning.filters.CoursewareViewStarted.run_filter')
     def test_filter_redirect(self, mock_run_filter):
         """

--- a/lms/djangoapps/courseware/tests/test_credit_requirements.py
+++ b/lms/djangoapps/courseware/tests/test_credit_requirements.py
@@ -3,10 +3,8 @@ Tests for credit requirement display on the progress page.
 """
 
 
-from unittest.mock import patch
-
 import ddt
-from django.conf import settings
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -19,7 +17,7 @@ from xmodule.modulestore.tests.django_utils import (
 from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable=wrong-import-order
 
 
-@patch.dict(settings.FEATURES, {"ENABLE_CREDIT_ELIGIBILITY": True})
+@override_settings(ENABLE_CREDIT_ELIGIBILITY=True)
 @ddt.ddt
 class ProgressPageCreditRequirementsTest(SharedModuleStoreTestCase):
     """

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1164,7 +1164,7 @@ def credit_course_requirements(course_key, student):
     # If credit eligibility is not enabled or this is not a credit course,
     # short-circuit and return `None`.  This indicates that credit requirements
     # should NOT be displayed on the progress page.
-    if not (settings.FEATURES.get("ENABLE_CREDIT_ELIGIBILITY", False) and is_credit_course(course_key)):
+    if not (settings.ENABLE_CREDIT_ELIGIBILITY and is_credit_course(course_key)):
         return None
 
     # This indicates that credit requirements should NOT be displayed on the progress page.

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -310,7 +310,7 @@ def courses(request):
         )
 
         if configuration_helpers.get_value("ENABLE_COURSE_SORTING_BY_START_DATE",
-                                           settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"]):
+                                           settings.ENABLE_COURSE_SORTING_BY_START_DATE):
             courses_list = sort_by_start_date(courses_list)
         else:
             courses_list = sort_by_announcement(courses_list)

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -74,7 +74,7 @@ def get_legacy_config() -> dict:
     return {
         "ENABLE_COURSE_SORTING_BY_START_DATE": configuration_helpers.get_value(
             "ENABLE_COURSE_SORTING_BY_START_DATE",
-            settings.FEATURES["ENABLE_COURSE_SORTING_BY_START_DATE"],
+            settings.ENABLE_COURSE_SORTING_BY_START_DATE,
         ),
         "HOMEPAGE_PROMO_VIDEO_YOUTUBE_ID": configuration_helpers.get_value(
             "homepage_promo_video_youtube_id", None

--- a/lms/djangoapps/mfe_config_api/views.py
+++ b/lms/djangoapps/mfe_config_api/views.py
@@ -85,7 +85,7 @@ def get_legacy_config() -> dict:
         "COURSE_ABOUT_TWITTER_ACCOUNT": configuration_helpers.get_value(
             "course_about_twitter_account", settings.PLATFORM_TWITTER_ACCOUNT
         ),
-        "NON_BROWSABLE_COURSES": not settings.FEATURES.get("COURSES_ARE_BROWSABLE"),
+        "NON_BROWSABLE_COURSES": not settings.COURSES_ARE_BROWSABLE,
         "ENABLE_COURSE_DISCOVERY": settings.ENABLE_COURSE_DISCOVERY,
     }
 

--- a/openedx/core/djangoapps/cache_toolbox/middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/middleware.py
@@ -138,7 +138,7 @@ class CacheBackedAuthenticationMiddleware(AuthenticationMiddleware, MiddlewareMi
         # security feature, we can turn it off when auto-auth is
         # enabled since auto-auth is highly insecure and only for
         # tests.
-        auto_auth_enabled = settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING', False)
+        auto_auth_enabled = settings.AUTOMATIC_AUTH_FOR_TESTING
         if not auto_auth_enabled and hasattr(request.user, 'get_session_auth_hash'):
             session_hash = request.session.get(HASH_SESSION_KEY)
             session_hash_verified = session_hash and constant_time_compare(

--- a/openedx/core/djangoapps/lang_pref/api.py
+++ b/openedx/core/djangoapps/lang_pref/api.py
@@ -20,7 +20,7 @@ def header_language_selector_is_enabled():
     setting = get_value('SHOW_HEADER_LANGUAGE_SELECTOR', settings.SHOW_HEADER_LANGUAGE_SELECTOR)
 
     # The SHOW_LANGUAGE_SELECTOR setting is deprecated, but might still be in use on some installations.
-    deprecated_setting = get_value('SHOW_LANGUAGE_SELECTOR', settings.FEATURES.get('SHOW_LANGUAGE_SELECTOR', False))
+    deprecated_setting = get_value('SHOW_LANGUAGE_SELECTOR', getattr(settings, 'SHOW_LANGUAGE_SELECTOR', False))
 
     return setting or deprecated_setting
 

--- a/openedx/core/djangoapps/lang_pref/api.py
+++ b/openedx/core/djangoapps/lang_pref/api.py
@@ -17,7 +17,7 @@ Language = namedtuple('Language', 'code name')
 
 def header_language_selector_is_enabled():
     """Return true if the header language selector has been enabled via settings or site-specific configuration."""
-    setting = get_value('SHOW_HEADER_LANGUAGE_SELECTOR', settings.FEATURES.get('SHOW_HEADER_LANGUAGE_SELECTOR', False))
+    setting = get_value('SHOW_HEADER_LANGUAGE_SELECTOR', settings.SHOW_HEADER_LANGUAGE_SELECTOR)
 
     # The SHOW_LANGUAGE_SELECTOR setting is deprecated, but might still be in use on some installations.
     deprecated_setting = get_value('SHOW_LANGUAGE_SELECTOR', settings.FEATURES.get('SHOW_LANGUAGE_SELECTOR', False))

--- a/openedx/core/djangoapps/lang_pref/api.py
+++ b/openedx/core/djangoapps/lang_pref/api.py
@@ -27,7 +27,7 @@ def header_language_selector_is_enabled():
 
 def footer_language_selector_is_enabled():
     """Return true if the footer language selector has been enabled via settings or site-specific configuration."""
-    return get_value('SHOW_FOOTER_LANGUAGE_SELECTOR', settings.FEATURES.get('SHOW_FOOTER_LANGUAGE_SELECTOR', False))
+    return get_value('SHOW_FOOTER_LANGUAGE_SELECTOR', settings.SHOW_FOOTER_LANGUAGE_SELECTOR)
 
 
 def released_languages():

--- a/openedx/core/djangoapps/lang_pref/tests/test_api.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_api.py
@@ -1,6 +1,4 @@
 """ Tests for the language API. """
-from unittest.mock import patch
-
 import ddt
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.test.utils import override_settings
@@ -39,7 +37,7 @@ class LanguageApiTest(CacheIsolationTestCase):
         """
         Verify that the header language selector config is correct.
         """
-        with patch.dict('django.conf.settings.FEATURES', base_config):
+        with override_settings(**base_config):
             with with_site_configuration_context(configuration=site_config):
                 assert language_api.header_language_selector_is_enabled() == expected
 
@@ -56,7 +54,7 @@ class LanguageApiTest(CacheIsolationTestCase):
         """
         Verify that the footer language selector config is correct.
         """
-        with patch.dict('django.conf.settings.FEATURES', base_config):
+        with override_settings(**base_config):
             with with_site_configuration_context(configuration=site_config):
                 assert language_api.footer_language_selector_is_enabled() == expected
 

--- a/openedx/core/djangoapps/user_authn/urls_common.py
+++ b/openedx/core/djangoapps/user_authn/urls_common.py
@@ -105,7 +105,7 @@ urlpatterns += [
 ]
 
 # enable automatic login
-if settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING'):
+if settings.AUTOMATIC_AUTH_FOR_TESTING:
     urlpatterns += [
         path('auto_auth', auto_auth.auto_auth),
     ]

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -258,7 +258,7 @@ def login_and_registration_form(request, initial_mode="login"):
             'password_reset_form_desc': json.loads(form_descriptions['password_reset']),
             'account_creation_allowed': configuration_helpers.get_value(
                 'ALLOW_PUBLIC_ACCOUNT_CREATION', settings.ALLOW_PUBLIC_ACCOUNT_CREATION),
-            'register_links_allowed': settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True),
+            'register_links_allowed': settings.SHOW_REGISTRATION_LINKS,
             'is_account_recovery_feature_enabled': is_secondary_email_feature_enabled(),
             'enterprise_slug_login_url': get_enterprise_slug_login_url(),
             'is_enterprise_enable': enterprise_enabled(),

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -257,7 +257,7 @@ def login_and_registration_form(request, initial_mode="login"):
             'registration_form_desc': json.loads(form_descriptions['registration']),
             'password_reset_form_desc': json.loads(form_descriptions['password_reset']),
             'account_creation_allowed': configuration_helpers.get_value(
-                'ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION', True)),
+                'ALLOW_PUBLIC_ACCOUNT_CREATION', settings.ALLOW_PUBLIC_ACCOUNT_CREATION),
             'register_links_allowed': settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True),
             'is_account_recovery_feature_enabled': is_secondary_email_feature_enabled(),
             'enterprise_slug_login_url': get_enterprise_slug_login_url(),

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -476,7 +476,7 @@ def _skip_activation_email(user, running_pipeline, third_party_provider):
 
     return (
         settings.FEATURES.get('SKIP_EMAIL_VALIDATION', None) or
-        settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING') or
+        settings.AUTOMATIC_AUTH_FOR_TESTING or
         (third_party_provider and third_party_provider.skip_email_verification and valid_email)
     )
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 import ddt
 from django.conf import settings
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import Client
 from opaque_keys.edx.locator import CourseLocator
 
@@ -45,7 +45,7 @@ class AutoAuthEnabledTestCase(AutoAuthTestCase, ModuleStoreTestCase):
         (COURSE_ID_SPLIT, CourseLocator.from_string(COURSE_ID_SPLIT)),
     )
 
-    @patch.dict("django.conf.settings.FEATURES", {"AUTOMATIC_AUTH_FOR_TESTING": True})
+    @override_settings(AUTOMATIC_AUTH_FOR_TESTING=True)
     def setUp(self):
         # Patching the settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING']
         # value affects the contents of urls.py,
@@ -303,7 +303,7 @@ class AutoAuthDisabledTestCase(AutoAuthTestCase):
     Test that the page is inaccessible with default settings
     """
 
-    @patch.dict("django.conf.settings.FEATURES", {"AUTOMATIC_AUTH_FOR_TESTING": False})
+    @override_settings(AUTOMATIC_AUTH_FOR_TESTING=False)
     def setUp(self):
         # Patching the settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING']
         # value affects the contents of urls.py,
@@ -327,7 +327,7 @@ class AutoAuthRestrictedTestCase(AutoAuthTestCase):
     work as intended.  These restrictions are in place for load tests.
     """
 
-    @patch.dict('django.conf.settings.FEATURES', {'AUTOMATIC_AUTH_FOR_TESTING': True})
+    @override_settings(AUTOMATIC_AUTH_FOR_TESTING=True)
     def setUp(self):
         # Patching the settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING']
         # value affects the contents of urls.py,


### PR DESCRIPTION
## Summary

Migrates 12 more feature flags off `settings.FEATURES['X']` dict-style access onto flat settings (`settings.X`) with `@override_settings(X=Y)` in tests. Follows the pattern established in #38772.

Each commit migrates a single flag:

- ALLOW_PUBLIC_ACCOUNT_CREATION
- SHOW_REGISTRATION_LINKS
- COURSES_ARE_BROWSABLE
- ENABLE_COURSE_SORTING_BY_START_DATE
- ALLOW_WIKI_ROOT_ACCESS
- DISABLE_LIBRARY_CREATION (also adds the flag + annotation to `cms/envs/common.py`)
- AUTOMATIC_AUTH_FOR_TESTING
- ENABLE_CREDIT_ELIGIBILITY
- DISABLE_ADVANCED_SETTINGS
- SHOW_HEADER_LANGUAGE_SELECTOR
- SHOW_LANGUAGE_SELECTOR (deprecated flag, uses `getattr` — not defined in envs)
- SHOW_FOOTER_LANGUAGE_SELECTOR