### PR TITLE
feat: implement toggle for redacting PII in ManualVerification during user retirement

### DIFF
--- a/lms/djangoapps/verify_student/config.py
+++ b/lms/djangoapps/verify_student/config.py
@@ -1,0 +1,16 @@
+"""
+Configuration toggles for the verify_student app.
+"""
+
+from edx_toggles.toggles import SettingToggle
+
+# .. toggle_name: REDACT_MANUAL_VERIFICATION_HISTORICAL_PII
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: False
+# .. toggle_description: Clears the `name` field for `ManualVerification` records
+#      before deleting those rows during learner retirement.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2026-07-15
+REDACT_MANUAL_VERIFICATION_HISTORICAL_PII = SettingToggle(
+    'REDACT_MANUAL_VERIFICATION_HISTORICAL_PII', default=False, module_name=__name__
+)

--- a/lms/djangoapps/verify_student/config.py
+++ b/lms/djangoapps/verify_student/config.py
@@ -1,5 +1,5 @@
 """
-Configuration toggles for the verify_student app.
+Configuration toggles for ManualVerification retirement.
 """
 
 from edx_toggles.toggles import SettingToggle

--- a/lms/djangoapps/verify_student/config.py
+++ b/lms/djangoapps/verify_student/config.py
@@ -8,7 +8,7 @@ from edx_toggles.toggles import SettingToggle
 # .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: Clears the `name` field for `ManualVerification` records
-#      before deleting those rows during learner retirement.
+#      before deleting those rows during user retirement.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2026-07-15
 REDACT_MANUAL_VERIFICATION_HISTORICAL_PII = SettingToggle(

--- a/lms/djangoapps/verify_student/config.py
+++ b/lms/djangoapps/verify_student/config.py
@@ -1,5 +1,5 @@
 """
-Configuration toggles for ManualVerification retirement.
+Configuration toggles for ManualVerification.
 """
 
 from edx_toggles.toggles import SettingToggle

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -198,7 +198,7 @@ class ManualVerification(IDVerificationAttempt, DeletableByUserValue):
     @classmethod
     def redact_before_delete_fields(cls):
         """
-        Redact PII fields before delete in downstream soft-delete systems.
+        Clear PII fields before delete in downstream soft-delete systems.
         """
         return {'name': ''}
 

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -43,6 +43,7 @@ from lms.djangoapps.verify_student.ssencrypt import (
 )
 from lms.djangoapps.verify_student.statuses import VerificationAttemptStatus
 from openedx.core.djangoapps.signals.signals import LEARNER_SSO_VERIFIED, PHOTO_VERIFICATION_APPROVED
+from openedx.core.djangolib.model_mixins import DeletableByUserValue
 
 from .utils import auto_verify_for_testing_enabled, earliest_allowed_verification_date, submit_request_to_ss
 
@@ -158,10 +159,13 @@ class IDVerificationAttempt(StatusModel):
         )
 
 
-class ManualVerification(IDVerificationAttempt):
+class ManualVerification(IDVerificationAttempt, DeletableByUserValue):
     """
     Each ManualVerification represents a user's verification that bypasses the need for
     any other verification.
+
+    The PII is retained by default, but can be redacted during retirement
+    by enabling ``REDACT_MANUAL_VERIFICATION_HISTORICAL_PII``.
 
     .. pii: The User's name is stored in the parent model
     .. pii_types: name
@@ -190,6 +194,13 @@ class ManualVerification(IDVerificationAttempt):
         Whether or not the status should be displayed to the user.
         """
         return False
+
+    @classmethod
+    def redact_before_delete_fields(cls):
+        """
+        Redact PII fields before delete in downstream soft-delete systems.
+        """
+        return {'name': ''}
 
 
 class SSOVerification(IDVerificationAttempt):

--- a/lms/djangoapps/verify_student/signals/handlers.py
+++ b/lms/djangoapps/verify_student/signals/handlers.py
@@ -9,7 +9,9 @@ from django.dispatch.dispatcher import receiver
 
 from common.djangoapps.student.models_api import get_name, get_pending_name_change
 from lms.djangoapps.verify_student.apps import VerifyStudentConfig  # pylint: disable=unused-import  # noqa: F401
