### PR TITLE
draft: add endpoints to create and modify users

### DIFF
--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -18,18 +18,12 @@ from openedx.core.djangoapps.django_comment_common import models
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.lib.api.test_utils import TEST_API_KEY, ApiTestCase
 from openedx.core.lib.time_zone_utils import get_display_time_zone
-from xmodule.modulestore.tests.django_utils import (
-    SharedModuleStoreTestCase,
-)  # pylint: disable=wrong-import-order
-from xmodule.modulestore.tests.factories import (
-    CourseFactory,
-)  # pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable=wrong-import-order
 
 from ..accounts.tests.retirement_helpers import RetirementTestCase  # noqa: F401
 from ..accounts.tests.retirement_helpers import fake_requested_retirement  # noqa: F401
-from ..accounts.tests.retirement_helpers import (
-    setup_retirement_states,
-)  # pylint: disable=unused-import; noqa: F401
+from ..accounts.tests.retirement_helpers import setup_retirement_states  # pylint: disable=unused-import; noqa: F401
 from ..models import UserOrgTag
 from ..tests.factories import UserPreferenceFactory
 
@@ -660,6 +654,7 @@ class CountryTimeZoneListViewTest(UserApiTestCase):
             self._assert_time_zone_is_valid(time_zone_info)
 
 
+@override_settings(ENABLE_AUTHN_REGISTER_HIBP_POLICY=False)
 @ddt.ddt
 class TestUserModifyAPI(ApiTestCase):
     """Test cases covering the user modification API"""

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -2,31 +2,34 @@
 
 import json
 from unittest.mock import patch
-from django.contrib.auth import get_user_model
+
 import ddt
 import pytest
+from django.contrib.auth import get_user_model
 from django.test.utils import override_settings
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from pytz import common_timezones, common_timezones_set, country_timezones
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
 
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.django_comment_common import models
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.lib.api.test_utils import TEST_API_KEY, ApiTestCase
 from openedx.core.lib.time_zone_utils import get_display_time_zone
-from rest_framework import status
-from rest_framework.exceptions import ValidationError
 from xmodule.modulestore.tests.django_utils import (
-    SharedModuleStoreTestCase,  # pylint: disable=wrong-import-order
-)
-from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable=wrong-import-order
+    SharedModuleStoreTestCase,
+)  # pylint: disable=wrong-import-order
+from xmodule.modulestore.tests.factories import (
+    CourseFactory,
+)  # pylint: disable=wrong-import-order
 
-from ..accounts.tests.retirement_helpers import (  # pylint: disable=unused-import
-    RetirementTestCase,  # noqa: F401
-    fake_requested_retirement,  # noqa: F401
-    setup_retirement_states,  # noqa: F401
-)
+from ..accounts.tests.retirement_helpers import RetirementTestCase  # noqa: F401
+from ..accounts.tests.retirement_helpers import fake_requested_retirement  # noqa: F401
+from ..accounts.tests.retirement_helpers import (
+    setup_retirement_states,
+)  # pylint: disable=unused-import; noqa: F401
 from ..models import UserOrgTag
 from ..tests.factories import UserPreferenceFactory
 
@@ -659,7 +662,7 @@ class CountryTimeZoneListViewTest(UserApiTestCase):
 
 @ddt.ddt
 class TestUserModifyAPI(ApiTestCase):
-    """ Test cases covering the user modification API """
+    """Test cases covering the user modification API"""
 
     PATH = "/api/user/v1/modify"
 
@@ -673,7 +676,7 @@ class TestUserModifyAPI(ApiTestCase):
     }
 
     def setUp(self):
-        """ Create a test user and log in with that user """
+        """Create a test user and log in with that user"""
         super().setUp()
 
         self.test_user = UserFactory.create(
@@ -681,48 +684,39 @@ class TestUserModifyAPI(ApiTestCase):
             email="user@example.com",
             password="pass",
             is_staff=True,
-            is_superuser=True
+            is_superuser=True,
         )
         self.client.login(username="user", password="pass")
 
     @override_settings(ENFORCE_SAFE_SESSIONS=False)
     def test_create_new_user_success(self):
