### PR TITLE
temp: Test for new openedx-events

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tasks.py
+++ b/openedx/core/djangoapps/content_libraries/tasks.py
@@ -122,6 +122,7 @@ def send_change_events_for_modified_entities(
     for entity in entities:
         change = changes_by_entity_id[entity.id]
         entity_opaque_key: LibraryUsageLocatorV2 | LibraryContainerLocator
+        event_data: LibraryBlockData | LibraryContainerData
         if hasattr(entity, "component"):
             # This is a library XBlock (component)
             entity_opaque_key = api.library_component_usage_key(library.library_key, entity.component)

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
@@ -231,7 +231,9 @@ class ObjectTagOrgView(ObjectTagView):
         """
         response = super().update(request, *args, **kwargs)
         if response.status_code == 200:
-            object_id = kwargs.get('object_id')
+            # object_id is the URL route parameter and is guaranteed present here,
+            # since a 200 response means the parent update resolved the object.
+            object_id: str = kwargs['object_id']
 
             # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
             # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1

--- a/openedx/core/djangoapps/notifications/handlers.py
+++ b/openedx/core/djangoapps/notifications/handlers.py
@@ -3,6 +3,7 @@ Handlers for notifications
 """
 import logging
 
+import attrs
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, ProgrammingError, transaction
 from django.db.models.signals import post_save
@@ -61,7 +62,9 @@ def generate_user_notifications(signal, sender, notification_data, metadata, **k
     """
 
     from openedx.core.djangoapps.notifications.tasks import send_notifications
-    notification_data = notification_data.__dict__
+    # openedx-events data classes are slotted attrs classes (no __dict__); asdict
+    # returns a fresh, mutable dict. recurse=False keeps nested values intact.
+    notification_data = attrs.asdict(notification_data, recurse=False)
     notification_data['course_key'] = str(notification_data['course_key'])
     send_notifications.delay(**notification_data)
 
@@ -98,7 +101,10 @@ def generate_course_notifications(signal, sender, course_notification_data, meta
     """
 
     from openedx.core.djangoapps.notifications.tasks import send_notifications
-    course_notification_data = course_notification_data.__dict__
+    # openedx-events data classes are slotted attrs classes (no __dict__), so
+    # convert to a shallow dict. recurse=False keeps nested values (e.g. the
+    # course_key object) intact, matching the previous __dict__ behavior.
+    course_notification_data = attrs.asdict(course_notification_data, recurse=False)
     user_ids = calculate_course_wide_notification_audience(
         str(course_notification_data['course_key']),
         course_notification_data['audience_filters']

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -850,7 +850,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==3.1.2
     # via -r requirements/edx/kernel.in
-openedx-events==11.2.0
+git+https://github.com/openedx/openedx-events.git@bmtcril/type_hints
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1401,7 +1401,7 @@ openedx-django-wiki==3.1.2
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-openedx-events==11.2.0
+git+https://github.com/openedx/openedx-events.git@bmtcril/type_hints
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1030,7 +1030,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.2
     # via -r requirements/edx/base.txt
-openedx-events==11.2.0
+git+https://github.com/openedx/openedx-events.git@bmtcril/type_hints
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise

--- a/requirements/edx/kernel.in
+++ b/requirements/edx/kernel.in
@@ -115,7 +115,7 @@ openedx-atlas                       # CLI tool to manage translations
 openedx-calc                        # Library supporting mathematical calculations for Open edX
 openedx-core
 openedx-django-require
-openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
+git+https://github.com/openedx/openedx-events.git@bmtcril/type_hints                      # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
 openedx-forum                       # Open edX forum v2 application
 openedx-django-wiki

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1070,7 +1070,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==3.1.2
     # via -r requirements/edx/base.txt
-openedx-events==11.2.0
+git+https://github.com/openedx/openedx-events.git@bmtcril/type_hints
     # via
     #   -r requirements/edx/base.txt
     #   edx-enterprise


### PR DESCRIPTION
This is a test PR for the version of openedx-events that includes all of the new type hinting. It does change a couple of things, so once the new version lands we'll need to manually upgrade it here along with the few lines of changes includede.