+from lms.djangoapps.verify_student.config import REDACT_MANUAL_VERIFICATION_HISTORICAL_PII
 from lms.djangoapps.verify_student.models import (
+    ManualVerification,
     SoftwareSecurePhotoVerification,
     VerificationAttempt,
     VerificationDeadline,
@@ -39,8 +41,13 @@ def _listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable
 
 @receiver(USER_RETIRE_LMS_CRITICAL)
 def _listen_for_lms_retire(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    Retire verify_student records handled in the LMS critical retirement phase.
+    """
     user = kwargs.get('user')
     SoftwareSecurePhotoVerification.retire_user(user.id)
+    if REDACT_MANUAL_VERIFICATION_HISTORICAL_PII.is_enabled():
+        ManualVerification.delete_by_user_value(value=user.id, field='user_id')
 
 
 @receiver(post_save, sender=SoftwareSecurePhotoVerification)

--- a/lms/djangoapps/verify_student/signals/handlers.py
+++ b/lms/djangoapps/verify_student/signals/handlers.py
@@ -42,7 +42,7 @@ def _listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable
 @receiver(USER_RETIRE_LMS_CRITICAL)
 def _listen_for_lms_retire(sender, **kwargs):  # pylint: disable=unused-argument
     """
-    Retire verify_student records handled in the LMS critical retirement phase.
+    Retire verify_student records handled in the LMS retirement.
     """
     user = kwargs.get('user')
     SoftwareSecurePhotoVerification.retire_user(user.id)

--- a/lms/djangoapps/verify_student/tests/test_handlers.py
+++ b/lms/djangoapps/verify_student/tests/test_handlers.py
@@ -5,6 +5,7 @@ Unit tests for the VerificationDeadline signals
 from datetime import timedelta
 from unittest.mock import patch  # pylint: disable=wrong-import-order
 
+import ddt
 from django.db import connection
 from django.test import override_settings
 from django.test.utils import CaptureQueriesContext
@@ -72,6 +73,7 @@ class VerificationDeadlineHandlerTest(ModuleStoreTestCase):
         assert actual_deadline == deadline
 
 
+@ddt.ddt
 class RetirementHandlerTest(ModuleStoreTestCase):
     """
     Tests for verify_student handlers in the LMS retirement flow.
@@ -122,7 +124,8 @@ class RetirementHandlerTest(ModuleStoreTestCase):
         for field in ('name', 'face_image_url', 'photo_id_image_url', 'photo_id_key'):
             assert '' == getattr(ver_obj, field)
 
-    def test_manual_verification_retained_when_toggle_disabled(self):
+    @ddt.data(False, True)
+    def test_manual_verification_retirement_behavior(self, toggle_enabled):
         user = UserFactory()
         other_user = UserFactory()
         user_name = 'Manual Verification Name'
@@ -137,39 +140,25 @@ class RetirementHandlerTest(ModuleStoreTestCase):
             status='approved',
         )
 
-        with override_settings(REDACT_MANUAL_VERIFICATION_HISTORICAL_PII=False):
-            _listen_for_lms_retire(sender=self.__class__, user=user)
-
-        manual_verification = ManualVerification.objects.get(user=user)
-        assert manual_verification.name == user_name
-        assert ManualVerification.objects.filter(user=user).exists()
-        assert ManualVerification.objects.filter(user=other_user, name=user_name).exists()
-
-    def test_manual_verification_redacted_and_deleted_when_toggle_enabled(self):
-        user = UserFactory()
-        other_user = UserFactory()
-        user_name = 'Manual Verification Name'
-        ManualVerification.objects.create(
-            user=user,
-            name=user_name,
-            status='approved',
-        )
-        ManualVerification.objects.create(
-            user=other_user,
-            name=user_name,
-            status='approved',
-        )
-
-        with override_settings(REDACT_MANUAL_VERIFICATION_HISTORICAL_PII=True):
-            with CaptureQueriesContext(connection) as context:
+        with override_settings(REDACT_MANUAL_VERIFICATION_HISTORICAL_PII=toggle_enabled):
+            if toggle_enabled:
+                with CaptureQueriesContext(connection) as context:
+                    _listen_for_lms_retire(sender=self.__class__, user=user)
+                assert_redact_before_delete(
+                    [query['sql'] for query in context.captured_queries],
+                    table=ManualVerification._meta.db_table,
+                    expected_redacted_value_list=[''],
+                )
+            else:
                 _listen_for_lms_retire(sender=self.__class__, user=user)
 
-        assert_redact_before_delete(
-            [query['sql'] for query in context.captured_queries],
-            table=ManualVerification._meta.db_table,
-            expected_redacted_value_list=[''],
-        )
-        assert not ManualVerification.objects.filter(user=user).exists()
+        if toggle_enabled:
+            assert not ManualVerification.objects.filter(user=user).exists()
+        else:
+            manual_verification = ManualVerification.objects.get(user=user)
+            assert manual_verification.name == user_name
+            assert ManualVerification.objects.filter(user=user).exists()
+
         assert ManualVerification.objects.filter(user=other_user, name=user_name).exists()
 
 

--- a/lms/djangoapps/verify_student/tests/test_handlers.py
+++ b/lms/djangoapps/verify_student/tests/test_handlers.py
@@ -2,7 +2,6 @@
 Unit tests for the VerificationDeadline signals
 """
 
-import ddt
 from datetime import timedelta
 from unittest.mock import patch  # pylint: disable=wrong-import-order
 
@@ -73,7 +72,6 @@ class VerificationDeadlineHandlerTest(ModuleStoreTestCase):
         assert actual_deadline == deadline
 
 
-@ddt.ddt
 class RetirementHandlerTest(ModuleStoreTestCase):
     """
     Tests for verify_student handlers in the LMS retirement flow.
@@ -124,11 +122,7 @@ class RetirementHandlerTest(ModuleStoreTestCase):
         for field in ('name', 'face_image_url', 'photo_id_image_url', 'photo_id_key'):
             assert '' == getattr(ver_obj, field)
 
-    @ddt.data(
-        ddt.named_data('toggle_disabled_retains_record', False),
-        ddt.named_data('toggle_enabled_redacts_and_deletes', True),
-    )
-    def test_manual_verification_retirement_behavior(self, toggle_enabled):
+    def test_manual_verification_retained_when_toggle_disabled(self):
         user = UserFactory()
         other_user = UserFactory()
         user_name = 'Manual Verification Name'
@@ -143,23 +137,39 @@ class RetirementHandlerTest(ModuleStoreTestCase):
             status='approved',
         )
 