-        """ Test creating a user with valid information """
+        """Test creating a user with valid information"""
         response = self.client.post(self.PATH, self.DATA)
-        self.assertEqual(
-            response.status_code,
-            status.HTTP_201_CREATED
-        )
+        assert response.status_code == status.HTTP_201_CREATED
         created_user = User.objects.get(username=self.DATA["username"])
-        self.assertEqual(
-            response.json(),
-            {"user_id": created_user.id, "username": created_user.username},
-        )
+        assert response.json() == {
+            "user_id": created_user.id,
+            "username": created_user.username,
+        }
 
     @ddt.data("username", "password", "email", "terms_of_service", "honor_code")
     def test_create_new_user_error_missing_info(self, missing_field):
-        """ Test creating a user with missing required information """
+        """Test creating a user with missing required information"""
         data = self.DATA.copy()
         data.pop(missing_field)
         response = self.client.post(self.PATH, data)
-        self.assertEqual(
-            response.status_code,
-            status.HTTP_400_BAD_REQUEST
-        )
-        self.assertIn("error_message", response.json())
-        self.assertIn(missing_field, str(response.json()["error_message"]))
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "error_message" in response.json()
+        assert missing_field in str(response.json()["error_message"])
 
     def test_create_new_user_error_invalid_attribute(self):
-        """ Test creating a user with an invalid attribute """
+        """Test creating a user with an invalid attribute"""
         data = self.DATA.copy()
         data["email"] = "invalid-email"
         response = self.client.post(self.PATH, data)
-        self.assertEqual(
-            response.status_code,
-            status.HTTP_400_BAD_REQUEST
-        )
-        self.assertIn("error_message", response.json())
-        self.assertIn("email", str(response.json()["error_message"]))
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "error_message" in response.json()
+        assert "email" in str(response.json()["error_message"])
 
     @ddt.data(
         ("email", "user@example.com", "existing account"),
@@ -730,16 +724,13 @@ class TestUserModifyAPI(ApiTestCase):
     )
     @ddt.unpack
     def test_create_new_user_error_already_exists(self, field, value, error_message):
-        """ Test creating a user with an invalid attribute """
+        """Test creating a user with an invalid attribute"""
         data = self.DATA.copy()
         data[field] = value
         response = self.client.post(self.PATH, data)
-        self.assertEqual(
-            response.status_code,
-            status.HTTP_400_BAD_REQUEST
-        )
-        self.assertIn("error_message", response.json())
-        self.assertIn(error_message, str(response.json()["error_message"]))
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "error_message" in response.json()
+        assert error_message in str(response.json()["error_message"])
 
     def test_patch_user_success(self):
         """Test updating a user with a valid lookup field"""
@@ -754,27 +745,23 @@ class TestUserModifyAPI(ApiTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            response.json(),
-            {"user_id": user.id, "username": user.username},
-        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"user_id": user.id, "username": user.username}
         user = User.objects.get(id=user.id)
