### PR TITLE
feat: accept library_content_key on the v1 Xblock create payload (FC-0118)

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/serializers/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/serializers/xblock.py
@@ -78,4 +78,9 @@ class XblockSerializer(StrictSerializer):
     target_index = serializers.IntegerField(required=False, allow_null=True)
     boilerplate = serializers.JSONField(required=False, allow_null=True)
     staged_content = serializers.CharField(required=False, allow_null=True)
+    # Present when a course block is created by importing a component from a v2
+    # library. Consumed by the create handler (``create_xblock_response`` reads
+    # ``library_content_key`` to set the block's upstream reference). Declared
+    # here so the strict serializer does not 400 the real Studio create payload.
+    library_content_key = serializers.CharField(required=False, allow_null=True)
     hide_from_toc = serializers.BooleanField(required=False, allow_null=True)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_xblock_viewset.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_xblock_viewset.py
@@ -59,6 +59,24 @@ class XblockViewSetRoutingTest(ModuleStoreTestCase, APITestCase):
         mock_fn.assert_called_once()
         assert mock_fn.call_args[0][0].method == "POST"
 
+    @patch(f"{_VIEW_MODULE}.create_xblock_response", return_value=_MOCK_RESPONSE)
+    def test_create_accepts_library_content_key(self, mock_fn):
+        """
+        Creating a course block by importing a component from a v2 library sends
+        ``library_content_key`` on the create body (consumed by
+        ``create_xblock_response`` to set the upstream reference). The strict
+        XblockSerializer must accept it so the request reaches the handler rather
+        than returning a 400.
+        """
+        data = {
+            "parent_locator": PARENT_LOCATOR,
+            "category": "library_content",
+            "library_content_key": "lct:edX:testlib:unit:u1",
+        }
+        response = self.client.post(_list_url(), data=data, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        mock_fn.assert_called_once()
+
     @patch(f"{_VIEW_MODULE}.retrieve_xblock_response", return_value=_MOCK_RESPONSE)
     def test_get_calls_retrieve_xblock_response(self, mock_fn):
         response = self.client.get(_detail_url())


### PR DESCRIPTION
## Description

The v1 `XblockViewSet` (`cms/djangoapps/contentstore/rest_api/v1/views/xblock.py`)
gates every write behind `@validate_request_with_serializer`, which validates the
request body against `XblockSerializer`. That serializer subclasses
`StrictSerializer`, so **any top-level field not declared on the serializer causes
a 400** before the handler runs.

Studio's real block-creation payload includes **`library_content_key`** when a
course block is created by importing a component from a v2 library. The create
handler already reads it:

```python
# cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
if upstream_ref := request.json.get("library_content_key"):
    # ... import the component from the v2 library
```

But because `library_content_key` was not declared on `XblockSerializer`, the
strict serializer rejects that payload with a 400 before the handler is reached.
This makes the v1 create endpoint unusable for the (common) library-import path.

This PR declares `library_content_key` as an optional field on `XblockSerializer`
so the strict validation accepts the legitimate create payload.

## Why this matters now

This unblocks migrating `frontend-app-authoring`'s block-creation caller
(`createCourseXblock`) from the legacy `/xblock/` route to the standardized
`/api/contentstore/v1/xblock/` endpoint as part of the FC-0118 downstream-consumer
migration — see **openedx/frontend-app-authoring#3127** (item #1, Xblock). Without
this field, migrating "add/import block" to v1 would break block creation.

## Changes

- `cms/djangoapps/contentstore/rest_api/v0/serializers/xblock.py` — declare
  `library_content_key = serializers.CharField(required=False, allow_null=True)`.
- `cms/djangoapps/contentstore/rest_api/v1/views/tests/test_xblock_viewset.py` —
  regression test asserting a create body carrying `library_content_key` reaches
  `create_xblock_response` (200) instead of being rejected (400).

## Testing

- Added `XblockViewSetRoutingTest.test_create_accepts_library_content_key`.
- Run: `pytest cms/djangoapps/contentstore/rest_api/v1/views/tests/test_xblock_viewset.py`.

## Notes

- Base branch: **`feat/axim-api_improvements`** (the FC-0118 standardization
  feature branch where the v1 `XblockViewSet` lives; not yet on `master`).
- The field is optional and additive — it does not change any existing behaviour;
  it only stops the strict serializer from rejecting a field the create handler
  already consumes.
- Two other fields the legacy caller sends (`type`, `courseKey`) are **not** added
  here because they are redundant/ignored by the handler; the frontend migration
  PR drops them instead of sending dead data.