-        with override_settings(REDACT_MANUAL_VERIFICATION_HISTORICAL_PII=toggle_enabled):
-            if toggle_enabled:
-                with CaptureQueriesContext(connection) as context:
-                    _listen_for_lms_retire(sender=self.__class__, user=user)
-                assert_redact_before_delete(
-                    [query['sql'] for query in context.captured_queries],
-                    table=ManualVerification._meta.db_table,
-                    expected_redacted_value_list=[''],
-                )
-            else:
+        with override_settings(REDACT_MANUAL_VERIFICATION_HISTORICAL_PII=False):
+            _listen_for_lms_retire(sender=self.__class__, user=user)
+
+        manual_verification = ManualVerification.objects.get(user=user)
+        assert manual_verification.name == user_name
+        assert ManualVerification.objects.filter(user=user).exists()
+        assert ManualVerification.objects.filter(user=other_user, name=user_name).exists()
+
+    def test_manual_verification_redacted_and_deleted_when_toggle_enabled(self):
+        user = UserFactory()
+        other_user = UserFactory()
+        user_name = 'Manual Verification Name'
+        ManualVerification.objects.create(
+            user=user,
+            name=user_name,
+            status='approved',
+        )
+        ManualVerification.objects.create(
+            user=other_user,
+            name=user_name,
+            status='approved',
+        )
+
+        with override_settings(REDACT_MANUAL_VERIFICATION_HISTORICAL_PII=True):
+            with CaptureQueriesContext(connection) as context:
                 _listen_for_lms_retire(sender=self.__class__, user=user)
 
