### PR TITLE
fix: add scroll to modal content when fullscreen (#38859)

### DIFF
--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -409,13 +409,16 @@
     div.edit-xblock-modal {
       display: flex;
       flex-direction: column;
+      min-height: 0;
       flex-grow: 1;
 
       div.modal-content {
         display: flex;
         flex-direction: column;
-        flex-grow: 1;
+        flex: 1;
+        min-height: 0;
         padding: 0;
+        overflow: auto;
 
         div.xblock-editor {
           display: flex;


### PR DESCRIPTION
Studio modal doesn't allow authors to scroll when content is longer than the screen height, so this commit adds a max-height based on screen height.

(cherry picked from commit c82accb66b38713b7b83f551974bb7c279b7207a)

Backport of https://github.com/openedx/openedx-platform/pull/38859