### PR TITLE
[Backport] chore: upgrade openedx-authz==1.21.0 (#38897)

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -834,7 +834,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.20.1
+openedx-authz==1.21.0
     # via -r requirements/edx/kernel.in
 openedx-calc==5.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1374,7 +1374,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.20.1
+openedx-authz==1.21.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1012,7 +1012,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.20.1
+openedx-authz==1.21.0
     # via -r requirements/edx/base.txt
 openedx-calc==5.0.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1052,7 +1052,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.20.1
+openedx-authz==1.21.0
     # via -r requirements/edx/base.txt
 openedx-calc==5.0.0
     # via


### PR DESCRIPTION
## Description

Backport of https://github.com/openedx/openedx-platform/pull/38897

Closes: https://github.com/openedx/openedx-authz/issues/341