-        if toggle_enabled:
-            assert not ManualVerification.objects.filter(user=user).exists()
-        else:
-            manual_verification = ManualVerification.objects.get(user=user)
-            assert manual_verification.name == user_name
+        assert_redact_before_delete(
+            [query['sql'] for query in context.captured_queries],
+            table=ManualVerification._meta.db_table,
+            expected_redacted_value_list=[''],
+        )
+        assert not ManualVerification.objects.filter(user=user).exists()
         assert ManualVerification.objects.filter(user=other_user, name=user_name).exists()
 
 

--- a/lms/djangoapps/verify_student/tests/test_handlers.py
+++ b/lms/djangoapps/verify_student/tests/test_handlers.py
@@ -5,7 +5,6 @@ Unit tests for the VerificationDeadline signals
 from datetime import timedelta
 from unittest.mock import patch  # pylint: disable=wrong-import-order
 
-import ddt
 from django.db import connection
 from django.test import override_settings
 from django.test.utils import CaptureQueriesContext
@@ -73,7 +72,6 @@ class VerificationDeadlineHandlerTest(ModuleStoreTestCase):
         assert actual_deadline == deadline
 
 
-@ddt.ddt
 class RetirementHandlerTest(ModuleStoreTestCase):
     """
     Tests for verify_student handlers in the LMS retirement flow.
@@ -124,8 +122,7 @@ class RetirementHandlerTest(ModuleStoreTestCase):
         for field in ('name', 'face_image_url', 'photo_id_image_url', 'photo_id_key'):
             assert '' == getattr(ver_obj, field)
 
-    @ddt.data(False, True)
-    def test_manual_verification_retirement_behavior(self, toggle_enabled):
+    def test_manual_verification_retirement_behavior(self):
         user = UserFactory()
         other_user = UserFactory()
         user_name = 'Manual Verification Name'
@@ -140,24 +137,24 @@ class RetirementHandlerTest(ModuleStoreTestCase):
             status='approved',
         )
 
-        with override_settings(REDACT_MANUAL_VERIFICATION_HISTORICAL_PII=toggle_enabled):
-            if toggle_enabled:
-                with CaptureQueriesContext(connection) as context:
-                    _listen_for_lms_retire(sender=self.__class__, user=user)
-                assert_redact_before_delete(
-                    [query['sql'] for query in context.captured_queries],
-                    table=ManualVerification._meta.db_table,
-                    expected_redacted_value_list=[''],
-                )
-            else:
+        with override_settings(REDACT_MANUAL_VERIFICATION_HISTORICAL_PII=False):
+            _listen_for_lms_retire(sender=self.__class__, user=user)
+
+        manual_verification = ManualVerification.objects.get(user=user)
+        assert manual_verification.name == user_name
+        assert ManualVerification.objects.filter(user=user).exists()
+        assert ManualVerification.objects.filter(user=other_user, name=user_name).exists()
+
+        with override_settings(REDACT_MANUAL_VERIFICATION_HISTORICAL_PII=True):
+            with CaptureQueriesContext(connection) as context:
                 _listen_for_lms_retire(sender=self.__class__, user=user)
 
-        if toggle_enabled:
-            assert not ManualVerification.objects.filter(user=user).exists()
-        else:
-            manual_verification = ManualVerification.objects.get(user=user)
-            assert manual_verification.name == user_name
-            assert ManualVerification.objects.filter(user=user).exists()
+        assert_redact_before_delete(
+            [query['sql'] for query in context.captured_queries],
+            table=ManualVerification._meta.db_table,
+            expected_redacted_value_list=[''],
+        )
+        assert not ManualVerification.objects.filter(user=user).exists()
 
         assert ManualVerification.objects.filter(user=other_user, name=user_name).exists()
 

--- a/lms/djangoapps/verify_student/tests/test_handlers.py
+++ b/lms/djangoapps/verify_student/tests/test_handlers.py
@@ -2,15 +2,19 @@
 Unit tests for the VerificationDeadline signals
 """
 
