### PR TITLE
fix: multiple fixes from openedx-core 1.0.3

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -61,10 +61,8 @@ libsass==0.10.0
 numpy<2.0.0
 
 # Date: 2023-09-18
-# Library is still in active development. Major versions require review
-# from openedx-maintainers. Minor and patch versions can roll out automatically.
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35269
-openedx-core<2
+# Verawood uses the 1.0 set of patch fixes for openedx-core
+openedx-core<1.1
 
 # Date: 2023-11-29
 # Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -840,7 +840,7 @@ openedx-calc==5.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   xblocks-contrib
-openedx-core==1.0.2
+openedx-core==1.0.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1383,7 +1383,7 @@ openedx-calc==5.0.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   xblocks-contrib
-openedx-core==1.0.2
+openedx-core==1.0.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/doc.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1018,7 +1018,7 @@ openedx-calc==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-openedx-core==1.0.2
+openedx-core==1.0.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1058,7 +1058,7 @@ openedx-calc==5.0.0
     # via
     #   -r requirements/edx/base.txt
     #   xblocks-contrib
-openedx-core==1.0.2
+openedx-core==1.0.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
These bring in library fixes around importing content with blank titles, restoring entities from archives where the keys do not match the file names, as well as a small tweak to reduce the size of backup archives.

It also changes the constraints in the Verawood branch to pull only from the 1.0.x series of releases of openedx-core, not < 2 as done previously (we're currently on 1.1 in the main branch).

FYI @farhaanbukhsh, @mariajgrimaldi 