### PR TITLE
fix: instructor dashboard add info encoded in the request body

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_api_v2.py
@@ -587,6 +587,72 @@ class RescoreViewTestCase(GradingEndpointTestBase):
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert mock_submit.call_args[0][3] is True
 
+    @patch('lms.djangoapps.instructor_task.api.submit_rescore_problem_for_student')
+    def test_rescore_only_if_higher_form_encoded_body(self, mock_submit):
+        """
+        only_if_higher sent form-encoded in the POST body (as the instructor
+        dashboard MFE does) must be honored, not silently dropped.
+
+        Regression test: dropping the flag caused "Rescore Only if Score
+        Improves" to run an unconditional rescore and lower learner scores.
+        """
+        mock_task = MagicMock()
+        mock_task.task_id = str(uuid4())
+        mock_submit.return_value = mock_task
+
+        response = self.client.post(
+            self._get_url(),
+            data='learner=test_student&only_if_higher=true',
+            content_type='application/x-www-form-urlencoded',
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert mock_submit.call_args[0][3] is True
+
+    @patch('lms.djangoapps.instructor_task.api.submit_rescore_problem_for_student')
+    def test_rescore_only_if_higher_json_body(self, mock_submit):
+        """only_if_higher as a JSON boolean in the body is honored."""
+        mock_task = MagicMock()
+        mock_task.task_id = str(uuid4())
+        mock_submit.return_value = mock_task
+
+        response = self.client.post(
+            self._get_url(),
+            data={'learner': 'test_student', 'only_if_higher': True},
+            content_type='application/json',
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert mock_submit.call_args[0][3] is True
+
+    @patch('lms.djangoapps.instructor_task.api.submit_rescore_problem_for_student')
+    def test_rescore_only_if_higher_false_in_body(self, mock_submit):
+        """An explicit 'false' string in the body resolves to False."""
+        mock_task = MagicMock()
+        mock_task.task_id = str(uuid4())
+        mock_submit.return_value = mock_task
+
+        response = self.client.post(
+            self._get_url(),
+            data='learner=test_student&only_if_higher=false',
+            content_type='application/x-www-form-urlencoded',
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert mock_submit.call_args[0][3] is False
+
+    @patch('lms.djangoapps.instructor_task.api.submit_rescore_problem_for_student')
+    def test_rescore_only_if_higher_query_param_wins_over_body(self, mock_submit):
+        """The documented query-param contract takes precedence over a conflicting body value."""
+        mock_task = MagicMock()
+        mock_task.task_id = str(uuid4())
+        mock_submit.return_value = mock_task
+
+        response = self.client.post(
+            self._get_url() + '?only_if_higher=true',
+            data='learner=test_student&only_if_higher=false',
+            content_type='application/x-www-form-urlencoded',
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert mock_submit.call_args[0][3] is True
+
     @patch('lms.djangoapps.instructor_task.tasks.rescore_problem.apply_async')
     def test_rescore_all_learners(self, mock_apply):
         """Bulk rescore queues a task and returns 202."""

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -3605,6 +3605,22 @@ def _get_learner_identifier(request):
     return request.query_params.get('learner') or request.data.get('learner')
 
 
+def _get_only_if_higher(request):
+    """
+    Extract the only_if_higher flag from query params or request body.
+
+    Accepts a 'true' string (case-insensitive) or a JSON boolean. Reading the
+    body as well as query params matches ``_get_learner_identifier``, since the
+    instructor dashboard MFE sends these fields form-encoded in the POST body.
+    """
+    value = request.query_params.get('only_if_higher')
+    if value is None:
+        value = request.data.get('only_if_higher')
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() == 'true'
+
+
 def _parse_course_and_problem(course_id, problem):
     """
     Parse and validate course_id and problem location strings.
@@ -3871,7 +3887,8 @@ class RescoreView(DeveloperErrorViewMixin, APIView):
     **POST** with `learner` query param: rescores a single learner (asynchronous task).
     **POST** without `learner`: rescores all learners (asynchronous task).
 
-    Optionally accepts `only_if_higher=true` query param to only update if new score is higher.
+    Optionally accepts `only_if_higher=true` (query param or request body) to only
+    update if the new score is higher.
     """
     permission_classes = (IsAuthenticated, permissions.InstructorPermission)
     permission_name = permissions.OVERRIDE_GRADES
@@ -3914,7 +3931,7 @@ class RescoreView(DeveloperErrorViewMixin, APIView):
             return error_response
         course_key, usage_key = parsed
 
-        only_if_higher = request.query_params.get('only_if_higher', 'false').lower() == 'true'
+        only_if_higher = _get_only_if_higher(request)
         learner_identifier = _get_learner_identifier(request)
 
         if learner_identifier:

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -3913,7 +3913,9 @@ class RescoreView(DeveloperErrorViewMixin, APIView):
             apidocs.string_parameter(
                 'only_if_higher',
                 apidocs.ParameterLocation.QUERY,
-                description="Optional: If 'true', only update scores that are higher than current.",
+                description="Optional: If 'true', only update scores that are higher than current. "
+                            "May be provided as a query parameter or in the request body "
+                            "(JSON boolean or string).",
             ),
         ],
         responses={


### PR DESCRIPTION
## Description
This pull request improves how the `only_if_higher` flag is handled in the instructor API for rescoring learners. The main change is to consistently support reading the flag from both query parameters and the request body, matching how the frontend sends data. This also makes the code more robust by accepting both boolean and string values for the flag.

**Improvements to request handling:**

* Added a new `_get_only_if_higher` helper function to extract the `only_if_higher` flag from either query parameters or the request body, accepting both string and boolean representations.
* Updated the `RescoreView` endpoint and its documentation to clarify that `only_if_higher` can be provided in either the query string or request body.
* Replaced the previous direct query param check for `only_if_higher` in the `post` method with the new helper for consistent and reliable extraction.

## Supporting Information
https://github.com/mitodl/hq/issues/11874 (MIT Internal)

## Testing instructions

### Steps to Reproduce
Make sure you have a course with graded sub-section with at least one problem(multi-select would do)

1. Enroll yourself as a learner in course.
2. Log in as the learner account.
3. Go to the unit page
4. Go to the first question "Multiple Choice" and choose "Correct Answer" - click submit.
5. You will see your score is reflected as correct
6. Log in as a staff member.
7. Go to the problem's unit in studio
8. Click the pencil icon to edit the that problem, "Multiple choice"
9. Scroll to Answers
10. Change the correct answer to be "Incorrect*"
11. Save your changes and publish the page.
12. Go to the grading module on the instructor dashboard
13. Type your learner account information into "Specify Learner", click "Select"
14. Put the location block for the problem into "Specify Problem", click "Select"
15. The page will update with the learner's responses to the problem.
16. Next to "Rescore submission" click "Rescore only if score improves", and confirm "rescore"
17. Reload the page and enter the learner name and problem block again.
18. The score should be same, 1/1
19. Log in as your learner and reload the unit with the problem
20. You should see that you are marked 1.0/1.0