### PR TITLE
refactor: migrate 10 more flags off FEATURES-as-dict (batch 9)

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1395,7 +1395,7 @@ def get_course_settings(request, course_key, course_block):
     enable_extended_course_details = configuration_helpers.get_value_for_org(
         course_block.location.org,
         'ENABLE_EXTENDED_COURSE_DETAILS',
-        settings.FEATURES.get('ENABLE_EXTENDED_COURSE_DETAILS', False)
+        settings.ENABLE_EXTENDED_COURSE_DETAILS
     )
 
     about_page_editable = not publisher_enabled

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1403,7 +1403,7 @@ def get_course_settings(request, course_key, course_block):
     short_description_editable = configuration_helpers.get_value_for_org(
         course_block.location.org,
         'EDITABLE_SHORT_DESCRIPTION',
-        settings.FEATURES.get('EDITABLE_SHORT_DESCRIPTION', True)
+        settings.EDITABLE_SHORT_DESCRIPTION
     )
     sidebar_html_enabled = ENABLE_COURSE_ABOUT_SIDEBAR_HTML.is_enabled()
 

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1385,7 +1385,7 @@ def get_course_settings(request, course_key, course_block):
     publisher_enabled = configuration_helpers.get_value_for_org(
         course_block.location.org,
         'ENABLE_PUBLISHER',
-        settings.FEATURES.get('ENABLE_PUBLISHER', False)
+        settings.ENABLE_PUBLISHER
     )
     marketing_enabled = configuration_helpers.get_value_for_org(
         course_block.location.org,

--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1347,7 +1347,7 @@ def create_xblock_info(  # pylint: disable=too-many-statements
                 "user_partitions": user_partitions,
                 "show_correctness": xblock.show_correctness,
                 "hide_from_toc": xblock.hide_from_toc,
-                "enable_hide_from_toc_ui": settings.FEATURES.get("ENABLE_HIDE_FROM_TOC_UI", False),
+                "enable_hide_from_toc_ui": settings.ENABLE_HIDE_FROM_TOC_UI,
                 "xblock_type": get_icon(xblock),
             }
         )

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -101,6 +101,17 @@ ENABLE_MAX_FAILED_LOGIN_ATTEMPTS = False
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/2334
 EDITABLE_SHORT_DESCRIPTION = True
 
+# .. toggle_name: settings.ENABLE_EXTENDED_COURSE_DETAILS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When enabled, exposes the extended course detail fields (course background image,
+#   video thumbnail image, and related text fields) on the Schedule & Details page in Open edX Studio.
+#   Can also be overridden per-org via site configuration.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2016-04-30
+# .. toggle_tickets: WL-398
+ENABLE_EXTENDED_COURSE_DETAILS = False
+
 # Hide any Personally Identifiable Information from application logs
 SQUELCH_PII_IN_LOGS = False
 

--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -431,7 +431,7 @@ def _footer_mobile_links(is_secure):
     platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
 
     mobile_links = []
