### PR TITLE
refactor: migrate 10 more flags off FEATURES-as-dict (batch 7)

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -49,7 +49,7 @@ def indexing_is_enabled():
     """
     Checks to see if the indexing feature is enabled
     """
-    return settings.FEATURES.get('ENABLE_COURSEWARE_INDEX', False)
+    return settings.ENABLE_COURSEWARE_INDEX
 
 
 class SearchIndexingError(Exception):

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1863,7 +1863,7 @@ def _get_course_index_context(request, course_key, course_block):
 
     lms_link = get_lms_link_for_item(course_block.location)
     reindex_link = None
-    if settings.FEATURES.get('ENABLE_COURSEWARE_INDEX', False):
+    if settings.ENABLE_COURSEWARE_INDEX:
         if GlobalStaff().has_user(request.user):
             reindex_link = f"/course/{str(course_key)}/search_reindex"
     sections = course_block.get_children()

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1630,7 +1630,7 @@ def get_course_context(request):
         }
 
     courses_iter, in_process_course_actions = get_courses_accessible_to_user(request)
-    split_archived = settings.FEATURES.get('ENABLE_SEPARATE_ARCHIVED_COURSES', False)
+    split_archived = settings.ENABLE_SEPARATE_ARCHIVED_COURSES
     active_courses, archived_courses = _process_courses_list(courses_iter, in_process_course_actions, split_archived)
     in_process_course_actions = [format_in_process_course_view(uca) for uca in in_process_course_actions]
     return active_courses, archived_courses, in_process_course_actions

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -251,7 +251,7 @@ if settings.ENABLE_SERVICE_STATUS:
 
 # The password pages in the admin tool are disabled so that all password
 # changes go through our user portal and follow complexity requirements.
-if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+if not settings.ENABLE_CHANGE_USER_PASSWORD_ADMIN:
     urlpatterns.append(re_path(r'^admin/auth/user/\d+/password/$', handler404))
 urlpatterns.append(path('admin/password_change/', handler404))
 urlpatterns.append(

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -246,7 +246,7 @@ if toggles.EXPORT_GIT.is_enabled():
                 name='export_git')
     ]
 
