### PR TITLE
refactor: migrate 10 more flags off FEATURES-as-dict (batch 8)

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -2150,7 +2150,7 @@ def get_allowed_organizations_for_libraries(user):
     # This allows org-level staff to create libraries. We should re-evaluate
     # whether this is necessary and try to normalize course and library creation
     # authorization behavior.
-    if settings.FEATURES.get('ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES', False):
+    if settings.ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES:
         organizations_set.update(get_organizations_for_non_course_creators(user))
 
     # This allows people in the course creator group for an org to create

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -457,10 +457,7 @@ class UnitTestLibraries(CourseTestCase):
                 with patch('common.djangoapps.student.roles.OrgStaffRole.get_orgs_for_user') as get_user_orgs:
                     get_user_orgs.return_value = ['org3']
                     # Call the method under test
-                    with mock.patch.dict(
-                        'django.conf.settings.FEATURES',
-                        {"ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES": False}
-                    ):
+                    with override_settings(ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES=False):
                         with override_settings(ENABLE_CREATOR_GROUP=False):
                             organizations = get_allowed_organizations_for_libraries(self.user)
                             # Assert that the method returned the expected value
@@ -474,9 +471,6 @@ class UnitTestLibraries(CourseTestCase):
                                     self.assertEqual(organizations, [])  # noqa: PT009
                                 else:
                                     self.assertEqual(organizations, ['org1', 'org2'])  # noqa: PT009
-                    with mock.patch.dict(
-                        'django.conf.settings.FEATURES',
-                        {"ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES": True}
-                    ):
+                    with override_settings(ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES=True):
                         organizations = get_allowed_organizations_for_libraries(self.user)
                         self.assertEqual(organizations, ['org3'])  # noqa: PT009

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -3,7 +3,6 @@
 
 import json
 
-from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -90,10 +89,7 @@ class TestOrganizationsForLibraries(TestCase):
 
     @override_settings(
         ENABLE_CREATOR_GROUP=False,
-        FEATURES={
-            **settings.FEATURES,
-            'ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES': False,
-        },
+        ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES=False,
     )
     def test_both_toggles_disabled(self):
         allowed_orgs = get_allowed_organizations_for_libraries(self.library_author)
@@ -101,10 +97,7 @@ class TestOrganizationsForLibraries(TestCase):
 
     @override_settings(
         ENABLE_CREATOR_GROUP=True,
-        FEATURES={
-            **settings.FEATURES,
-            'ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES': True,
-        },
+        ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES=True,
     )
     def test_both_toggles_enabled(self):
         allowed_orgs = get_allowed_organizations_for_libraries(self.library_author)
@@ -112,10 +105,7 @@ class TestOrganizationsForLibraries(TestCase):
 
     @override_settings(
         ENABLE_CREATOR_GROUP=False,
-        FEATURES={
-            **settings.FEATURES,
-            'ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES': True,
-        },
+        ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES=True,
     )
     def test_org_staff_enabled(self):
         allowed_orgs = get_allowed_organizations_for_libraries(self.library_author)
@@ -123,10 +113,7 @@ class TestOrganizationsForLibraries(TestCase):
 
     @override_settings(
         ENABLE_CREATOR_GROUP=True,
-        FEATURES={
-            **settings.FEATURES,
-            'ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES': False,
-        },
+        ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES=False,
     )
     def test_creator_group_enabled(self):
         allowed_orgs = get_allowed_organizations_for_libraries(self.library_author)

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -1370,7 +1370,7 @@ def enforce_single_login(sender, request, user, signal, **kwargs):  # pylint: di
     Sets the current session id in the user profile,
     to prevent concurrent logins.
     """
-    if settings.FEATURES.get('PREVENT_CONCURRENT_LOGINS', False):
+    if settings.PREVENT_CONCURRENT_LOGINS:
         if signal == user_logged_in:
             key = request.session.session_key
         else:

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -7,7 +7,6 @@ from zoneinfo import ZoneInfo
 
 import ddt
 from crum import set_current_request
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User  # pylint: disable=imported-auth-user
 from django.core.cache import cache
 from django.db import connection
@@ -912,9 +911,7 @@ class TestUserPostSaveCallback(SharedModuleStoreTestCase):
         course_overview.save()
 
         if feature_enabled:
-            with override_settings(
-                FEATURES={**settings.FEATURES, 'DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED': True}
-            ):
+            with override_settings(DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED=True):
                 assert register_and_enroll_student() is None
         else:
             assert register_and_enroll_student() is not None

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -1013,7 +1013,11 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
 
 
 @skip_unless_lms
-@unittest.skipUnless(settings.FEATURES.get("ENABLE_NOTICES"), 'Notices plugin is not enabled')
+# TODO: It seems like ENABLE_NOTICES does not exist on the backend at all. There's a
+# frontend config flag called ENABLE_NOTICES, but it's unaffected by anything on the
+# backend. We should remove this skipUnless and the override_settings calls, and get
+# then get these tests to pass as-is.
+@unittest.skipUnless(getattr(settings, "ENABLE_NOTICES", False), 'Notices plugin is not enabled')
 class TestCourseDashboardNoticesRedirects(SharedModuleStoreTestCase):
     """
     Tests for the Dashboard redirect functionality introduced via the Notices plugin.
