### PR TITLE
feat: allow library linked problem edits

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -304,7 +304,7 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
     Wraps the results of rendering an XBlock view in a div which adds a header and Studio action buttons.
     """
     # Allow some imported components to be edited by authors in course.
-    editable_library_components = ["html"]
+    editable_library_components = ["html", "problem"]
     # Only add the Studio wrapper when on the container page. The "Pages" page will remain as is for now.
     if not context.get('is_pages_view', None) and view in PREVIEW_VIEWS:
         root_xblock = context.get('root_xblock')


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Problem block edit should be allowed when used from a V2 Library. When editing a problem block in the library, we don't see certain course-specific fields, and they were meant to be allowed to be edited in the course. All of this was discussed in https://github.com/openedx/frontend-app-authoring/issues/1317.

Due to changes in https://github.com/openedx/openedx-platform/pull/36553 and https://github.com/openedx/openedx-platform/pull/37124, it only allowed HTML/Text blocks to be edited in the course. This PR adds back the problem in the allowlist. It is understood that resyncing upstream will erase problem content changes and fields that are meant to be synced.

## Supporting information

https://github.com/openedx/frontend-app-authoring/issues/1317
https://github.com/openedx/openedx-platform/pull/37124
https://github.com/openedx/openedx-platform/pull/36553

## Testing instructions

- Checkout master branch
- Create a V2 library and a problem block in it.
- Notice that fields like scoring are not available in the editor.
- Create a course and use a problem from the library.
- Click on the edit icon and notice it only allows you to edit the title of the problem and does not open the editor.
- Check out this branch, and the editor should open when you try to edit the block in the course.
- You should see extra fields like scoring and be able to change those. Change some of the scoring settings.
- Go back to the library and make changes to the problem content.
- Sync the problem block in the course and verify that changes are synced with the library and scoring field settings remain the same as changed.
