### PR TITLE
refactor: migrate 10 more flags off FEATURES-as-dict (batch 6)

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_details.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_details.py
@@ -2,9 +2,10 @@
 Unit tests for course details views.
 """
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import ddt
+from django.test.utils import override_settings
 from django.urls import reverse
 from openedx_authz.constants.roles import COURSE_EDITOR, COURSE_STAFF
 from rest_framework import status
@@ -57,7 +58,7 @@ class CourseDetailsViewTest(CourseTestCase, PermissionAccessMixin):
         self.assertEqual(error, "You do not have permission to perform this action.")  # noqa: PT009
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)  # noqa: PT009
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_PREREQUISITE_COURSES": True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_put_invalid_pre_requisite_course(self):
         pre_requisite_course_keys = [str(self.course.id), "invalid_key"]
         request_data = {"pre_requisite_courses": pre_requisite_course_keys}
@@ -619,7 +620,7 @@ class CourseDetailsAuthzViewTest(CourseAuthoringAuthzTestMixin, CourseTestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
 
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_PREREQUISITE_COURSES": True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_put_invalid_pre_requisite_course_with_authz(self):
         """
         Ensure validation still applies under AuthZ.

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_settings.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_settings.py
@@ -1,8 +1,6 @@
 """
 Unit tests for course settings views.
 """
-from unittest.mock import patch
-
 import ddt
 from django.conf import settings
 from django.test.utils import override_settings
@@ -74,13 +72,7 @@ class CourseSettingsViewTest(CourseTestCase, PermissionAccessMixin):
         self.assertIn("credit_requirements", response.data)  # noqa: PT009
         self.assertTrue(response.data["is_credit_course"])  # noqa: PT009
 
-    @patch.dict(
-        "django.conf.settings.FEATURES",
-        {
-            "ENABLE_PREREQUISITE_COURSES": True,
-            "MILESTONES_APP": True,
-        },
-    )
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True, MILESTONES_APP=True)
     def test_prerequisite_courses_enabled_setting(self):
         """
         Make sure if the feature flags are enabled we have updated the dict keys in response.

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -289,7 +289,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         elif field in encoded and encoded[field] is not None:
             self.fail(field + " included in encoding but missing from details at " + context)
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_pre_requisite_course_update_and_fetch(self):
         self.assertFalse(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),  # noqa: PT009
                          msg='The initial empty state should be: no prerequisite courses')
@@ -325,7 +325,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         self.assertFalse(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),  # noqa: PT009
                          msg='Should not have prerequisite courses anymore')
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_invalid_pre_requisite_course(self):
         url = get_url(self.course.id)
         resp = self.client.get_json(url)
@@ -437,7 +437,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         self.assertEqual(course.entrance_exam_minimum_score_pct, .5)  # noqa: PT009
 
     @unittest.skipUnless(settings.ENTRANCE_EXAMS, True)
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_entrance_after_changing_other_setting(self):
         """
         Test entrance exam is not deactivated when prerequisites removed.

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -884,10 +884,7 @@ class UpdateCourseDetailsTests(ModuleStoreTestCase):
         super().setUp()
         self.course = CourseFactory.create()
 
-    @patch.dict("django.conf.settings.FEATURES", {
-        "ENABLE_PREREQUISITE_COURSES": False,
-    })
-    @override_settings(ENTRANCE_EXAMS=False)
+    @override_settings(ENABLE_PREREQUISITE_COURSES=False, ENTRANCE_EXAMS=False)
     @patch("cms.djangoapps.contentstore.utils.CourseDetails.update_from_json")
     def test_update_course_details_self_paced(self, mock_update):
         """
@@ -910,10 +907,7 @@ class UpdateCourseDetailsTests(ModuleStoreTestCase):
         utils.update_course_details(mock_request, self.course.id, payload, None)
         mock_update.assert_called_once_with(self.course.id, expected_payload, mock_request.user)
 
-    @patch.dict("django.conf.settings.FEATURES", {
-        "ENABLE_PREREQUISITE_COURSES": False,
-    })
-    @override_settings(ENTRANCE_EXAMS=False)
+    @override_settings(ENABLE_PREREQUISITE_COURSES=False, ENTRANCE_EXAMS=False)
     @patch("cms.djangoapps.contentstore.utils.CourseDetails.update_from_json")
     def test_update_course_details_instructor_paced(self, mock_update):
         """

