### PR TITLE
feat: scope immediate notification email batching per user (backport #38866)

### DIFF
--- a/openedx/core/djangoapps/notifications/email/tasks.py
+++ b/openedx/core/djangoapps/notifications/email/tasks.py
@@ -15,7 +15,6 @@ from django.utils.translation import override as translation_override
 from edx_ace import ace
 from edx_ace.recipient import Recipient
 from edx_django_utils.monitoring import set_code_owner_attribute
-from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.notifications.email_notifications import EmailCadence
 from openedx.core.djangoapps.notifications.models import (
@@ -530,6 +529,13 @@ def decide_email_action(user: User, course_key: str, notification: Notification)
     """
     Decide what to do with this notification.
 
+    The immediate-email buffer is scoped per user (not per user + course): a
+    learner who just received an immediate email for any enrolled course has
+    subsequent immediate notifications — regardless of course — grouped into a
+    single buffered digest. ``course_key`` is accepted for signature stability
+    and is used by the caller for the immediate-email content, but it no longer
+    affects the batching decision.
+
     Logic:
     - No recent email? → send_immediate (1st)
     - Recent email + no buffer? → schedule_buffer (2nd)
@@ -541,10 +547,10 @@ def decide_email_action(user: User, course_key: str, notification: Notification)
     buffer_minutes = get_buffer_minutes()
     buffer_threshold = datetime.now() - timedelta(minutes=buffer_minutes)
 
-    # Use select_for_update to prevent race conditions
+    # Use select_for_update to prevent race conditions.
+    # Scoped by user only so all of the user's courses share one buffer window.
     recent_notifications = Notification.objects.select_for_update().filter(
         user=user,
-        course_id=course_key,
         created__gte=buffer_threshold
     )
 
@@ -644,13 +650,19 @@ def schedule_digest_buffer(
     """
     Schedule a buffer job for digest email.
     Called for the SECOND notification only.
+
+    The digest is scheduled ``buffer_minutes`` after the user's most recent
+    immediate email (``last_sent.email_sent_on``), not ``buffer_minutes`` after
+    this second notification. This keeps the delay between the immediate email
+    and its follow-up digest fixed at ``buffer_minutes``, no matter how long the
+    second notification takes to arrive.
     """
     buffer_minutes = get_buffer_minutes()
 
-    # Find when we last sent an email
+    # Find when we last sent an email to this user (across all courses — the
+    # buffer is per user, so the digest window starts at the user's most recent send).
     last_sent = Notification.objects.filter(
         user=user,
-        course_id=course_key,
         email_sent_on__isnull=False
     ).order_by('-email_sent_on').first()
 
@@ -659,7 +671,15 @@ def schedule_digest_buffer(
         return
 
     start_date = last_sent.email_sent_on
-    scheduled_time = datetime.now() + timedelta(minutes=buffer_minutes)
+    # Anchor the digest to the immediate email that opened this buffer window, so the
+    # total wait before the digest is a consistent ``buffer_minutes`` regardless of how
+    # long after the immediate email the second notification arrives. If that window has
+    # already elapsed (the second notification came in more than ``buffer_minutes`` later),
+    # fall back to "now" so the digest fires promptly instead of being scheduled in the past.
+    scheduled_time = max(
+        start_date + timedelta(minutes=buffer_minutes),
+        django_timezone.now(),
+    )
 
     # Mark this notification as scheduled FIRST
     notification.email_scheduled = True
@@ -711,7 +731,11 @@ def send_buffered_digest(
     Send digest email with all buffered notifications.
 
     This collects ALL notifications where email_scheduled=True
-    for this user+course within the buffer period.
+    for this user within the buffer period, regardless of course.
+
+    ``course_key`` is retained in the signature for compatibility with tasks
+    that were enqueued before the per-user batching change; it is no longer
+    used to filter notifications.
 
     Simple! No task ID tracking needed.
     """
@@ -729,11 +753,10 @@ def send_buffered_digest(
 
         end_date = datetime.now()
 
-        # Get ALL scheduled notifications
+        # Get ALL scheduled notifications for the user (across every course).
         # Simple query: just find where email_scheduled=True
         scheduled_notifications = Notification.objects.filter(
             user=user,
-            course_id=course_key,
             email_scheduled=True,  # This is all we need!
             created__gte=start_date,
             created__lte=end_date,
@@ -764,10 +787,9 @@ def send_buffered_digest(
                 scheduled_notifications.update(email_scheduled=False)
                 return
 
-            # Build digest email
+            # Build digest email. The digest may span multiple courses; per-notification
+            # course names are resolved on demand inside create_email_digest_context.
             apps_dict = create_app_notifications_dict(notifications_list)
-            course_key = CourseKey.from_string(course_key)
-            course_name = get_course_info(course_key).get("name", course_key)
 
             message_context = create_email_digest_context(
                 apps_dict,
@@ -775,7 +797,7 @@ def send_buffered_digest(
                 start_date,
                 end_date,
                 EmailCadence.IMMEDIATELY,
-                courses_data={course_key: {'name': course_name}}
+                courses_data={}
             )
 
             # Send digest

--- a/openedx/core/djangoapps/notifications/email/tests/test_tasks.py
+++ b/openedx/core/djangoapps/notifications/email/tests/test_tasks.py
@@ -457,22 +457,24 @@ class TestDecideEmailAction(ModuleStoreTestCase):
         assert decision == 'send_immediate'
 
     @freeze_time("2025-12-15 10:00:00")
-    def test_different_course_doesnt_affect_decision(self):
-        """Test that notifications from different courses are independent."""
+    @override_settings(NOTIFICATION_IMMEDIATE_EMAIL_BUFFER_MINUTES=15)
+    def test_recent_email_in_different_course_schedules_buffer(self):
+        """A recent email in another course counts toward the user-level buffer."""
         other_course = CourseFactory.create()
 
-        # Notification from different course
+        # Email recently sent for a different course
         self._create_notification(
             course_id=str(other_course.id),
             email_sent_on=timezone.now() - timedelta(minutes=5)
         )
 
-        # This course should still send immediate
+        # New notification in this course should join the shared (per-user) buffer,
+        # not send immediately, because the user already got a recent email.
         notification = self._create_notification()
 
         decision = decide_email_action(self.user, self.course_key, notification)
 
-        assert decision == 'send_immediate'
+        assert decision == 'schedule_buffer'
 
     @freeze_time("2025-12-15 10:00:00")
     def test_race_condition_protection(self):
@@ -568,9 +570,10 @@ class TestScheduleDigestBuffer(ModuleStoreTestCase):
     @freeze_time("2025-12-15 10:00:00", tz_offset=0)
     @patch('openedx.core.djangoapps.notifications.email.tasks.send_buffered_digest.apply_async')
     @override_settings(NOTIFICATION_IMMEDIATE_EMAIL_BUFFER_MINUTES=15)
-    def test_buffer_scheduled_with_correct_delay(self, mock_apply_async):
-        """Test that buffer task is scheduled with correct countdown."""
-        # Create notification that was sent 5 minutes ago
+    def test_buffer_scheduled_relative_to_last_email(self, mock_apply_async):
+        """Digest is scheduled buffer_minutes after the last immediate email, not after 'now'."""
+        # Immediate email was sent 5 minutes ago
+        last_sent = timezone.now() - timedelta(minutes=5)
         Notification.objects.create(
             user=self.user,
             course_id=self.course_key,
@@ -578,7 +581,7 @@ class TestScheduleDigestBuffer(ModuleStoreTestCase):
             notification_type='new_discussion_post',
             content_url='http://example.com',
             email=True,
-            email_sent_on=timezone.now() - timedelta(minutes=5)
+            email_sent_on=last_sent
         )
 
         new_notification = Notification.objects.create(
@@ -604,16 +607,59 @@ class TestScheduleDigestBuffer(ModuleStoreTestCase):
         new_notification.refresh_from_db()
         assert new_notification.email_scheduled is True
 
-        # Verify scheduled time (should be 15 minutes from now)
+        # ETA should be 15 minutes after the last email (i.e. now + 10), NOT now + 15.
         call_kwargs = mock_apply_async.call_args[1]
         eta = call_kwargs['eta']
-        expected_eta = timezone.now() + timedelta(minutes=15)
+        expected_eta = last_sent + timedelta(minutes=15)
         if timezone.is_naive(eta) and timezone.is_aware(expected_eta):
             expected_eta = timezone.make_naive(expected_eta)
         elif timezone.is_aware(eta) and timezone.is_naive(expected_eta):
             expected_eta = timezone.make_aware(expected_eta)
-        # --- FIX END ---
         # Allow 1 second tolerance
+        assert abs((eta - expected_eta).total_seconds()) < 1
+
+    @freeze_time("2025-12-15 10:00:00", tz_offset=0)
+    @patch('openedx.core.djangoapps.notifications.email.tasks.send_buffered_digest.apply_async')
+    @override_settings(NOTIFICATION_IMMEDIATE_EMAIL_BUFFER_MINUTES=15)
+    def test_buffer_fires_now_when_window_already_elapsed(self, mock_apply_async):
+        """If the second notification arrives after the buffer window has passed, fire promptly."""
+        # Immediate email was sent 20 minutes ago — already past the 15 minute window
+        Notification.objects.create(
+            user=self.user,
+            course_id=self.course_key,
+            app_name='discussion',
+            notification_type='new_discussion_post',
+            content_url='http://example.com',
+            email=True,
+            email_sent_on=timezone.now() - timedelta(minutes=20)
+        )
+
+        new_notification = Notification.objects.create(
+            user=self.user,
+            course_id=self.course_key,
+            app_name='discussion',
+            notification_type='new_discussion_post',
+            content_url='http://example.com',
+            email=True,
+        )
+
+        schedule_digest_buffer(
+            user=self.user,
+            notification=new_notification,
+            course_key=self.course_key,
+            user_language='en'
+        )
+
+        assert mock_apply_async.called
+
+        # ETA is clamped to "now" instead of being scheduled 5 minutes in the past.
+        call_kwargs = mock_apply_async.call_args[1]
+        eta = call_kwargs['eta']
+        expected_eta = timezone.now()
+        if timezone.is_naive(eta) and timezone.is_aware(expected_eta):
+            expected_eta = timezone.make_naive(expected_eta)
+        elif timezone.is_aware(eta) and timezone.is_naive(expected_eta):
+            expected_eta = timezone.make_aware(expected_eta)
         assert abs((eta - expected_eta).total_seconds()) < 1
 
     @patch('openedx.core.djangoapps.notifications.email.tasks.send_buffered_digest.apply_async')
@@ -759,6 +805,44 @@ class TestSendBufferedDigest(ModuleStoreTestCase):
         for notif in notifications:
             assert notif.email_sent_on is not None
             assert notif.email_scheduled is False
+
+    @freeze_time("2025-12-15 10:15:00")
+    @patch('openedx.core.djangoapps.notifications.email.tasks.ace.send')
+    def test_digest_collects_notifications_across_courses(self, mock_ace_send):
+        """Buffered digest pools scheduled notifications from all of the user's courses."""
+        course2 = CourseFactory.create(display_name='Second Course')
+        start_time = timezone.now() - timedelta(minutes=15)
+
+        for course_id in (self.course_key, str(course2.id)):
+            Notification.objects.create(
+                user=self.user,
+                course_id=course_id,
+                app_name='discussion',
+                notification_type='new_discussion_post',
+                content_url='http://example.com',
+                content_context=get_new_post_notification_content_context(),
+                email=True,
+                email_scheduled=True,
+                created=start_time + timedelta(minutes=5)
+            )
+
+        send_buffered_digest(  # pylint: disable=no-value-for-parameter
+            user_id=self.user.id,
+            course_key=self.course_key,
+            start_date=start_time,
+            user_language='en'
+        )
+
+        # A single digest email is sent...
+        assert mock_ace_send.call_count == 1
+        # ...covering the notifications from BOTH courses.
+        sent = Notification.objects.filter(
+            user=self.user,
+            email_sent_on__isnull=False,
+            email_scheduled=False,
+        )
+        assert sent.count() == 2
+        assert {str(n.course_id) for n in sent} == {self.course_key, str(course2.id)}
 
     @patch('openedx.core.djangoapps.notifications.email.tasks.ace.send')
     def test_digest_skips_non_scheduled_notifications(self, mock_ace_send):
@@ -1050,12 +1134,14 @@ class TestIntegrationScenarios(ModuleStoreTestCase):
             assert notif2.email_sent_on is not None
             assert notif2.email_scheduled is False
 
-    def test_multiple_courses_independent_buffers(self):
-        """Test that different courses maintain independent buffers."""
+    @freeze_time("2025-12-15 10:00:00")
+    @override_settings(NOTIFICATION_IMMEDIATE_EMAIL_BUFFER_MINUTES=15)
+    def test_multiple_courses_share_buffer(self):
+        """Notifications from different courses share a single per-user buffer."""
         course2 = CourseFactory.create()
 
-        # Notifications in course 1
-        notif1 = Notification.objects.create(  # noqa: F841
+        # Recent email sent for course 1
+        Notification.objects.create(
             user=self.user,
             course_id=self.course.id,
             app_name='discussion',
@@ -1065,7 +1151,7 @@ class TestIntegrationScenarios(ModuleStoreTestCase):
             email_sent_on=timezone.now() - timedelta(minutes=5)
         )
 
-        # Notification in course 2 should be independent
+        # Notification in course 2 should join the shared buffer (not send immediately)
         notif2 = Notification.objects.create(
             user=self.user,
             course_id=str(course2.id),
@@ -1076,7 +1162,7 @@ class TestIntegrationScenarios(ModuleStoreTestCase):
         )
 
         decision = decide_email_action(self.user, str(course2.id), notif2)
-        assert decision == 'send_immediate'
+        assert decision == 'schedule_buffer'
 
 
 def get_new_post_notification_content_context(**kwargs):


### PR DESCRIPTION
Backport of #38866 to `release/verawood`.

Cherry-pick of merged commit `0cbeaec1712e48562bdc9ce1452fd15a9172f430` (squash of #38866). Applied cleanly with no conflicts.

## Original PR summary
Scopes the immediate-notification email batching **per user** instead of per user+course:
- `decide_email_action` no longer filters recent notifications by `course_id`, so a recent immediate email for *any* enrolled course now buffers subsequent immediate notifications into one digest.
- `schedule_digest_buffer` anchors the digest ETA to the user's last immediate email (`last_sent.email_sent_on` + `buffer_minutes`), falling back to `now` if that window already elapsed.
- `send_buffered_digest` collects all scheduled notifications for the user across every course; `course_key` is retained in signatures for compatibility but no longer filters.
- Tests updated to match the per-user batching behavior.

Original PR: https://github.com/openedx/openedx-platform/pull/38866