-    if settings.FEATURES.get('ENABLE_FOOTER_MOBILE_APP_LINKS'):
+    if settings.ENABLE_FOOTER_MOBILE_APP_LINKS:
         mobile_links = [
             {
                 "name": "apple",

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -45,7 +45,7 @@ class TestFooter(CacheIsolationTestCase):
         assert resp['Content-Type'] == content_type
         self.assertContains(resp, content)
 
-    @mock.patch.dict(settings.FEATURES, {'ENABLE_FOOTER_MOBILE_APP_LINKS': True})
+    @override_settings(ENABLE_FOOTER_MOBILE_APP_LINKS=True)
     def test_footer_json(self):
         self._set_feature_flag(True)
         with with_comprehensive_theme_context(None):

--- a/lms/djangoapps/courseware/course_tools.py
+++ b/lms/djangoapps/courseware/course_tools.py
@@ -34,16 +34,13 @@ class FinancialAssistanceTool(CourseTool):
         Show this link for active courses where financial assistance is available, unless upgrade deadline has passed
         """
         now = datetime.datetime.now(pytz.UTC)
-        feature_flags = None
         try:
             course_overview = CourseOverview.objects.get(id=course_key)
         except CourseOverview.DoesNotExist:
             course_overview = None
 
-        # hide link if there's no ENABLE_FINANCIAL_ASSISTANCE_FORM setting (ex: Edge) or if it's False
-        subset_name = 'FEATURES'
-        feature_flags = getattr(settings, subset_name)
-        if feature_flags is None or not feature_flags.get('ENABLE_FINANCIAL_ASSISTANCE_FORM'):
+        # hide link if financial assistance is not enabled
+        if not settings.ENABLE_FINANCIAL_ASSISTANCE_FORM:
             return False
 
         # hide link for archived courses

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -892,7 +892,7 @@ def course_about(request, course_id):  # pylint: disable=too-many-statements
             'studio_url': studio_url,
             'registered': registered,
             'course_target': course_target,
-            'is_cosmetic_price_enabled': settings.FEATURES.get('ENABLE_COSMETIC_DISPLAY_PRICE'),
+            'is_cosmetic_price_enabled': settings.ENABLE_COSMETIC_DISPLAY_PRICE,
             'course_price': course_price,
             'ecommerce_checkout': ecommerce_checkout,
             'ecommerce_checkout_link': ecommerce_checkout_link,

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -759,7 +759,7 @@ def _section_send_email(course, access):
             'list_email_content', kwargs={'course_id': str(course_key)}
         ),
     }
-    if settings.FEATURES.get("ENABLE_NEW_BULK_EMAIL_EXPERIENCE", False) is not False:
+    if settings.ENABLE_NEW_BULK_EMAIL_EXPERIENCE is not False:
         section_data[
             "communications_mfe_url"
         ] = f"{settings.COMMUNICATIONS_MICROFRONTEND_URL}/courses/{str(course_key)}/bulk_email"

--- a/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
+++ b/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
@@ -3,9 +3,7 @@ Tests for the fake software secure response.
 """
 
 
-from unittest.mock import patch
-
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.util.testing import UrlResetMixin
@@ -21,7 +19,7 @@ class SoftwareSecureFakeViewTest(UrlResetMixin, TestCase):
 
     def setUp(self, **kwargs):
         enable_software_secure_fake = kwargs.get('enable_software_secure_fake', False)
-        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_SOFTWARE_SECURE_FAKE': enable_software_secure_fake}):
+        with override_settings(ENABLE_SOFTWARE_SECURE_FAKE=enable_software_secure_fake):
             super().setUp()
 
         self.user = UserFactory.create(username="test", password="test")

--- a/lms/djangoapps/verify_student/urls.py
+++ b/lms/djangoapps/verify_student/urls.py
@@ -121,7 +121,7 @@ urlpatterns = [
 ]
 
 # Fake response page for incourse reverification ( software secure )
-if settings.FEATURES.get('ENABLE_SOFTWARE_SECURE_FAKE'):
+if settings.ENABLE_SOFTWARE_SECURE_FAKE:
     from lms.djangoapps.verify_student.tests.fake_software_secure import SoftwareSecureFakeView
     urlpatterns += [
         path('software-secure-fake-response', SoftwareSecureFakeView.as_view()),

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -267,6 +267,16 @@ SKIP_EMAIL_VALIDATION = False
 # .. toggle_warning: The use case of this feature toggle is uncertain.
 ENABLE_COSMETIC_DISPLAY_PRICE = False
 
+# .. toggle_name: settings.ENABLE_FINANCIAL_ASSISTANCE_FORM
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When enabled, exposes the financial assistance application form and its URL route,
+#   and shows the "financial assistance" course tool link for eligible learners.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2015-12-04
+# .. toggle_tickets: ECOM-2824
+ENABLE_FINANCIAL_ASSISTANCE_FORM = False
+
 # Automatically approve student identity verification attempts
 # .. toggle_name: settings.AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING
 # .. toggle_implementation: DjangoSetting

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -947,7 +947,7 @@ if 'debug_toolbar' in settings.INSTALLED_APPS:
         path('__debug__/', include(debug_toolbar.urls)),
     ]
 
-if settings.FEATURES.get('ENABLE_FINANCIAL_ASSISTANCE_FORM'):
+if settings.ENABLE_FINANCIAL_ASSISTANCE_FORM:
     urlpatterns += [
         path(
             'financial-assistance/',

--- a/openedx/core/djangoapps/video_config/services.py
+++ b/openedx/core/djangoapps/video_config/services.py
@@ -175,7 +175,7 @@ class VideoConfigService:
         """
         translations = []
         if verify_assets is None:
-            verify_assets = not settings.FEATURES.get('FALLBACK_TO_ENGLISH_TRANSCRIPTS')
+            verify_assets = not settings.FALLBACK_TO_ENGLISH_TRANSCRIPTS
 
         sub, other_langs = transcripts["sub"], transcripts["transcripts"]
 

--- a/openedx/core/djangoapps/video_config/tests/test_services.py
+++ b/openedx/core/djangoapps/video_config/tests/test_services.py
@@ -3,9 +3,8 @@ Tests for VideoConfigService.
 """
 
 import unittest
-from unittest.mock import patch
 
-from django.conf import settings
+from django.test import override_settings
 from opaque_keys.edx.locator import CourseLocator
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
@@ -76,7 +75,7 @@ class VideoConfigServiceTestCase(unittest.TestCase):
         )
         assert translations_with_fallback == ['en']
 
-        with patch.dict(settings.FEATURES, FALLBACK_TO_ENGLISH_TRANSCRIPTS=False):
+        with override_settings(FALLBACK_TO_ENGLISH_TRANSCRIPTS=False):
             # Some organizations don't have English transcripts for all videos
             # This feature makes it configurable
             translations_no_fallback = video_config_service.available_translations(

--- a/xmodule/tests/test_video.py
+++ b/xmodule/tests/test_video.py
@@ -899,9 +899,7 @@ class VideoExportTestCase(VideoBlockTestBase):
 
 
 @ddt.ddt
-@patch.object(settings, 'FEATURES', create=True, new={
-    'FALLBACK_TO_ENGLISH_TRANSCRIPTS': False,
-})
+@patch.object(settings, 'FALLBACK_TO_ENGLISH_TRANSCRIPTS', False)
 class VideoBlockStudentViewDataTestCase(unittest.TestCase):
     """
     Make sure that VideoBlock returns the expected student_view_data.
@@ -1023,10 +1021,8 @@ class VideoBlockStudentViewDataTestCase(unittest.TestCase):
         }
     }
 })
-@patch.object(settings, 'FEATURES', create=True, new={
-    # The default value in {lms,cms}/envs/common.py and xmodule/tests/test_video.py should be consistent.
-    'FALLBACK_TO_ENGLISH_TRANSCRIPTS': True,
-})
+# The default value in openedx/envs/common.py and xmodule/tests/test_video.py should be consistent.
+@patch.object(settings, 'FALLBACK_TO_ENGLISH_TRANSCRIPTS', True)
 class VideoBlockIndexingTestCase(unittest.TestCase):
     """
     Make sure that VideoBlock can format data for indexing as expected.


### PR DESCRIPTION
## Summary

Migrates 10 more feature flags off `settings.FEATURES['X']` dict-style access onto flat settings (`settings.X`) with `@override_settings(X=Y)` in tests. Follows the pattern established in #38772.

Each commit migrates a single flag:

- EDITABLE_SHORT_DESCRIPTION
- ENABLE_COSMETIC_DISPLAY_PRICE
- ENABLE_EXTENDED_COURSE_DETAILS
- ENABLE_FINANCIAL_ASSISTANCE_FORM
- ENABLE_FOOTER_MOBILE_APP_LINKS
- ENABLE_HIDE_FROM_TOC_UI
- ENABLE_NEW_BULK_EMAIL_EXPERIENCE
- ENABLE_PUBLISHER
- ENABLE_SOFTWARE_SECURE_FAKE
- FALLBACK_TO_ENGLISH_TRANSCRIPTS

Two flags (ENABLE_EXTENDED_COURSE_DETAILS, ENABLE_FINANCIAL_ASSISTANCE_FORM) had no flat definition in any `envs/common.py`, so those commits add an annotated `DjangoSetting` definition matching the prior inline default before switching the readers.
