### PR TITLE
fix: CSRF fix for xqueue interface [backport to verawood]

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -539,7 +539,7 @@ edx-search==5.0.0
     #   openedx-forum
 edx-sga==0.28.0
     # via -r requirements/edx/bundled.in
-edx-submissions==4.0.0
+edx-submissions==4.0.1
     # via
     #   -r requirements/edx/kernel.in
     #   ora2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -832,7 +832,7 @@ edx-sga==0.28.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-edx-submissions==4.0.0
+edx-submissions==4.0.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -630,7 +630,7 @@ edx-search==5.0.0
     #   openedx-forum
 edx-sga==0.28.0
     # via -r requirements/edx/base.txt
-edx-submissions==4.0.0
+edx-submissions==4.0.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -648,7 +648,7 @@ edx-search==5.0.0
     #   openedx-forum
 edx-sga==0.28.0
     # via -r requirements/edx/base.txt
-edx-submissions==4.0.0
+edx-submissions==4.0.1
     # via
     #   -r requirements/edx/base.txt
     #   ora2


### PR DESCRIPTION
Update edx-submissions to bring in CSRF changes to the LMS's new xqueue interface.

Code being pulled in:

https://github.com/openedx/edx-submissions/pull/352