--- a/cms/lib/xblock/test/test_authoring_mixin.py
+++ b/cms/lib/xblock/test/test_authoring_mixin.py
@@ -3,7 +3,6 @@ Tests for the Studio authoring XBlock mixin.
 """
 
 
-from django.conf import settings
 from django.test.utils import override_settings
 from xblock.core import XBlock
 
@@ -31,9 +30,6 @@ class AuthoringMixinTestCase(ModuleStoreTestCase):
     CONTENT_GROUPS_TITLE = "Content Groups"
     ENROLLMENT_GROUPS_TITLE = "Enrollment Track Groups"
     STAFF_LOCKED = 'The unit that contains this component is hidden from learners'
-
-    FEATURES_WITH_ENROLLMENT_TRACK_DISABLED = settings.FEATURES.copy()
-    FEATURES_WITH_ENROLLMENT_TRACK_DISABLED['ENABLE_ENROLLMENT_TRACK_USER_PARTITION'] = False
 
     @XBlock.register_temp_plugin(PureXBlock, 'pure')
     def setUp(self):
@@ -170,7 +166,7 @@ class AuthoringMixinTestCase(ModuleStoreTestCase):
             [self.STAFF_LOCKED]
         )
 
-    @override_settings(FEATURES=FEATURES_WITH_ENROLLMENT_TRACK_DISABLED)
+    @override_settings(ENABLE_ENROLLMENT_TRACK_USER_PARTITION=False)
     def test_enrollment_tracks_disabled(self):
         """
         Test that the "no groups" messages doesn't reference enrollment tracks if

--- a/common/djangoapps/student/tests/test_course_listing.py
+++ b/common/djangoapps/student/tests/test_course_listing.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 from django.conf import settings
 from django.test.client import Client
+from django.test.utils import override_settings
 from milestones.tests.utils import MilestonesTestCaseMixin
 
 from common.djangoapps.student.models import CourseEnrollment  # pylint: disable=unused-import
@@ -139,7 +140,7 @@ class TestCourseListing(ModuleStoreTestCase, MilestonesTestCaseMixin):
         assert len(courses_list) == 1, courses_list
         assert courses_list[0].course_id == good_location
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_course_listing_has_pre_requisite_courses(self):
         """
         Creates four courses. Enroll test user in all courses

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -318,7 +318,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         assert ('Share on Twitter' in response.content.decode('utf-8')) == (set_marketing or set_social_sharing)
         assert ('Share on Facebook' in response.content.decode('utf-8')) == (set_marketing or set_social_sharing)
 
-    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_pre_requisites_appear_on_dashboard(self):
         """
         When a course has a prerequisite, the dashboard should display the prerequisite.

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -365,7 +365,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
             self.assertContains(response, f'class="course {mode}"')
         self.assertContains(response, value)
 
-    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_VERIFIED_CERTIFICATES': True})
+    @override_settings(ENABLE_VERIFIED_CERTIFICATES=True)
     def test_verification_status_visible(self):
         """
         Test that the certificate verification status for courses is visible on the dashboard.
@@ -402,7 +402,7 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
             self.assertNotContains(response, f"class=\"course {mode}\"")
             self.assertNotContains(response, value)
 
-    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_VERIFIED_CERTIFICATES': False})
+    @override_settings(ENABLE_VERIFIED_CERTIFICATES=False)
     def test_verification_status_invisible(self):
         """
         Test that the certificate verification status for courses is not visible on the dashboard
@@ -621,7 +621,7 @@ class DashboardTestsWithSiteOverrides(SiteMixin, ModuleStoreTestCase):
         cache.clear()
 
     @skip_unless_lms
-    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_VERIFIED_CERTIFICATES': False})
+    @override_settings(ENABLE_VERIFIED_CERTIFICATES=False)
     @ddt.data(
         ('testserver1.com', {'ENABLE_VERIFIED_CERTIFICATES': True}),
         ('testserver2.com', {'ENABLE_VERIFIED_CERTIFICATES': True, 'DISPLAY_COURSE_MODES_ON_DASHBOARD': True}),
@@ -642,7 +642,7 @@ class DashboardTestsWithSiteOverrides(SiteMixin, ModuleStoreTestCase):
         self.assertContains(response, 'class="course professional"')
 
     @skip_unless_lms
-    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_VERIFIED_CERTIFICATES': False})
+    @override_settings(ENABLE_VERIFIED_CERTIFICATES=False)
     @ddt.data(
         ('testserver3.com', {'ENABLE_VERIFIED_CERTIFICATES': False}),
         ('testserver4.com', {'DISPLAY_COURSE_MODES_ON_DASHBOARD': False}),

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -534,7 +534,7 @@ def student_dashboard(request):  # pylint: disable=too-many-statements
 
     enable_verified_certificates = configuration_helpers.get_value(
         'ENABLE_VERIFIED_CERTIFICATES',
-        settings.FEATURES.get('ENABLE_VERIFIED_CERTIFICATES')
+        getattr(settings, 'ENABLE_VERIFIED_CERTIFICATES', False)
     )
     display_course_modes_on_dashboard = configuration_helpers.get_value(
         'DISPLAY_COURSE_MODES_ON_DASHBOARD',

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -538,7 +538,7 @@ def student_dashboard(request):  # pylint: disable=too-many-statements
     )
     display_course_modes_on_dashboard = configuration_helpers.get_value(
         'DISPLAY_COURSE_MODES_ON_DASHBOARD',
-        settings.FEATURES.get('DISPLAY_COURSE_MODES_ON_DASHBOARD', True)
+        settings.DISPLAY_COURSE_MODES_ON_DASHBOARD
     )
     activation_email_support_link = configuration_helpers.get_value(
         'ACTIVATION_EMAIL_SUPPORT_LINK', settings.ACTIVATION_EMAIL_SUPPORT_LINK

--- a/common/djangoapps/third_party_auth/management/commands/remove_social_auth_users.py
+++ b/common/djangoapps/third_party_auth/management/commands/remove_social_auth_users.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         slug = options['IDP']
 
-        if not settings.FEATURES.get('ENABLE_ENROLLMENT_RESET'):
+        if not settings.ENABLE_ENROLLMENT_RESET:
             raise CommandError('ENABLE_ENROLLMENT_RESET feature not enabled on this enviroment')
 
         try:

--- a/common/djangoapps/third_party_auth/management/commands/tests/test_remove_social_auth_users.py
+++ b/common/djangoapps/third_party_auth/management/commands/tests/test_remove_social_auth_users.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager
 from uuid import uuid4
 
 import pytest
-from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase, override_settings
@@ -19,9 +18,6 @@ from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth.management.commands import remove_social_auth_users
 from common.djangoapps.third_party_auth.tests.factories import SAMLProviderConfigFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-
-FEATURES_WITH_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_ENABLED['ENABLE_ENROLLMENT_RESET'] = True
 
 
 @skip_unless_lms
@@ -64,7 +60,7 @@ class TestRemoveSocialAuthUsersCommand(TestCase):
     def find_user_social_auth_entry(self, username):
         UserSocialAuth.objects.get(user__username=username)
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     def test_remove_users(self):
         call_command(self.command, self.provider_hogwarts.slug, force=True)
 
@@ -83,14 +79,14 @@ class TestRemoveSocialAuthUsersCommand(TestCase):
         # other social auth intact
         self.find_user_social_auth_entry(self.user_viktor.username)
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     def test_invalid_idp(self):
         invalid_slug = 'jedi-academy'
         err_string = f'No SAML provider found for slug {invalid_slug}'
         with self.assertRaisesRegex(CommandError, err_string):  # noqa: PT027
             call_command(self.command, invalid_slug)
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     def test_confirmation_required(self):
         """ By default this command will require user input to confirm """
         with self._replace_stdin('confirm'):
@@ -101,7 +97,7 @@ class TestRemoveSocialAuthUsersCommand(TestCase):
         with pytest.raises(UserSocialAuth.DoesNotExist):
             self.find_user_social_auth_entry('harry')
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     def test_confirmation_failure(self):
         err_string = 'User confirmation required.  No records have been modified'
         with self.assertRaisesRegex(CommandError, err_string):  # noqa: PT027

--- a/common/djangoapps/util/milestones_helpers.py
+++ b/common/djangoapps/util/milestones_helpers.py
@@ -44,7 +44,7 @@ def is_prerequisite_courses_enabled():
     """
     Returns boolean indicating prerequisite courses enabled system wide or not.
     """
-    return settings.FEATURES.get('ENABLE_PREREQUISITE_COURSES') and ENABLE_MILESTONES_APP.is_enabled()
+    return settings.ENABLE_PREREQUISITE_COURSES and ENABLE_MILESTONES_APP.is_enabled()
 
 
 def add_prerequisite_course(course_key, prerequisite_course_key):

--- a/common/djangoapps/util/tests/test_milestones_helpers.py
+++ b/common/djangoapps/util/tests/test_milestones_helpers.py
@@ -1,7 +1,6 @@
 """
 Tests for the milestones helpers library, which is the integration point for the edx_milestones API
 """
-from unittest.mock import patch
 
 import ddt
 import pytest
@@ -61,9 +60,10 @@ class MilestonesHelpersTestCase(ModuleStoreTestCase):
         ENABLE_PREREQUISITE_COURSES and MILESTONES_APP feature flags.
         """
 
-        with patch.dict("django.conf.settings.FEATURES", {
-            'ENABLE_PREREQUISITE_COURSES': feature_flags[0],
-        }), override_settings(MILESTONES_APP=feature_flags[1]):
+        with override_settings(
+            ENABLE_PREREQUISITE_COURSES=feature_flags[0],
+            MILESTONES_APP=feature_flags[1],
+        ):
             assert feature_flags[2] == milestones_helpers.is_prerequisite_courses_enabled()
 
     def test_add_milestone_returns_none_when_app_disabled(self):

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -133,7 +133,7 @@ class PreRequisiteCourseCatalog(ModuleStoreTestCase, LoginEnrollmentTestCase, Mi
     """
     ENABLED_SIGNALS = ['course_published']
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_course_with_prereq(self):
         """
         Simulate having a course which has closed enrollments that has

--- a/lms/djangoapps/certificates/tests/tests.py
+++ b/lms/djangoapps/certificates/tests/tests.py
@@ -4,10 +4,9 @@ Tests for the certificates models.
 
 
 from datetime import datetime, timedelta
-from unittest.mock import patch
 
 from ddt import data, ddt, unpack
-from django.conf import settings
+from django.test.utils import override_settings
 from milestones.tests.utils import MilestonesTestCaseMixin
 from pytz import UTC
 
@@ -181,7 +180,7 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
             {course_1.id, course_2.id}
         )
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_course_milestone_collected(self):
         student = UserFactory()
         course = CourseFactory.create(org='edx', number='998', display_name='Test Course')

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 import ddt
 import pytz
 from crum import set_current_request
-from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
@@ -115,7 +114,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         resp = self.client.get(url)
         self.assertRedirects(resp, reverse('dashboard'), fetch_redirect_response=False)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_COURSE_HOME_REDIRECT': True})
+    @override_settings(ENABLE_COURSE_HOME_REDIRECT=True)
     def test_logged_in_marketing(self):
         self.setup_user()
         url = reverse('about_course', args=[str(self.course.id)])
@@ -133,7 +132,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         # should not be redirected
         self.assertContains(resp, "OOGIE BLOOGIE")
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_pre_requisite_course(self):
         pre_requisite_course = CourseFactory.create(org='edX', course='900', display_name='pre requisite course')
         course = CourseFactory.create(pre_requisite_courses=[str(pre_requisite_course.id)])
@@ -148,7 +147,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
             f'{pre_requisite_courses[0]["display"]}</a> before you begin this course.'
         ) in resp.content.decode(resp.charset).strip('\n')
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_about_page_unfulfilled_prereqs(self):
         pre_requisite_course = CourseFactory.create(
             org='edX',

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -722,8 +722,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         assert isinstance(see_in_catalog_response, access_response.CatalogVisibilityError)
         assert access._has_access_course(user, 'see_about_page', course_about)
 
-    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
-    @override_settings(MILESTONES_APP=True)
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True, MILESTONES_APP=True)
     def test_access_on_course_with_pre_requisites(self):
         """
         Test course access when a course has pre-requisite course yet to be completed

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -200,8 +200,7 @@ class TestMasqueradeLearnerOptions(StaffMasqueradeTestCase):
         """
         If there are partitions, then the View as Learner should NOT be available
         """
-        with patch.dict('django.conf.settings.FEATURES',
-                        {'ENABLE_ENROLLMENT_TRACK_USER_PARTITION': partitions_enabled}):
+        with override_settings(ENABLE_ENROLLMENT_TRACK_USER_PARTITION=partitions_enabled):
             response = self.get_available_masquerade_identities()
             is_learner_available = 'Learner' in map(itemgetter('name'), response.json()['available'])
             assert partitions_enabled != is_learner_available

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1214,7 +1214,7 @@ def _course_home_redirect_enabled():
     Return True if users should be redirected from the course about page to course home.
     """
     return bool(configuration_helpers.get_value(
-        'ENABLE_COURSE_HOME_REDIRECT', settings.FEATURES.get('ENABLE_COURSE_HOME_REDIRECT', False)
+        'ENABLE_COURSE_HOME_REDIRECT', settings.ENABLE_COURSE_HOME_REDIRECT
     ))
 
 

--- a/lms/djangoapps/mobile_api/tests/test_milestones.py
+++ b/lms/djangoapps/mobile_api/tests/test_milestones.py
@@ -3,10 +3,8 @@ Milestone related tests for the mobile_api
 """
 
 
-from unittest.mock import patch
 
 from crum import set_current_request
-from django.conf import settings
 from django.test import override_settings
 
 from common.djangoapps.util.milestones_helpers import add_prerequisite_course, fulfill_course_milestone
@@ -31,14 +29,14 @@ class MobileAPIMilestonesMixin:
 
     ALLOW_ACCESS_TO_MILESTONE_COURSE = False
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_unfulfilled_prerequisite_course(self):
         """ Tests the case for an unfulfilled pre-requisite course """
         self._add_prerequisite_course()
         self.init_course_access()
         self._verify_unfulfilled_milestone_response()
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_unfulfilled_prerequisite_course_for_staff(self):
         self._add_prerequisite_course()
         self.user.is_staff = True
@@ -46,7 +44,7 @@ class MobileAPIMilestonesMixin:
         self.init_course_access()
         self.api_response()
 
-    @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     def test_fulfilled_prerequisite_course(self):
         """
         Tests the case when a user fulfills existing pre-requisite course

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -167,8 +167,8 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
                    str(courses[((num_courses - course_index) - 1)].id)
 
     @ddt.data(API_V05, API_V1, API_V2)
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
     @patch.dict(settings.FEATURES, {
-        'ENABLE_PREREQUISITE_COURSES': True,
         'DISABLE_START_DATES': False,
     })
     def test_courseware_access(self, api_version):

--- a/lms/djangoapps/verify_student/management/commands/tests/test_retry_failed_photo_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_retry_failed_photo_verifications.py
@@ -97,8 +97,7 @@ class TestRetryFailedPhotoVerifications(MockS3Boto3Mixin, TestVerificationBase):
                 )
 
 
-@override_settings(VERIFY_STUDENT=FAKE_SETTINGS)
-@patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
+@override_settings(VERIFY_STUDENT=FAKE_SETTINGS, AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING=True)
 class TestRetryFailedPhotoVerificationsBetweenDates(MockS3Boto3Mixin, TestVerificationBase):
     """
     Tests that the command selects specific objects within a date range

--- a/lms/djangoapps/verify_student/management/commands/tests/test_trigger_softwaresecurephotoverifications_post_save_signal.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_trigger_softwaresecurephotoverifications_post_save_signal.py
@@ -17,7 +17,6 @@ from lms.djangoapps.verify_student.tests.test_models import FAKE_SETTINGS, mock_
 
 # Lots of patching to stub in our own settings, and HTTP posting
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
-@patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
 @patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post)
 class TestTriggerSoftwareSecurePhotoVerificationsPostSaveSignal(MockS3Boto3Mixin, TestVerificationBase):
     """

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -2,7 +2,6 @@
 
 import base64
 from datetime import datetime, timedelta
-from unittest import mock
 from unittest.mock import patch
 
 import ddt
@@ -10,6 +9,7 @@ import pytest
 import requests.exceptions
 import simplejson as json
 from django.conf import settings
+from django.test.utils import override_settings
 from django.utils.timezone import now
 from freezegun import freeze_time
 
@@ -219,7 +219,7 @@ class TestPhotoVerification(TestVerificationBase, MockS3Boto3Mixin, ModuleStoreT
             attempt = self.create_upload_and_submit_attempt_for_user()
             assert attempt.status == PhotoVerification.STATUS.must_retry
 
-    @mock.patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
+    @override_settings(AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING=True)
     def test_submission_while_testing_flag_is_true(self):
         """ Test that a fake value is set for field 'photo_id_key' of user's
         initial verification when the feature flag 'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING'

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1230,7 +1230,7 @@ class TestCheckoutWithEcommerceService(ModuleStoreTestCase):
 
 
 @ddt.ddt
-@patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
+@override_settings(AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING=True)
 class TestSubmitPhotosForVerification(MockS3Boto3Mixin, TestVerificationBase):
     """
     Tests for submitting photos for verification.
@@ -1289,7 +1289,7 @@ class TestSubmitPhotosForVerification(MockS3Boto3Mixin, TestVerificationBase):
 
     # Disable auto-auth since we will be intercepting POST requests
     # to the verification service ourselves in this test.
-    @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': False})
+    @override_settings(AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING=False)
     @override_settings(VERIFY_STUDENT={
         "SOFTWARE_SECURE": {
             "API_URL": "https://verify.example.com/submit/",

--- a/lms/djangoapps/verify_student/utils.py
+++ b/lms/djangoapps/verify_student/utils.py
@@ -136,7 +136,7 @@ def auto_verify_for_testing_enabled(override=None):
     """
     if override is not None:
         return override
-    return settings.FEATURES.get('AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING')
+    return settings.AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING
 
 
 def can_verify_now(verification_status, expiration_datetime):

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -855,7 +855,7 @@ if settings.ENABLE_SERVICE_STATUS:
         path('status/', include('openedx.core.djangoapps.service_status.urls')),
     ]
 
-if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
     urlpatterns += [
         path(
             'instructor_task_status/',

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -1029,7 +1029,7 @@ class TestEmailChangeMiddleware(TestSafeSessionsLogMixin, TestCase):
         # Verify that email is set in the session
         self.assertEqual(self.request.session.get('email'), self.user.email)  # noqa: PT009
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     def test_user_remain_authenticated_on_email_change_in_other_browser_with_toggle_disabled(self):
         """
         Integration Test: test that a user remains authenticated upon email change
@@ -1061,7 +1061,7 @@ class TestEmailChangeMiddleware(TestSafeSessionsLogMixin, TestCase):
         response = self.client.get(self.dashboard_url)
         assert response.status_code == 200
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     @override_settings(ENFORCE_SESSION_EMAIL_MATCH=True)
     def test_cookies_are_updated_with_new_email_on_email_change_with_toggle_enabled(self):
         """
@@ -1114,7 +1114,7 @@ class TestEmailChangeMiddleware(TestSafeSessionsLogMixin, TestCase):
             email_change_response.cookies[jwt_cookies.jwt_cookie_signature_name()].value
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     @override_settings(ENFORCE_SESSION_EMAIL_MATCH=False)
     def test_cookies_are_updated_with_new_email_on_email_change_with_toggle_disabled(self):
         """
@@ -1167,7 +1167,7 @@ class TestEmailChangeMiddleware(TestSafeSessionsLogMixin, TestCase):
             email_change_response.cookies[jwt_cookies.jwt_cookie_signature_name()].value
         )
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     @override_settings(ENFORCE_SESSION_EMAIL_MATCH=True)
     def test_logged_in_user_unauthenticated_on_email_change_in_other_browser(self):
         """
@@ -1201,7 +1201,7 @@ class TestEmailChangeMiddleware(TestSafeSessionsLogMixin, TestCase):
         assert response.status_code == 302
         self._assert_logged_in_cookies_not_present(response)
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     @override_settings(ENFORCE_SESSION_EMAIL_MATCH=True)
     def test_logged_in_user_remains_authenticated_on_email_change_in_same_browser(self):
         """
@@ -1248,7 +1248,7 @@ class TestEmailChangeMiddleware(TestSafeSessionsLogMixin, TestCase):
         response = self.client.get(self.dashboard_url)
         assert response.status_code == 200
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     @override_settings(ENFORCE_SESSION_EMAIL_MATCH=True)
     def test_registered_user_unauthenticated_on_email_change_in_other_browser(self):
         """
@@ -1286,7 +1286,7 @@ class TestEmailChangeMiddleware(TestSafeSessionsLogMixin, TestCase):
         assert response.status_code == 302
         self._assert_logged_in_cookies_not_present(response)
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     @override_settings(ENFORCE_SESSION_EMAIL_MATCH=True)
     def test_registered_user_remain_authenticated_on_email_change_in_same_browser(self):
         """

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -56,7 +56,7 @@ ALL_LOGGED_IN_COOKIE_NAMES = JWT_COOKIE_NAMES + DEPRECATED_LOGGED_IN_COOKIE_NAME
 
 def are_logged_in_cookies_set(request):
     """ Check whether the request has logged in cookies set. """
-    if settings.FEATURES.get('DISABLE_SET_JWT_COOKIES_FOR_TESTS', False):
+    if getattr(settings, 'DISABLE_SET_JWT_COOKIES_FOR_TESTS', False):
         cookies_that_should_exist = DEPRECATED_LOGGED_IN_COOKIE_NAMES
     else:
         cookies_that_should_exist = ALL_LOGGED_IN_COOKIE_NAMES
@@ -294,7 +294,7 @@ def _create_and_set_jwt_cookies(response, request, cookie_settings, user=None):
     # a login oauth client cannot be found in the database in ``_get_login_oauth_client``.
     # This solution is not ideal, but see https://github.com/openedx/edx-platform/pull/19180#issue-226706355
     # for a discussion of alternative solutions that did not work or were halted.
-    if settings.FEATURES.get('DISABLE_SET_JWT_COOKIES_FOR_TESTS', False):
+    if getattr(settings, 'DISABLE_SET_JWT_COOKIES_FOR_TESTS', False):
         return
 
     expires_in = settings.JWT_AUTH['JWT_IN_COOKIE_EXPIRATION']

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -125,7 +125,7 @@ class CookieTests(TestCase):
         self._assert_consistent_expires(response)
         self._assert_recreate_jwt_from_cookies(response, can_recreate=False)
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     def test_set_logged_in_jwt_cookies(self):
         setup_login_oauth_client()
         response = cookies_api.set_logged_in_cookies(self.request, HttpResponse(), self.user)
@@ -133,7 +133,7 @@ class CookieTests(TestCase):
         self._assert_consistent_expires(response, num_of_unique_expires=2)
         self._assert_recreate_jwt_from_cookies(response, can_recreate=True)
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     def test_delete_and_are_logged_in_cookies_set(self):
         setup_login_oauth_client()
         response = cookies_api.set_logged_in_cookies(self.request, HttpResponse(), self.user)
@@ -144,7 +144,7 @@ class CookieTests(TestCase):
         self._copy_cookies_to_request(response, self.request)
         assert not cookies_api.are_logged_in_cookies_set(self.request)
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     def test_refresh_jwt_cookies(self):
         setup_login_oauth_client()
         response = cookies_api.get_response_with_refreshed_jwt_cookies(self.request, self.user)

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -611,7 +611,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
             response, _audit_log = self._login_response(self.user_email, 'wrong_password')
         self._assert_response(response, success=False, value='Too many failed login attempts')
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     def test_login_refresh(self):
         def _assert_jwt_cookie_present(response):
             assert response.status_code == 200
@@ -624,7 +624,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
         response = self.client.post(reverse('login_refresh'))
         _assert_jwt_cookie_present(response)
 
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     def test_login_refresh_anonymous_user(self):
         response = self.client.post(reverse('login_refresh'))
         assert response.status_code == 401

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -114,7 +114,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         expected_data = f'"initial_mode": "{initial_mode}"'
         self.assertContains(response, expected_data)
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    @override_settings(DISABLE_SET_JWT_COOKIES_FOR_TESTS=False)
     @ddt.data("signin_user", "register_user")
     def test_login_and_registration_form_already_authenticated(self, url_name):
         setup_login_oauth_client()

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1050,6 +1050,14 @@ AUTOPLAY_VIDEOS = False
 # auto-advance.
 ENABLE_AUTOADVANCE_VIDEOS = False
 
+# .. toggle_name: DISPLAY_COURSE_MODES_ON_DASHBOARD
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: When True, course modes (verified, honor, etc.) are shown as pills on the learner dashboard.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2017-09-13
+DISPLAY_COURSE_MODES_ON_DASHBOARD = True
+
 # .. toggle_name: CUSTOM_COURSES_EDX
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False

--- a/xmodule/discussion_block.py
+++ b/xmodule/discussion_block.py
@@ -218,7 +218,7 @@ class _BuiltInDiscussionXBlock(XBlock, StudioEditableXBlockMixin,
                 'can_create_subcomment': self.has_permission("create_sub_comment"),
                 'login_msg': login_msg,
                 'PLATFORM_NAME': settings.PLATFORM_NAME,
-                'enable_discussion_home_panel': settings.FEATURES.get("ENABLE_DISCUSSION_HOME_PANEL", False),
+                'enable_discussion_home_panel': settings.ENABLE_DISCUSSION_HOME_PANEL,
             }
             fragment.add_content(
                 render_to_string('discussion/_discussion_inline.html', context)

--- a/xmodule/partitions/enrollment_track_partition_generator.py
+++ b/xmodule/partitions/enrollment_track_partition_generator.py
@@ -16,15 +16,12 @@ from xmodule.partitions.partitions import (
 
 log = logging.getLogger(__name__)
 
-FEATURES = getattr(settings, 'FEATURES', {})
-
-
 def create_enrollment_track_partition_with_course_id(course_id):
     """
     Create and return the dynamic enrollment track user partition based only on course_id.
     If it cannot be created, None is returned.
     """
-    if not FEATURES.get('ENABLE_ENROLLMENT_TRACK_USER_PARTITION'):
+    if not settings.ENABLE_ENROLLMENT_TRACK_USER_PARTITION:
         return None
 
     try:

--- a/xmodule/partitions/tests/test_partitions.py
+++ b/xmodule/partitions/tests/test_partitions.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from unittest.mock import Mock
 
 import pytest
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from opaque_keys.edx.locator import CourseLocator
 from stevedore.extension import Extension, ExtensionManager
 
@@ -20,7 +20,7 @@ from xmodule.partitions.partitions import (
     UserPartition,
     UserPartitionError,
 )
-from xmodule.partitions.partitions_service import FEATURES, PartitionService, get_all_partitions_for_course
+from xmodule.partitions.partitions_service import PartitionService, get_all_partitions_for_course
 
 
 class TestGroup(TestCase):
@@ -520,21 +520,11 @@ class TestPartitionService(PartitionServiceBaseClass):
         assert group2 == groups[1]
 
 
+@override_settings(ENABLE_ENROLLMENT_TRACK_USER_PARTITION=True)
 class TestGetCourseUserPartitions(PartitionServiceBaseClass):
     """
     Test the helper method get_all_partitions_for_course.
     """
-
-    def setUp(self):
-        super().setUp()
-        TestGetCourseUserPartitions._enable_enrollment_track_partition(True)
-
-    @staticmethod
-    def _enable_enrollment_track_partition(enable):
-        """
-        Enable or disable the feature flag for the enrollment track user partition.
-        """
-        FEATURES['ENABLE_ENROLLMENT_TRACK_USER_PARTITION'] = enable
 
     def test_filter_inactive_user_partitions(self):
         """


### PR DESCRIPTION
## Summary

Migrates 10 more feature flags off `settings.FEATURES['X']` dict-style access onto flat settings (`settings.X`) with `@override_settings(X=Y)` in tests. Follows the pattern established in #38772.

Each commit migrates a single flag:

- ENABLE_PREREQUISITE_COURSES
- ENABLE_DISCUSSION_HOME_PANEL
- ENABLE_COURSE_HOME_REDIRECT
- DISPLAY_COURSE_MODES_ON_DASHBOARD (also adds the flag + annotation to `openedx/envs/common.py`)
- ENABLE_VERIFIED_CERTIFICATES
- ENABLE_ENROLLMENT_TRACK_USER_PARTITION
- AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING
- ENABLE_INSTRUCTOR_BACKGROUND_TASKS
- ENABLE_ENROLLMENT_RESET
- DISABLE_SET_JWT_COOKIES_FOR_TESTS