-        self.assertEqual(user.first_name, "Updated Name")
+        assert user.first_name == "Updated Name"
 
     def test_patch_user_not_found(self):
         """Test patch returns 404 when no user matches the lookup fields"""
         response = self.client.patch(
             self.PATH,
-            data=json.dumps({"email": "missing@example.com", "first_name": "Updated Name"}),
+            data=json.dumps(
+                {"email": "missing@example.com", "first_name": "Updated Name"}
+            ),
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(
-            response.json(),
-            {"error_message": "User not found."},
-        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json() == {"error_message": "User not found."}
 
     @patch("openedx.core.djangoapps.user_api.views.UserSerializer.update")
     def test_patch_user_validation_error(self, serializer_update):
@@ -793,8 +780,7 @@ class TestUserModifyAPI(ApiTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            response.json(),
-            {"error_message": {"email": ["Invalid email address."]}},
-        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            "error_message": {"email": ["Invalid email address."]}
+        }

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -740,18 +740,16 @@ class TestUserModifyAPI(ApiTestCase):
         self.assertIn("error_message", response.json())
         self.assertIn(error_message, str(response.json()["error_message"]))
 
-    @patch("openedx.core.djangoapps.user_api.views.UserSerializer.update")
-    def test_patch_user_success(self, serializer_update):
+    def test_patch_user_success(self):
         """Test updating a user with a valid lookup field"""
         user = UserFactory.create(
             username="patch-user",
             email="patch@example.com",
         )
-        serializer_update.return_value = user
 
         response = self.client.patch(
             self.PATH,
-            data=json.dumps({"email": user.email, "name": "Updated Name"}),
+            data=json.dumps({"email": user.email, "first_name": "Updated Name"}),
             content_type="application/json",
         )
 
@@ -760,13 +758,14 @@ class TestUserModifyAPI(ApiTestCase):
             response.json(),
             {"user_id": user.id, "username": user.username},
         )
-        self.assertEqual(serializer_update.call_count, 1)
+        user = User.objects.get(id=user.id)
+        self.assertEqual(user.first_name, "Updated Name")
 
     def test_patch_user_not_found(self):
         """Test patch returns 404 when no user matches the lookup fields"""
         response = self.client.patch(
             self.PATH,
-            data=json.dumps({"email": "missing@example.com", "name": "Updated Name"}),
+            data=json.dumps({"email": "missing@example.com", "first_name": "Updated Name"}),
             content_type="application/json",
         )
 
@@ -789,7 +788,7 @@ class TestUserModifyAPI(ApiTestCase):
 
         response = self.client.patch(
             self.PATH,
-            data=json.dumps({"email": user.email, "name": "Updated Name"}),
+            data=json.dumps({"email": user.email, "first_name": "Updated Name"}),
             content_type="application/json",
         )
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -701,8 +701,8 @@ class TestUserModifyAPI(ApiTestCase):
         data.pop(missing_field)
         response = self.client.post(self.PATH, data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "error_message" in response.json()
-        assert missing_field in str(response.json()["error_message"])
+        assert "error" in response.json()
+        assert missing_field in str(response.json()["error"])
 
     def test_create_new_user_error_invalid_attribute(self):
         """Test creating a user with an invalid attribute"""
@@ -710,22 +710,22 @@ class TestUserModifyAPI(ApiTestCase):
         data["email"] = "invalid-email"
         response = self.client.post(self.PATH, data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "error_message" in response.json()
-        assert "email" in str(response.json()["error_message"])
+        assert "error" in response.json()
+        assert "email" in str(response.json()["error"])
 
     @ddt.data(
         ("email", "user@example.com", "existing account"),
         ("username", "user", "already exists"),
     )
     @ddt.unpack
-    def test_create_new_user_error_already_exists(self, field, value, error_message):
+    def test_create_new_user_error_already_exists(self, field, value, error):
         """Test creating a user with an invalid attribute"""
         data = self.DATA.copy()
         data[field] = value
         response = self.client.post(self.PATH, data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "error_message" in response.json()
-        assert error_message in str(response.json()["error_message"])
+        assert "error" in response.json()
+        assert error in str(response.json()["error"])
 
     def test_patch_user_success(self):
         """Test updating a user with a valid lookup field"""
@@ -756,7 +756,7 @@ class TestUserModifyAPI(ApiTestCase):
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.json() == {"error_message": "User not found."}
+        assert response.json() == {"error": "User not found."}
 
     @patch("openedx.core.djangoapps.user_api.views.UserSerializer.update")
     def test_patch_user_validation_error(self, serializer_update):
@@ -777,5 +777,5 @@ class TestUserModifyAPI(ApiTestCase):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
-            "error_message": {"email": ["Invalid email address."]}
+            "error": {"email": ["Invalid email address."]}
         }

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -12,6 +12,7 @@ from openedx.core.djangoapps.django_comment_common import models
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.lib.api.test_utils import TEST_API_KEY, ApiTestCase
 from openedx.core.lib.time_zone_utils import get_display_time_zone
+from rest_framework import status
 from xmodule.modulestore.tests.django_utils import (
     SharedModuleStoreTestCase,  # pylint: disable=wrong-import-order
 )
@@ -649,3 +650,69 @@ class CountryTimeZoneListViewTest(UserApiTestCase):
         assert len(results) == len(common_timezones)
         for time_zone_info in results:
             self._assert_time_zone_is_valid(time_zone_info)
+
+
+@ddt.ddt
+class TestUserModifyAPI(ApiTestCase):
+    """ Test cases covering the user modification API """
+
+    PATH = '/api/user/v1/modify'
+
+    DATA = {
+        'name': 'Test User',
+        'username': 'testuser',
+        'password': 'Password1234',
+        'email': 'e@mail.com',
+        'terms_of_service': 'true',
+        'honor_code': 'true',
+    }
+
+    def setUp(self):
+        """ Create a test user and log in with that user """
+        super().setUp()
+
+        self.test_user = UserFactory.create(
+            username="user",
+            email="user@example.com",
+            password="pass",
+            is_staff=True,
+            is_superuser=True
+        )
+        self.client.login(username="user", password="pass")
+
+    @override_settings(ENFORCE_SAFE_SESSIONS=False)
+    def test_create_new_user_success(self):
+        """ Test creating a user with valid information """
+        response = self.client.post(self.PATH, self.DATA)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_201_CREATED
+        )
+
+    @ddt.data('username', 'password', 'email', 'terms_of_service', 'honor_code')
+    def test_create_new_user_error_missing_info(self, missing_field):
+        """ Test creating a user with missing required information """
+        data = self.DATA.copy()
+        data.pop(missing_field)
+        response = self.client.post(self.PATH, data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST
+        )
+
+    @ddt.data(
+        ('email', 'invalid-email'),
+        ('email', 'user@example.com'),
+        ('username', 'user'),
+    )
+    @ddt.unpack
+    def test_create_new_user_error_invalid_attribute(self, field, value):
+        """ Test creating a user with an invalid attribute """
+        data = self.DATA.copy()
+        data[field] = value
+        response = self.client.post(self.PATH, data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST
+        )
+

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -23,7 +23,7 @@ from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable
 
 from ..accounts.tests.retirement_helpers import RetirementTestCase  # noqa: F401
 from ..accounts.tests.retirement_helpers import fake_requested_retirement  # noqa: F401
-from ..accounts.tests.retirement_helpers import setup_retirement_states  # pylint: disable=unused-import; noqa: F401
+from ..accounts.tests.retirement_helpers import setup_retirement_states  # noqa: F401
 from ..models import UserOrgTag
 from ..tests.factories import UserPreferenceFactory
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1,9 +1,8 @@
 """Tests for the user API at the HTTP request level. """
 
-import pytest
 import json
 from unittest.mock import patch
-
+from django.contrib.auth import get_user_model
 import ddt
 import pytest
 from django.test.utils import override_settings
@@ -17,6 +16,7 @@ from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_un
 from openedx.core.lib.api.test_utils import TEST_API_KEY, ApiTestCase
 from openedx.core.lib.time_zone_utils import get_display_time_zone
 from rest_framework import status
+from rest_framework.exceptions import ValidationError
 from xmodule.modulestore.tests.django_utils import (
     SharedModuleStoreTestCase,  # pylint: disable=wrong-import-order
 )
@@ -34,6 +34,7 @@ USER_LIST_URI = "/api/user/v1/users/"
 USER_PREFERENCE_LIST_URI = "/api/user/v1/user_prefs/"
 ROLE_LIST_URI = "/api/user/v1/forum_roles/Moderator/users/"
 
+User = get_user_model()
 
 class UserAPITestCase(ApiTestCase):
     """

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -21,9 +21,9 @@ from openedx.core.lib.time_zone_utils import get_display_time_zone
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase  # pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable=wrong-import-order
 
-from ..accounts.tests.retirement_helpers import RetirementTestCase  # noqa: F401
-from ..accounts.tests.retirement_helpers import fake_requested_retirement  # noqa: F401
-from ..accounts.tests.retirement_helpers import setup_retirement_states  # noqa: F401
+from ..accounts.tests.retirement_helpers import RetirementTestCase  # pylint: disable=unused-import; noqa: F401
+from ..accounts.tests.retirement_helpers import fake_requested_retirement  # pylint: disable=unused-import; noqa: F401
+from ..accounts.tests.retirement_helpers import setup_retirement_states  # pylint: disable=unused-import; noqa: F401
 from ..models import UserOrgTag
 from ..tests.factories import UserPreferenceFactory
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1,5 +1,9 @@
 """Tests for the user API at the HTTP request level. """
 
+import pytest
+import json
+from unittest.mock import patch
+
 import ddt
 import pytest
 from django.test.utils import override_settings
@@ -656,15 +660,15 @@ class CountryTimeZoneListViewTest(UserApiTestCase):
 class TestUserModifyAPI(ApiTestCase):
     """ Test cases covering the user modification API """
 
-    PATH = '/api/user/v1/modify'
+    PATH = "/api/user/v1/modify"
 
     DATA = {
-        'name': 'Test User',
-        'username': 'testuser',
-        'password': 'Password1234',
-        'email': 'e@mail.com',
-        'terms_of_service': 'true',
-        'honor_code': 'true',
+        "name": "Test User",
+        "username": "testuser",
+        "password": "Password1234",
+        "email": "e@mail.com",
+        "terms_of_service": "true",
+        "honor_code": "true",
     }
 
     def setUp(self):
@@ -688,8 +692,13 @@ class TestUserModifyAPI(ApiTestCase):
             response.status_code,
             status.HTTP_201_CREATED
         )
+        created_user = User.objects.get(username=self.DATA["username"])
+        self.assertEqual(
+            response.json(),
+            {"user_id": created_user.id, "username": created_user.username},
+        )
 
-    @ddt.data('username', 'password', 'email', 'terms_of_service', 'honor_code')
+    @ddt.data("username", "password", "email", "terms_of_service", "honor_code")
     def test_create_new_user_error_missing_info(self, missing_field):
         """ Test creating a user with missing required information """
         data = self.DATA.copy()
@@ -699,14 +708,27 @@ class TestUserModifyAPI(ApiTestCase):
             response.status_code,
             status.HTTP_400_BAD_REQUEST
         )
+        self.assertIn("error_message", response.json())
+        self.assertIn(missing_field, str(response.json()["error_message"]))
+
+    def test_create_new_user_error_invalid_attribute(self):
+        """ Test creating a user with an invalid attribute """
+        data = self.DATA.copy()
+        data["email"] = "invalid-email"
+        response = self.client.post(self.PATH, data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST
+        )
+        self.assertIn("error_message", response.json())
+        self.assertIn("email", str(response.json()["error_message"]))
 
     @ddt.data(
-        ('email', 'invalid-email'),
-        ('email', 'user@example.com'),
-        ('username', 'user'),
+        ("email", "user@example.com", "existing account"),
+        ("username", "user", "already exists"),
     )
     @ddt.unpack
-    def test_create_new_user_error_invalid_attribute(self, field, value):
+    def test_create_new_user_error_already_exists(self, field, value, error_message):
         """ Test creating a user with an invalid attribute """
         data = self.DATA.copy()
         data[field] = value
@@ -715,4 +737,64 @@ class TestUserModifyAPI(ApiTestCase):
             response.status_code,
             status.HTTP_400_BAD_REQUEST
         )
+        self.assertIn("error_message", response.json())
+        self.assertIn(error_message, str(response.json()["error_message"]))
 
+    @patch("openedx.core.djangoapps.user_api.views.UserSerializer.update")
+    def test_patch_user_success(self, serializer_update):
+        """Test updating a user with a valid lookup field"""
+        user = UserFactory.create(
+            username="patch-user",
+            email="patch@example.com",
+        )
+        serializer_update.return_value = user
+
+        response = self.client.patch(
+            self.PATH,
+            data=json.dumps({"email": user.email, "name": "Updated Name"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {"user_id": user.id, "username": user.username},
+        )
+        self.assertEqual(serializer_update.call_count, 1)
+
+    def test_patch_user_not_found(self):
+        """Test patch returns 404 when no user matches the lookup fields"""
+        response = self.client.patch(
+            self.PATH,
+            data=json.dumps({"email": "missing@example.com", "name": "Updated Name"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(
+            response.json(),
+            {"error_message": "User not found."},
+        )
+
+    @patch("openedx.core.djangoapps.user_api.views.UserSerializer.update")
+    def test_patch_user_validation_error(self, serializer_update):
+        """Test serializer validation errors are returned with status 400"""
+        user = UserFactory.create(
+            username="test-user",
+            email="patch-error@example.com",
+        )
+        serializer_update.side_effect = ValidationError(
+            {"email": ["Invalid email address."]}
+        )
+
+        response = self.client.patch(
+            self.PATH,
+            data=json.dumps({"email": user.email, "name": "Updated Name"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {"error_message": {"email": ["Invalid email address."]}},
+        )

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -178,6 +178,9 @@ urlpatterns = [
     path('v1/accounts/replace_usernames/', UsernameReplacementView.as_view(),
          name='username_replacement'
          ),
+    path('v1/modify', user_api_views.UserModifyView.as_view(),
+         name='user_account_modify'
+         ),
     re_path(
         fr'^v1/preferences/{settings.USERNAME_PATTERN}$',
         PreferencesView.as_view(),

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -233,3 +233,51 @@ class UserModifyView(APIView):
             data={"user_id": user.id, "username": user.username},
             status=status.HTTP_201_CREATED,
         )
+
+    def patch(self, request):
+        """
+        Update user information by email or username.
+        """
+        try:
+            user = self._get_user_by_email_or_username(request)
+            if not user:
+                return Response(
+                    data={"error_message": "User not found."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            user = UserSerializer().update(user, request.data)
+        except (
+            AccountValidationError,
+            ValueError,
+            ValidationError,
+            DjangoValidationError,
+        ) as e:
+            if isinstance(e, ValidationError):
+                message = e.detail
+            else:
+                message = str(e)
+            return Response(
+                data={"error_message": message},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response(
+            data={"user_id": user.id, "username": user.username},
+            status=status.HTTP_200_OK,
+        )
+
+    @staticmethod
+    def _get_user_by_email_or_username(request):
+        """
+        Get a user by email and/or username.
+
+        Returns None if one doesn't exist.
+        """
+
+        email = request.data.get("email")
+        username = request.data.get("username")
+        query = {}
+        if email:
+            query["email"] = email
+        if username:
+            query["username"] = username
+        return User.objects.filter(**query).first()

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -226,7 +226,7 @@ class UserModifyView(APIView):
             else:
                 message = str(e)
             return Response(
-                data={"error_message": message},
+                data={"error": message},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -243,7 +243,7 @@ class UserModifyView(APIView):
             user = self._get_user_by_email_or_username(request)
             if not user:
                 return Response(
-                    data={"error_message": "User not found."},
+                    data={"error": "User not found."},
                     status=status.HTTP_404_NOT_FOUND,
                 )
 
@@ -267,7 +267,7 @@ class UserModifyView(APIView):
             else:
                 message = str(e)
             return Response(
-                data={"error_message": message},
+                data={"error": message},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return Response(

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -15,7 +15,8 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework import generics, status, viewsets
 from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
-from rest_framework.views import APIView, Response
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from common.djangoapps.student.helpers import AccountValidationError
 from openedx.core.djangoapps.django_comment_common.models import Role
@@ -182,10 +183,10 @@ class UserModifyView(APIView):
 
         PATCH /api/user/v1/modify/
 
-    **Example GET Response**
+    **Example POST Response**
 
-        If the request is successful, an HTTP 200 "OK" response is returned
-        along with the user id and username, e.g.:
+        If the request is successful, an HTTP 201 "Created" response is
+        returned along with the user id and username, e.g.:
 
         {
             "user_id": 5,
@@ -245,7 +246,16 @@ class UserModifyView(APIView):
                     data={"error_message": "User not found."},
                     status=status.HTTP_404_NOT_FOUND,
                 )
-            user = UserSerializer().update(user, request.data)
+
+            data = request.data.copy()
+            # Remove email and username from the data to prevent changing them
+            data.pop("email", None)
+            data.pop("username", None)
+            # Remove password from the data and handle it separately
+            password = data.pop("password", None)
+            if password:
+                user.set_password(password)
+            user = UserSerializer().update(user, data)
         except (
             AccountValidationError,
             ValueError,
@@ -275,6 +285,8 @@ class UserModifyView(APIView):
 
         email = request.data.get("email")
         username = request.data.get("username")
+        if not email and not username:
+            raise ValidationError("email or username must be specified")
         query = {}
         if email:
             query["email"] = email

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -1,19 +1,23 @@
 """HTTP end-points for the User API. """
 
-from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django_filters.rest_framework import DjangoFilterBackend
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx import locator
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import generics, status, viewsets
-from rest_framework.exceptions import ParseError
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.views import APIView
+from rest_framework.exceptions import ParseError, ValidationError
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
+from rest_framework.views import APIView, Response
 
+from common.djangoapps.student.helpers import AccountValidationError
 from openedx.core.djangoapps.django_comment_common.models import Role
 from openedx.core.djangoapps.user_api.models import UserPreference
 from openedx.core.djangoapps.user_api.preferences.api import get_country_time_zones, update_email_opt_in
@@ -22,6 +26,8 @@ from openedx.core.djangoapps.user_api.serializers import (
     UserPreferenceSerializer,
     UserSerializer,
 )
+from openedx.core.djangoapps.user_authn.views.register import create_account_with_params
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 from openedx.core.lib.api.view_utils import require_post_params
 
@@ -161,3 +167,69 @@ class CountryTimeZoneListView(generics.ListAPIView):
     def get_queryset(self):
         country_code = self.request.GET.get("country_code", None)
         return get_country_time_zones(country_code)
+
+
+class UserModifyView(APIView):
+    """
+    **Use Cases**
+
+        Creates a user with email and username, or updates user information by
+        email or username.
+
+    **Example Requests**
+
+        POST /api/user/v1/modify/
+
+        PATCH /api/user/v1/modify/
+
+    **Example GET Response**
+
+        If the request is successful, an HTTP 200 "OK" response is returned
+        along with the user id and username, e.g.:
+
+        {
+            "user_id": 5,
+            "username": "newuser"
+        }
+
+    """
+
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
+    permission_classes = (IsAdminUser,)
+
+    @method_decorator(transaction.non_atomic_requests)
+    def dispatch(self, request, *args, **kwargs):
+        """
+        Decorate with `non_atomic_requests` to work on newer versions of platform.
+        """
+        return super().dispatch(request, *args, **kwargs)
+
+    def post(self, request):
+        """
+        Create a user with email and username.
+        """
+        try:
+            user = create_account_with_params(request, request.data)
+        except (
+            AccountValidationError,
+            ValueError,
+            ValidationError,
+            DjangoValidationError,
+        ) as e:
+            if isinstance(e, ValidationError):
+                message = e.detail
+            else:
+                message = str(e)
+            return Response(
+                data={"error_message": message},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response(
+            data={"user_id": user.id, "username": user.username},
+            status=status.HTTP_201_CREATED,
+        )


### PR DESCRIPTION
## Description

This PR adds endpoints to create and modify users.

## Supporting information

Private Refs:
- https://tasks.opencraft.com/browse/BB-9993
- https://tasks.opencraft.com/browse/BB-10024

## Testing instructions

1. Make a POST request to /api/user/v1/modify to create a user, e.g.
```
$ http POST http://local.openedx.io:8000/api/user/v1/modify --auth-type bearer --auth TOKEN username=test email=test@example.com password=12345678 name=Test
HTTP/1.1 201 Created
Allow: POST, PATCH, OPTIONS
Content-Language: en
Content-Length: 31
Content-Type: application/json
Date: Wed, 15 Jul 2026 14:49:26 GMT
Server: WSGIServer/0.2 CPython/3.11.8
Set-Cookie: openedx-language-preference=en; Domain=local.openedx.io; expires=Wed, 29 Jul 2026 14:49:26 GMT; Max-Age=1209600; Path=/; SameSite=Lax
Set-Cookie: csrftoken=uVKV5sKqW6wkR7bzxV6Avju4QLpYIMuw; expires=Wed, 14 Jul 2027 14:49:26 GMT; Max-Age=31449600; Path=/; SameSite=Lax
Set-Cookie: lms_sessionid=1|2dh9womlw77dgrx1pivuj0sg9i9u5ybq|WWtn1GLVCf45|IjRjOTNkMjg0ZjVlOGY2NGUzMDQ4NjY1YzYxNzY2YjBmNTI2MmI5NWI4ZjY5ZWMzZTk4YWVjNTYwZjZlOWVkZWYi:1wk0vO:YUj--lO47gIYgyE3ECpwA9H3ats72cPfhsaAMISRph4; Domain=local.openedx.io; HttpOnly; Path=/; SameSite=Lax
Vary: Accept, Accept-Language, Cookie, origin
X-Frame-Options: SAMEORIGIN

{
    "user_id": 6,
    "username": "test"
}
```

2. Make a PATCH request to modify an existing user, e.g.
```
$ http PATCH http://local.openedx.io:8000/api/user/v1/modify --auth-type bearer --auth TOKEN username=test first_name=Test last_name=User
HTTP/1.1 200 OK
Allow: POST, PATCH, OPTIONS
Content-Language: en
Content-Length: 31
Content-Type: application/json
Date: Wed, 15 Jul 2026 15:14:34 GMT
Server: WSGIServer/0.2 CPython/3.11.8
Set-Cookie: openedx-language-preference=en; Domain=local.openedx.io; expires=Wed, 29 Jul 2026 15:14:34 GMT; Max-Age=1209600; Path=/; SameSite=Lax
Set-Cookie: lms_sessionid=1|w489j3st009e06ej1fuqk52mbtjviq2r|ZXnG9qPRsD9K|ImI5ZTJlMjBkMDE3NmJkM2Q0YzM1YmU3Nzg3OGMyMjUwODQ1NWM4Zjc2NWRjNDZhMTc5Y2Q1YjAzMjhiMGRiNzIi:1wk1Ji:E-vJBuc200cn9TzEhbD3k3fTpUkuESZ6M7A8TzVq0HM; Domain=local.openedx.io; expires=Wed, 29 Jul 2026 15:14:34 GMT; HttpOnly; Max-Age=1209600; Path=/; SameSite=Lax
Vary: Accept, Accept-Language, origin, Cookie
X-Frame-Options: SAMEORIGIN

{
    "user_id": 6,
    "username": "test"
}
```

## Deadline

None, still a draft