-
+import ddt
 from datetime import timedelta
 from unittest.mock import patch  # pylint: disable=wrong-import-order
 
+from django.db import connection
+from django.test import override_settings
+from django.test.utils import CaptureQueriesContext
 from django.utils.timezone import now
 
 from common.djangoapps.student.models_api import do_name_change_request
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.verify_student.models import (
+    ManualVerification,
     SoftwareSecurePhotoVerification,
     VerificationAttempt,
     VerificationDeadline,
@@ -25,6 +29,7 @@ from lms.djangoapps.verify_student.tests.factories import (
     VerificationAttemptFactory,
 )
 from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import fake_completed_retirement
+from openedx.core.djangolib.testing.utils import assert_redact_before_delete
 from xmodule.modulestore.tests.django_utils import (
     ModuleStoreTestCase,  # pylint: disable=wrong-import-order
 )
@@ -68,9 +73,10 @@ class VerificationDeadlineHandlerTest(ModuleStoreTestCase):
         assert actual_deadline == deadline
 
 
+@ddt.ddt
 class RetirementHandlerTest(ModuleStoreTestCase):
     """
-    Tests for the VerificationDeadline handler
+    Tests for verify_student handlers in the LMS retirement flow.
     """
 
     def _create_entry(self):
@@ -117,6 +123,44 @@ class RetirementHandlerTest(ModuleStoreTestCase):
         # All values for this user should now be empty string
         for field in ('name', 'face_image_url', 'photo_id_image_url', 'photo_id_key'):
             assert '' == getattr(ver_obj, field)
+
+    @ddt.data(
+        ddt.named_data('toggle_disabled_retains_record', False),
+        ddt.named_data('toggle_enabled_redacts_and_deletes', True),
+    )
+    def test_manual_verification_retirement_behavior(self, toggle_enabled):
+        user = UserFactory()
+        other_user = UserFactory()
+        user_name = 'Manual Verification Name'
+        ManualVerification.objects.create(
+            user=user,
+            name=user_name,
+            status='approved',
+        )
+        ManualVerification.objects.create(
+            user=other_user,
+            name=user_name,
+            status='approved',
+        )
+
+        with override_settings(REDACT_MANUAL_VERIFICATION_HISTORICAL_PII=toggle_enabled):
+            if toggle_enabled:
+                with CaptureQueriesContext(connection) as context:
+                    _listen_for_lms_retire(sender=self.__class__, user=user)
+                assert_redact_before_delete(
+                    [query['sql'] for query in context.captured_queries],
+                    table=ManualVerification._meta.db_table,
+                    expected_redacted_value_list=[''],
+                )
+            else:
+                _listen_for_lms_retire(sender=self.__class__, user=user)
+
+        if toggle_enabled:
+            assert not ManualVerification.objects.filter(user=user).exists()
+        else:
+            manual_verification = ManualVerification.objects.get(user=user)
+            assert manual_verification.name == user_name
+        assert ManualVerification.objects.filter(user=other_user, name=user_name).exists()
 
 
 class PostSavePhotoVerificationTest(ModuleStoreTestCase):


### PR DESCRIPTION
## Summary
Adds an optional way to remove old ManualVerification personal data during LMS retirement. By default, nothing changes and the records are kept. If `REDACT_MANUAL_VERIFICATION_HISTORICAL_PII` is turned on, the system first removes personal information (like the name) from ManualVerification records and then deletes those records. Tests confirm that the data is removed before deletion and that only the correct records are affected.


## Private Jira Ticket
https://2u-internal.atlassian.net/browse/BOMS-680