@@ -1088,7 +1092,7 @@ class TestCourseDashboardNoticesRedirects(SharedModuleStoreTestCase):
         """
         mock_notices.return_value = reverse("root")
 
-        with override_settings(FEATURES={**settings.FEATURES, 'ENABLE_NOTICES': True}):
+        with override_settings(ENABLE_NOTICES=True):
             response = self.client.get(self.path)
 
         assert response.status_code == 302
@@ -1103,7 +1107,7 @@ class TestCourseDashboardNoticesRedirects(SharedModuleStoreTestCase):
         """
         mock_notices.return_value = None
 
-        with override_settings(FEATURES={**settings.FEATURES, 'ENABLE_NOTICES': True}):
+        with override_settings(ENABLE_NOTICES=True):
             response = self.client.get(self.path)
 
         assert response.status_code == 200
@@ -1116,7 +1120,7 @@ class TestCourseDashboardNoticesRedirects(SharedModuleStoreTestCase):
         """
         mock_notices.return_value = None
 
-        with override_settings(FEATURES={**settings.FEATURES, 'ENABLE_NOTICES': False}):
+        with override_settings(ENABLE_NOTICES=False):
             response = self.client.get(self.path)
 
         assert response.status_code == 200

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -204,7 +204,6 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
     }
     MOCK_SETTINGS_HIDE_COURSES = {
         'FEATURES': {
-            'HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED': True,
             'DISABLE_SET_JWT_COOKIES_FOR_TESTS': True,
         }
     }
@@ -599,6 +598,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         response = self.client.get(self.path)
         assert pq(response.content)(self.EMAIL_SETTINGS_ELEMENT_ID).length == 0
 
+    @override_settings(HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED=True)
     @patch.multiple('django.conf.settings', **MOCK_SETTINGS_HIDE_COURSES)
     def test_hide_dashboard_courses_until_activated(self):
         """

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -545,7 +545,7 @@ def student_dashboard(request):  # pylint: disable=too-many-statements
     ) or settings.SUPPORT_SITE_LINK
     hide_dashboard_courses_until_activated = configuration_helpers.get_value(
         'HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED',
-        settings.FEATURES.get('HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED', False)
+        settings.HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED
     )
     empty_dashboard_message = configuration_helpers.get_value(
         'EMPTY_DASHBOARD_MESSAGE', None

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -247,7 +247,7 @@ def compose_activation_email(
     })
 
     if route_enabled:
-        dest_addr = settings.FEATURES['REROUTE_ACTIVATION_EMAIL']
+        dest_addr = getattr(settings, 'REROUTE_ACTIVATION_EMAIL', False)
     else:
         dest_addr = user.email
 