-if settings.FEATURES.get('ENABLE_SERVICE_STATUS'):
+if settings.ENABLE_SERVICE_STATUS:
     urlpatterns.append(path('status/', include('openedx.core.djangoapps.service_status.urls')))
 
 # The password pages in the admin tool are disabled so that all password

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -538,7 +538,7 @@ class UserChangeForm(BaseUserChangeForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+        if not settings.ENABLE_CHANGE_USER_PASSWORD_ADMIN:
             self.fields["password"] = ReadOnlyPasswordHashField(
                 label=_("Password"),
                 help_text=_(

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 
 import ddt
 import pytest
-from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
 from openedx_events.testing import OpenEdxEventsTestMixin
@@ -178,7 +177,7 @@ class EnrollmentTest(OpenEdxEventsTestMixin, UrlResetMixin, ModuleStoreTestCase)
         assert traits['mode'] == 'verified'
         assert traits['email'] == self.EMAIL
 
-    @patch.dict(settings.FEATURES, {'ENABLE_MKTG_EMAIL_OPT_IN': True})
+    @override_settings(ENABLE_MKTG_EMAIL_OPT_IN=True)
     @patch('openedx.core.djangoapps.user_api.preferences.api.update_email_opt_in')
     @ddt.data(
         ([], 'true'),

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -422,7 +422,7 @@ def change_enrollment(request, check_access=True):
             return HttpResponseBadRequest(_("Course id is invalid"))
 
         # Record the user's email opt-in preference
-        if settings.FEATURES.get('ENABLE_MKTG_EMAIL_OPT_IN'):
+        if getattr(settings, 'ENABLE_MKTG_EMAIL_OPT_IN', False):
             _update_email_opt_in(request, course_id.org)
 
         available_modes = CourseMode.modes_for_course_dict(course_id)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3180,7 +3180,7 @@ class TestCoursewareMFESearchAPI(SharedModuleStoreTestCase):
         (CourseMode.MASTERS, True),
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED': True})
+    @override_settings(ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED=True)
     def test_courseware_mfe_search_verified_only(self, mode, expected_enabled):
         """
         Only verified enrollees may use Courseware Search if ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED
@@ -3196,7 +3196,7 @@ class TestCoursewareMFESearchAPI(SharedModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)  # noqa: PT009
         self.assertEqual(body, {'enabled': expected_enabled})  # noqa: PT009
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED': True})
+    @override_settings(ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED=True)
     def test_courseware_mfe_search_staff_access(self):
         """
         Staff users may use Courseware Search regardless of their enrollment status.

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -2353,7 +2353,7 @@ def courseware_mfe_search_enabled(request, course_id=None):
     user = request.user
 
     has_required_enrollment = False
-    if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED'):
+    if settings.ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED:
         enrollment_mode, _ = CourseEnrollment.enrollment_mode_for_user(user, course_key)
         if (
             auth.user_has_role(user, CourseStaffRole(CourseKey.from_string(course_id)))

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -848,7 +848,7 @@ urlpatterns += [
     path('_o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 ]
 
-if settings.FEATURES.get('ENABLE_SERVICE_STATUS'):
+if settings.ENABLE_SERVICE_STATUS:
     urlpatterns += [
         path('status/', include('openedx.core.djangoapps.service_status.urls')),
     ]

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -58,7 +58,7 @@ RENDER_VIDEO_XBLOCK_NAME = 'render_public_video_xblock'
 RENDER_VIDEO_XBLOCK_EMBED_NAME = 'render_public_video_xblock_embed'
 COURSE_PROGRESS_NAME = 'progress'
 
-if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
+if settings.DEBUG or settings.ENABLE_DJANGO_ADMIN_SITE:
     django_autodiscover()
     admin.site.site_header = _('LMS Administration')
     admin.site.site_title = admin.site.site_header
@@ -800,7 +800,7 @@ if settings.FEATURES.get('ENABLE_STUDENT_HISTORY_VIEW'):
         ),
     ]
 
-if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
+if settings.DEBUG or settings.ENABLE_DJANGO_ADMIN_SITE:
     # Jasmine and admin
 
     # The password pages in the admin tool are disabled so that all password

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -789,7 +789,7 @@ urlpatterns += [
     ),
 ]
 
-if settings.FEATURES.get('ENABLE_STUDENT_HISTORY_VIEW'):
+if settings.ENABLE_STUDENT_HISTORY_VIEW:
     urlpatterns += [
         re_path(
             r'^courses/{}/submission_history/(?P<learner_identifier>[^/]*)/(?P<location>.*?)$'.format(  # noqa: UP032

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -807,7 +807,7 @@ if settings.DEBUG or settings.ENABLE_DJANGO_ADMIN_SITE:
     # changes go through our user portal and follow complexity requirements.
     # The form to change another user's password is conditionally enabled
     # for backwards compatibility.
-    if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+    if not settings.ENABLE_CHANGE_USER_PASSWORD_ADMIN:
         urlpatterns += [
             re_path(r'^admin/auth/user/\d+/password/$', handler404),
         ]

--- a/openedx/core/djangoapps/cors_csrf/middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/middleware.py
@@ -62,7 +62,7 @@ class CorsCSRFMiddleware(CsrfViewMiddleware, MiddlewareMixin):
 
     def __init__(self, *args, **kwargs):
         """Disable the middleware if the feature flag is disabled. """
-        if not settings.FEATURES.get('ENABLE_CORS_HEADERS'):
+        if not settings.ENABLE_CORS_HEADERS:
             raise MiddlewareNotUsed()
         super().__init__(*args, **kwargs)
 

--- a/openedx/core/djangoapps/cors_csrf/middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/middleware.py
@@ -85,7 +85,7 @@ class CsrfCrossDomainCookieMiddleware(MiddlewareMixin):
         2) Set `CROSS_DOMAIN_CSRF_COOKIE_NAME` and `CROSS_DOMAIN_CSRF_COOKIE_DOMAIN`
             in settings.
         3) Add the domain to `CORS_ORIGIN_WHITELIST`
-        4) Enable `FEATURES['ENABLE_CROSS_DOMAIN_CSRF_COOKIE']`
+        4) Enable `ENABLE_CROSS_DOMAIN_CSRF_COOKIE`
 
     For testing, it is often easier to relax the security checks by setting:
         * `CORS_ALLOW_INSECURE = True`
@@ -95,19 +95,19 @@ class CsrfCrossDomainCookieMiddleware(MiddlewareMixin):
 
     def __init__(self, *args, **kwargs):
         """Disable the middleware if the feature is not enabled. """
-        if not settings.FEATURES.get('ENABLE_CROSS_DOMAIN_CSRF_COOKIE'):
+        if not settings.ENABLE_CROSS_DOMAIN_CSRF_COOKIE:
             raise MiddlewareNotUsed()
 
         if not getattr(settings, 'CROSS_DOMAIN_CSRF_COOKIE_NAME', ''):
             raise ImproperlyConfigured(
                 "You must set `CROSS_DOMAIN_CSRF_COOKIE_NAME` when "
-                "`FEATURES['ENABLE_CROSS_DOMAIN_CSRF_COOKIE']` is True."
+                "`ENABLE_CROSS_DOMAIN_CSRF_COOKIE` is True."
             )
 
         if not getattr(settings, 'CROSS_DOMAIN_CSRF_COOKIE_DOMAIN', ''):
             raise ImproperlyConfigured(
                 "You must set `CROSS_DOMAIN_CSRF_COOKIE_DOMAIN` when "
-                "`FEATURES['ENABLE_CROSS_DOMAIN_CSRF_COOKIE']` is True."
+                "`ENABLE_CROSS_DOMAIN_CSRF_COOKIE` is True."
             )
         super().__init__(*args, **kwargs)
 

--- a/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
@@ -116,15 +116,15 @@ class TestCsrfCrossDomainCookieMiddleware(TestCase):
     COOKIE_DOMAIN = '.edx.org'
 
     @override_settings(
-        FEATURES={'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': True},
+        ENABLE_CROSS_DOMAIN_CSRF_COOKIE=True,
         CROSS_DOMAIN_CSRF_COOKIE_NAME=COOKIE_NAME,
-        CROSS_DOMAIN_CSRF_COOKIE_DOMAIN=COOKIE_DOMAIN
+        CROSS_DOMAIN_CSRF_COOKIE_DOMAIN=COOKIE_DOMAIN,
     )
     def setUp(self):
         super().setUp()
         self.middleware = CsrfCrossDomainCookieMiddleware(get_response=lambda request: None)
 
-    @override_settings(FEATURES={'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': False})
+    @override_settings(ENABLE_CROSS_DOMAIN_CSRF_COOKIE=False)
     def test_disabled_by_feature_flag(self):
         with pytest.raises(MiddlewareNotUsed):
             CsrfCrossDomainCookieMiddleware(get_response=lambda request: None)
@@ -132,7 +132,7 @@ class TestCsrfCrossDomainCookieMiddleware(TestCase):
     @ddt.data('CROSS_DOMAIN_CSRF_COOKIE_NAME', 'CROSS_DOMAIN_CSRF_COOKIE_DOMAIN')
     def test_improperly_configured(self, missing_setting):
         settings = {
-            'FEATURES': {'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': True},
+            'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': True,
             'CROSS_DOMAIN_CSRF_COOKIE_NAME': self.COOKIE_NAME,
             'CROSS_DOMAIN_CSRF_COOKIE_DOMAIN': self.COOKIE_DOMAIN
         }

--- a/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
@@ -32,7 +32,7 @@ class TestCorsMiddlewareProcessRequest(TestCase):
         request.is_secure = lambda: is_secure
         return request
 
-    @override_settings(FEATURES={'ENABLE_CORS_HEADERS': True})
+    @override_settings(ENABLE_CORS_HEADERS=True)
     def setUp(self):
         super().setUp()
         self.middleware = CorsCSRFMiddleware(get_response=lambda request: None)
@@ -78,8 +78,8 @@ class TestCorsMiddlewareProcessRequest(TestCase):
         self.check_enabled(request)
 
     @override_settings(
-        FEATURES={'ENABLE_CORS_HEADERS': False},
-        CORS_ORIGIN_WHITELIST=['https://foo.com']
+        ENABLE_CORS_HEADERS=False,
+        CORS_ORIGIN_WHITELIST=['https://foo.com'],
     )
     def test_disabled_no_cors_headers(self):
         with pytest.raises(MiddlewareNotUsed):

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -12,7 +12,6 @@ from zoneinfo import ZoneInfo
 
 import ddt
 import pytest
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
@@ -1397,22 +1396,16 @@ class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestC
 
 def cross_domain_config(func):
     """Decorator for configuring a cross-domain request. """
-    feature_flag_decorator = patch.dict(settings.FEATURES, {
-        'ENABLE_CORS_HEADERS': True,
-        'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': True
-    })
     settings_decorator = override_settings(
+        ENABLE_CORS_HEADERS=True,
+        ENABLE_CROSS_DOMAIN_CSRF_COOKIE=True,
         CORS_ORIGIN_WHITELIST=["https://www.edx.org"],
         CROSS_DOMAIN_CSRF_COOKIE_NAME="prod-edx-csrftoken",
-        CROSS_DOMAIN_CSRF_COOKIE_DOMAIN=".edx.org"
+        CROSS_DOMAIN_CSRF_COOKIE_DOMAIN=".edx.org",
     )
     is_secure_decorator = patch.object(WSGIRequest, 'is_secure', return_value=True)
 
-    return feature_flag_decorator(
-        settings_decorator(
-            is_secure_decorator(func)
-        )
-    )
+    return settings_decorator(is_secure_decorator(func))
 
 
 @skip_unless_lms


### PR DESCRIPTION
## Summary

Migrates 10 more feature flags off `settings.FEATURES['X']` dict-style access onto flat settings (`settings.X`) with `@override_settings(X=Y)` in tests. Follows the pattern established in #38772.

Each commit migrates a single flag:

- ENABLE_DJANGO_ADMIN_SITE
- ENABLE_SERVICE_STATUS
- ENABLE_SEPARATE_ARCHIVED_COURSES
- ENABLE_MKTG_EMAIL_OPT_IN
- ENABLE_STUDENT_HISTORY_VIEW
- ENABLE_CORS_HEADERS
- ENABLE_CROSS_DOMAIN_CSRF_COOKIE
- ENABLE_COURSEWARE_INDEX
- ENABLE_COURSEWARE_SEARCH_VERIFIED_ENROLLMENT_REQUIRED
- ENABLE_CHANGE_USER_PASSWORD_ADMIN