@@ -293,7 +293,7 @@ def compose_and_send_activation_email(
         redirect_url: The URL to redirect to after successful activation
         registration_flow: Is the request coming from registration workflow
     """
-    route_enabled = settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL')
+    route_enabled = getattr(settings, 'REROUTE_ACTIVATION_EMAIL', False)
 
     msg = compose_activation_email(
         user, user_registration, route_enabled, profile.name, redirect_url, registration_flow

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -38,12 +38,7 @@ from xmodule.modulestore.tests.utils import ProceduralCourseTestMixin
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES + AUTHZ_TABLES
 
 
-@mock.patch.dict(
-    'django.conf.settings.FEATURES',
-    {
-        'ENABLE_XBLOCK_VIEW_ENDPOINT': True,
-    }
-)
+@override_settings(ENABLE_XBLOCK_VIEW_ENDPOINT=True)
 @ddt.ddt
 class FieldOverridePerformanceTestCase(FieldOverrideTestMixin, ProceduralCourseTestMixin, ModuleStoreTestCase):
     """

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -297,7 +297,7 @@ def _can_enroll_courselike(user, courselike):
             # DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED flag is used to disable enrollment for user invited
             # to a course if user is registering when the course enrollment is closed
             if (
-                settings.FEATURES.get('DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED') and
+                getattr(settings, 'DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED', False) and
                 not course_enrollment_open and
                 not user_has_staff_access
             ):

--- a/lms/djangoapps/courseware/block_render.py
+++ b/lms/djangoapps/courseware/block_render.py
@@ -1005,9 +1005,9 @@ def xblock_view(request, course_id, usage_id, view_name):
         resources: A list of tuples where the first element is the resource hash, and
             the second is the resource description
     """
-    if not settings.FEATURES.get('ENABLE_XBLOCK_VIEW_ENDPOINT', False):
+    if not settings.ENABLE_XBLOCK_VIEW_ENDPOINT:
         log.warning("Attempt to use deactivated XBlock view endpoint -"
-                    " see FEATURES['ENABLE_XBLOCK_VIEW_ENDPOINT']")
+                    " see ENABLE_XBLOCK_VIEW_ENDPOINT")
         raise Http404
 
     try:

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -11,7 +11,6 @@ import ddt
 import pytest
 import pytz
 from ccx_keys.locator import CCXLocator
-from django.conf import settings
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -551,7 +550,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         course.save()
         assert not access._has_access_course(user, 'enroll', course)
 
-    @override_settings(FEATURES={**settings.FEATURES, 'DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED': True})
+    @override_settings(DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED=True)
     def test__has_access_course_with_disable_allowed_enrollment_flag(self):
         yesterday = datetime.datetime.now(pytz.utc) - datetime.timedelta(days=1)
         tomorrow = datetime.datetime.now(pytz.utc) + datetime.timedelta(days=1)

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -993,7 +993,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
 
 
 @ddt.ddt
-@patch.dict('django.conf.settings.FEATURES', {'ENABLE_XBLOCK_VIEW_ENDPOINT': True})
+@override_settings(ENABLE_XBLOCK_VIEW_ENDPOINT=True)
 class TestXBlockView(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test the handle_xblock_callback function

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -824,7 +824,7 @@ def _section_open_response_assessment(request, course, openassessment_blocks, ac
     section_data = {
         'fragment': block.render('ora_blocks_listing_view', context={
             'ora_items': ora_items,
-            'ora_item_view_enabled': settings.FEATURES.get('ENABLE_XBLOCK_VIEW_ENDPOINT', False)
+            'ora_item_view_enabled': settings.ENABLE_XBLOCK_VIEW_ENDPOINT
         }),
         'section_key': 'open_response_assessment',
         'section_display_name': _('Open Responses'),

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -864,7 +864,7 @@ if settings.ENABLE_INSTRUCTOR_BACKGROUND_TASKS:
         ),
     ]
 
-if settings.FEATURES.get('ENABLE_DEBUG_RUN_PYTHON'):
+if settings.ENABLE_DEBUG_RUN_PYTHON:
     urlpatterns += [
         path('debug/run_python', debug_views.run_python),
     ]

--- a/openedx/core/djangoapps/user_authn/views/auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/auto_auth.py
@@ -90,7 +90,7 @@ def auto_auth(request):  # pylint: disable=too-many-statements
     redirect_when_done = _str2bool(request.GET.get('redirect', '')) or redirect_to
     login_when_done = 'no_login' not in request.GET
 
-    restricted = settings.FEATURES.get('RESTRICT_AUTOMATIC_AUTH', True)
+    restricted = settings.RESTRICT_AUTOMATIC_AUTH
     if is_superuser and restricted:
         return HttpResponseForbidden(_('Superuser creation not allowed'))
 

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -475,7 +475,7 @@ def _skip_activation_email(user, running_pipeline, third_party_provider):
         )
 
     return (
-        settings.FEATURES.get('SKIP_EMAIL_VALIDATION', None) or
+        getattr(settings, 'SKIP_EMAIL_VALIDATION', False) or
         settings.AUTOMATIC_AUTH_FOR_TESTING or
         (third_party_provider and third_party_provider.skip_email_verification and valid_email)
     )

--- a/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
@@ -67,7 +67,7 @@ class AutoAuthEnabledTestCase(AutoAuthTestCase, ModuleStoreTestCase):
         assert user.is_active
         assert not user.profile.requires_parental_consent()
 
-    @patch.dict("django.conf.settings.FEATURES", {'RESTRICT_AUTOMATIC_AUTH': False})
+    @override_settings(RESTRICT_AUTOMATIC_AUTH=False)
     def test_create_same_user(self):
         self._auto_auth({'username': 'test'})
         self._auto_auth({'username': 'test'})
@@ -105,7 +105,7 @@ class AutoAuthEnabledTestCase(AutoAuthTestCase, ModuleStoreTestCase):
         # By default, the user should not be global staff
         assert not user.is_staff
 
-    @patch.dict("django.conf.settings.FEATURES", {'RESTRICT_AUTOMATIC_AUTH': False})
+    @override_settings(RESTRICT_AUTOMATIC_AUTH=False)
     def test_create_staff_user(self):
 
         # Create a staff user
@@ -132,7 +132,7 @@ class AutoAuthEnabledTestCase(AutoAuthTestCase, ModuleStoreTestCase):
 
     @ddt.data(*COURSE_IDS_DDT)
     @ddt.unpack
-    @patch.dict("django.conf.settings.FEATURES", {'RESTRICT_AUTOMATIC_AUTH': False})
+    @override_settings(RESTRICT_AUTOMATIC_AUTH=False)
     def test_double_enrollment(self, course_id, course_key):
 
         # Create a user and enroll in a course
@@ -337,7 +337,7 @@ class AutoAuthRestrictedTestCase(AutoAuthTestCase):
         self.url = '/auto_auth'
         self.client = Client()
 
-    @patch.dict("django.conf.settings.FEATURES", {'RESTRICT_AUTOMATIC_AUTH': True})
+    @override_settings(RESTRICT_AUTOMATIC_AUTH=True)
     def test_superuser(self):
         """
         Make sure that superusers cannot be created.
@@ -345,7 +345,7 @@ class AutoAuthRestrictedTestCase(AutoAuthTestCase):
         response = self.client.get(self.url, {'username': 'test', 'superuser': 'true'})
         assert response.status_code == 403
 
-    @patch.dict("django.conf.settings.FEATURES", {'RESTRICT_AUTOMATIC_AUTH': True})
+    @override_settings(RESTRICT_AUTOMATIC_AUTH=True)
     def test_modify_user(self):
         """
         Make sure that existing users cannot be modified.

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -630,7 +630,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
         assert response.status_code == 401
         assert jwt_cookies.jwt_cookie_header_payload_name() not in self.client.cookies
 
-    @patch.dict("django.conf.settings.FEATURES", {'PREVENT_CONCURRENT_LOGINS': True})
+    @override_settings(PREVENT_CONCURRENT_LOGINS=True)
     def test_single_session(self):
         creds = {'email': self.user_email, 'password': self.password}
         client1 = Client()
@@ -659,7 +659,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
         # client1 will be logged out
         assert response.status_code == 302
 
-    @patch.dict("django.conf.settings.FEATURES", {'PREVENT_CONCURRENT_LOGINS': True})
+    @override_settings(PREVENT_CONCURRENT_LOGINS=True)
     def test_single_session_exempt_user(self):
         """
         A user whose username is in SINGLE_LOGIN_EXEMPT_USERNAMES is not subject
@@ -688,7 +688,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
             # so it stays valid independent of what profile meta records.
             assert Session.objects.filter(session_key=client1.session.session_key).exists()
 
-    @patch.dict("django.conf.settings.FEATURES", {'PREVENT_CONCURRENT_LOGINS': True})
+    @override_settings(PREVENT_CONCURRENT_LOGINS=True)
     def test_single_session_exempt_group(self):
         """
         A user in a group listed in SINGLE_LOGIN_EXEMPT_GROUPS is not subject
@@ -715,7 +715,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
             # session is ever deleted.
             assert 'session_id' not in self.user.profile.get_meta()
 
-    @patch.dict("django.conf.settings.FEATURES", {'PREVENT_CONCURRENT_LOGINS': True})
+    @override_settings(PREVENT_CONCURRENT_LOGINS=True)
     def test_single_session_with_no_user_profile(self):
         """
         Assert that user login with cas (Central Authentication Service) is
@@ -757,7 +757,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
         # client1 will be logged out
         assert response.status_code == 302
 
-    @patch.dict("django.conf.settings.FEATURES", {'PREVENT_CONCURRENT_LOGINS': True})
+    @override_settings(PREVENT_CONCURRENT_LOGINS=True)
     def test_single_session_with_url_not_having_login_required_decorator(self):
         # accessing logout url as it does not have login-required decorator it will avoid redirect
         # and go inside the enforce_single_login


### PR DESCRIPTION
## Summary

Migrates 10 more feature flags off `settings.FEATURES['X']` dict-style access onto flat settings (`settings.X`) with `@override_settings(X=Y)` in tests. Follows the pattern established in #38772.

Each commit migrates a single flag:

- ENABLE_NOTICES
- RESTRICT_AUTOMATIC_AUTH
- PREVENT_CONCURRENT_LOGINS
- SKIP_EMAIL_VALIDATION
- REROUTE_ACTIVATION_EMAIL
- DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED
- HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED
- ENABLE_DEBUG_RUN_PYTHON
- ENABLE_XBLOCK_VIEW_ENDPOINT
- ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES