### PR TITLE
refactor: migrate 10 more flags off FEATURES-as-dict (batch 10)

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1890,7 +1890,7 @@ def _get_course_index_context(request, course_key, course_block):
     frontend_app_publisher_url = configuration_helpers.get_value_for_org(
         course_block.location.org,
         'FRONTEND_APP_PUBLISHER_URL',
-        settings.FEATURES.get('FRONTEND_APP_PUBLISHER_URL', False)
+        settings.FRONTEND_APP_PUBLISHER_URL
     )
     # gather any errors in the currently stored proctoring settings.
     advanced_dict = CourseMetadata.fetch(course_block)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -320,6 +320,13 @@ FRONTEND_LOGIN_URL = LOGIN_URL
 FRONTEND_LOGOUT_URL = '/logout/'
 FRONTEND_REGISTER_URL = Derived(lambda settings: settings.LMS_ROOT_URL + '/register')
 
+# .. setting_name: FRONTEND_APP_PUBLISHER_URL
+# .. setting_default: None
+# .. setting_description: Base URL of the publisher frontend app. When set (globally here or per-org via
+#   site configuration), the course "settings" page in Studio links out to the publisher app. Left unset
+#   (None) by default, in which case no publisher link is shown.
+FRONTEND_APP_PUBLISHER_URL = None
+
 ENTERPRISE_API_URL = Derived(lambda settings: settings.LMS_INTERNAL_ROOT_URL + '/enterprise/api/v1/')
 ENTERPRISE_CONSENT_API_URL = Derived(lambda settings: settings.LMS_INTERNAL_ROOT_URL + '/consent/api/v1/')
 

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -43,13 +43,13 @@ CDL_METHOD_NAME = 'openedx.features.course_duration_limits.models.CourseDuration
 
 @ddt.ddt
 @skip_unless_lms
+@override_settings(MODE_CREATION_FOR_TESTING=True)
 class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTestCase, CourseCatalogServiceMockMixin):
     """
     Course Mode View tests
     """
     URLCONF_MODULES = ['common.djangoapps.course_modes.urls']
 
-    @patch.dict(settings.FEATURES, {'MODE_CREATION_FOR_TESTING': True})
     def setUp(self):
         super().setUp()
         now = datetime.now(ZoneInfo("UTC"))

--- a/common/djangoapps/course_modes/urls.py
+++ b/common/djangoapps/course_modes/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
 ]
 
 # Enable verified mode creation
-if settings.FEATURES.get('MODE_CREATION_FOR_TESTING'):
+if getattr(settings, 'MODE_CREATION_FOR_TESTING', False):
     urlpatterns.append(
         re_path(fr'^create_mode/{settings.COURSE_ID_PATTERN}/$',
                 views.create_mode,

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -381,7 +381,7 @@ class ChooseModeView(View):
 def create_mode(request, course_id):
     """Add a mode to the course corresponding to the given course ID.
 
-    Only available when settings.FEATURES['MODE_CREATION_FOR_TESTING'] is True.
+    Only available when settings.MODE_CREATION_FOR_TESTING is True.
 
     Attempts to use the following querystring parameters from the request:
         `mode_slug` (str): The mode to add, either 'honor', 'verified', or 'professional'

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -316,7 +316,7 @@ def get_next_url_for_login_page(request, include_host=False):
     # Append a tpa_hint query parameter, if one is configured
     tpa_hint = configuration_helpers.get_value(
         "THIRD_PARTY_AUTH_HINT",
-        settings.FEATURES.get("THIRD_PARTY_AUTH_HINT", '')
+        settings.THIRD_PARTY_AUTH_HINT
     )
     if tpa_hint:
         # Don't add tpa_hint if we're already in the TPA pipeline (prevent infinite loop),

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -126,7 +126,7 @@ class TestLoginHelper(TestCase):
             next_page = get_next_url_for_login_page(req)
             assert next_page == expected_url
 
-        with override_settings(FEATURES=dict(settings.FEATURES, THIRD_PARTY_AUTH_HINT=tpa_hint)):
+        with override_settings(THIRD_PARTY_AUTH_HINT=tpa_hint):
             validate_login()
 
         with with_site_configuration_context(configuration=dict(THIRD_PARTY_AUTH_HINT=tpa_hint)):

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -451,5 +451,4 @@ def _id_verification_enforced_and_missing(user):
     """
     Return true if IDV is required for this course and the user does not have it
     """
-    return settings.FEATURES.get(
-        'ENABLE_CERTIFICATES_IDV_REQUIREMENT') and not IDVerificationService.user_is_verified(user)
+    return settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT and not IDVerificationService.user_is_verified(user)

--- a/lms/djangoapps/certificates/management/commands/tests/test_regenerate_noidv_cert.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_regenerate_noidv_cert.py
@@ -5,8 +5,8 @@ Tests for the cert_generation command
 from unittest import mock
 
 import pytest
-from django.conf import settings
 from django.core.management import CommandError, call_command
+from django.test import override_settings
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
@@ -25,7 +25,7 @@ WEB_CERTS_METHOD = 'lms.djangoapps.certificates.generation_handler.has_html_cert
 
 # base setup is unverified users, Enable certificates IDV requirements turned off,
 # and normal passing grade certificates for convenience
-@mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=False)
+@override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=False)
 @mock.patch(ID_VERIFIED_METHOD, mock.Mock(return_value=False))
 @mock.patch(PASSING_GRADE_METHOD, mock.Mock(return_value=True))
 @mock.patch(WEB_CERTS_METHOD, mock.Mock(return_value=True))

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 import ddt
 import pytz
 from config_models.models import cache
-from django.conf import settings
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -553,7 +552,7 @@ class GenerateUserCertificatesTest(ModuleStoreTestCase):
 
         with mock.patch(PASSING_GRADE_METHOD, return_value=True):
             with mock.patch(ID_VERIFIED_METHOD, return_value=False):
-                with mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
+                with override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
                     generate_certificate_task(self.user, self.course_run_key)
 
                     cert = get_certificate_for_user_id(self.user.id, self.course_run_key)

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -5,7 +5,6 @@ import logging
 from unittest import mock
 
 import ddt
-from django.conf import settings
 from django.test import override_settings
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -209,7 +208,7 @@ class AllowlistTests(ModuleStoreTestCase):
         Test handling when the user's id is not verified
         """
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
-                mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
+                override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
             self.assertNotEqual(  # noqa: PT009
                 enable_idv_requirement,
                 _can_generate_allowlist_certificate(self.user, self.course_run_key, self.enrollment_mode))
@@ -360,7 +359,7 @@ class AllowlistTests(ModuleStoreTestCase):
             assert not _can_generate_allowlist_certificate(self.user, course_run_key, enrollment_mode)
 
 
-@mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=False)
+@override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=False)
 @mock.patch(ID_VERIFIED_METHOD, mock.Mock(return_value=True))
 @mock.patch(CCX_COURSE_METHOD, mock.Mock(return_value=False))
 @mock.patch(PASSING_GRADE_METHOD, mock.Mock(return_value=True))
@@ -537,7 +536,7 @@ class CertificateTests(ModuleStoreTestCase):
         )
 
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
-                mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
+                override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
             self.assertNotEqual(  # noqa: PT009
                 enable_idv_requirement,
                 _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
@@ -559,7 +558,7 @@ class CertificateTests(ModuleStoreTestCase):
         )
 
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
-                mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
+                override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement):
             self.assertNotEqual(  # noqa: PT009
                 enable_idv_requirement,
                 _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
@@ -587,7 +586,7 @@ class CertificateTests(ModuleStoreTestCase):
         )
 
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
-                mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement), \
+                override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement), \
                 mock.patch(PASSING_GRADE_METHOD, return_value=False):
             assert not _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
             if enable_idv_requirement:
@@ -617,7 +616,7 @@ class CertificateTests(ModuleStoreTestCase):
         CertificateAllowlistFactory(course_id=self.course_run_key, user=u)
 
         with mock.patch(ID_VERIFIED_METHOD, return_value=False), \
-                mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement), \
+                override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_idv_requirement), \
                 mock.patch(PASSING_GRADE_METHOD, return_value=False):
             assert not _can_generate_regular_certificate(u, self.course_run_key, self.enrollment_mode, self.grade)
             if enable_idv_requirement:

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -1676,7 +1676,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         """
         Test that for a verified cert, the correct language is used when the integrity signature feature is enabled.
         """
-        with patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_cert_idv_requirement):
+        with override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_cert_idv_requirement):
             self._add_course_certificates(count=1, signatory_count=2, is_active=True)
             self._create_custom_template_with_verified_description()
             self.cert.mode = 'verified'

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -81,7 +81,7 @@ def get_certificate_description(mode, certificate_type, platform_name, course_ke
                                          "{platform_name} and has completed all of the required tasks for this course "
                                          "under its guidelines. ").format(cert_type=certificate_type,
                                                                           platform_name=platform_name)
-        if settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT'):
+        if settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT:
             certificate_type_description += _("A {cert_type} certificate also indicates that the "
                                               "identity of the learner has been checked and "
                                               "is valid.").format(cert_type=certificate_type)
@@ -249,7 +249,7 @@ def _update_course_context(request, context, course, platform_name):
     context['accomplishment_copy_course_name'] = accomplishment_copy_course_name
     course_number = course.display_coursenumber if course.display_coursenumber else course.number
     context['course_number'] = course_number
-    context['idv_enabled_for_certificates'] = settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT')
+    context['idv_enabled_for_certificates'] = settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT
     if context['organization_long_name']:
         # Translators:  This text represents the description of course
         context['accomplishment_copy_course_description'] = _('a course of study offered by {partner_short_name}, '

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -810,9 +810,7 @@ class SidebarBlocksTestViews(BaseCourseHomeTests):
         self.create_completion(problem, int(problem_complete))
         self.create_completion(library, int(library_complete))
 
-        with override_settings(
-            FEATURES={**settings.FEATURES, 'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': library_complete_on_view}
-        ):
+        with override_settings(MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW=library_complete_on_view):
             response = self.client.get(reverse('course-home:course-navigation', args=[self.course.id]))
 
         sequence_data = response.data['blocks'][str(self.sequential.location)]

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -225,7 +225,7 @@ class BaseStudentModuleHistory(models.Model):
 
         # If we turn off reading from multiple history tables, then we don't want to read from
         # StudentModuleHistory anymore, we believe that all history is in the Extended table.
-        if settings.FEATURES.get('ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES'):
+        if settings.ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES:
             # we want to save later SQL queries on the model which allows us to prefetch
             history_entries += StudentModuleHistory.objects.prefetch_related('student_module').filter(
                 student_module__in=student_modules

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1296,7 +1296,7 @@ class ProgressPageTests(ProgressPageBaseTests):
             ), check_mongo_calls(2):
                 self._get_progress_page()
 
-    @patch.dict(settings.FEATURES, {'ENABLE_CERTIFICATES_IDV_REQUIREMENT': True})
+    @override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=True)
     @ddt.data(
         *itertools.product(
             (
@@ -1581,7 +1581,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         """
         certs_api.set_certificate_generation_config(enabled=True)
         certs_api.set_cert_generation_enabled(self.course.id, True)
-        with patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_cert_idv_requirement):
+        with override_settings(ENABLE_CERTIFICATES_IDV_REQUIREMENT=enable_cert_idv_requirement):
             with patch(
                 'lms.djangoapps.certificates.api.certificate_downloadable_status',
                 return_value=self.mock_certificate_downloadable_status()

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1091,7 +1091,7 @@ def _downloadable_certificate_message(course, cert_downloadable_status):  # pyli
 
 
 def _missing_required_verification(student, enrollment_mode):
-    return settings.FEATURES.get('ENABLE_CERTIFICATES_IDV_REQUIREMENT') and (
+    return settings.ENABLE_CERTIFICATES_IDV_REQUIREMENT and (
         enrollment_mode in CourseMode.VERIFIED_MODES and not IDVerificationService.user_is_verified(student)
     )
 

--- a/lms/djangoapps/coursewarehistoryextended/tests.py
+++ b/lms/djangoapps/coursewarehistoryextended/tests.py
@@ -8,7 +8,6 @@ backend tables.
 
 import json
 from unittest import skipUnless
-from unittest.mock import patch
 
 from django.conf import settings
 from django.db import connections
@@ -43,8 +42,7 @@ class TestStudentModuleHistoryBackends(TestCase):
                                         max_grade=csm.max_grade)
             csmh.save()
 
-    @override_settings(ENABLE_CSMH_EXTENDED=True)
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": True})
+    @override_settings(ENABLE_CSMH_EXTENDED=True, ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES=True)
     def test_get_history_true_true(self):
         student_module = StudentModule.objects.all()
         history = BaseStudentModuleHistory.get_history(student_module)
@@ -56,8 +54,7 @@ class TestStudentModuleHistoryBackends(TestCase):
         assert {'type': 'csmh', 'order': 2} == json.loads(history[4].state)
         assert {'type': 'csmh', 'order': 1} == json.loads(history[5].state)
 
-    @override_settings(ENABLE_CSMH_EXTENDED=True)
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": False})
+    @override_settings(ENABLE_CSMH_EXTENDED=True, ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES=False)
     def test_get_history_true_false(self):
         student_module = StudentModule.objects.all()
         history = BaseStudentModuleHistory.get_history(student_module)
@@ -66,8 +63,7 @@ class TestStudentModuleHistoryBackends(TestCase):
         assert {'type': 'csmhe', 'order': 2} == json.loads(history[1].state)
         assert {'type': 'csmhe', 'order': 1} == json.loads(history[2].state)
 
-    @override_settings(ENABLE_CSMH_EXTENDED=False)
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": True})
+    @override_settings(ENABLE_CSMH_EXTENDED=False, ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES=True)
     def test_get_history_false_true(self):
         student_module = StudentModule.objects.all()
         history = BaseStudentModuleHistory.get_history(student_module)
@@ -76,8 +72,7 @@ class TestStudentModuleHistoryBackends(TestCase):
         assert {'type': 'csmh', 'order': 2} == json.loads(history[1].state)
         assert {'type': 'csmh', 'order': 1} == json.loads(history[2].state)
 
-    @override_settings(ENABLE_CSMH_EXTENDED=False)
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": False})
+    @override_settings(ENABLE_CSMH_EXTENDED=False, ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES=False)
     def test_get_history_false_false(self):
         student_module = StudentModule.objects.all()
         history = BaseStudentModuleHistory.get_history(student_module)

--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -104,7 +104,7 @@ class SubsectionGradeFactory:
             )
             self._update_saved_subsection_grade(subsection.location, grade_model)
 
-            if settings.FEATURES.get('ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL'):
+            if settings.ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL:
                 COURSE_ASSESSMENT_GRADE_CHANGED.send(
                     sender=self,
                     course_id=self.course_data.course_key,

--- a/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
@@ -6,7 +6,7 @@ Tests for the SubsectionGradeFactory class.
 from unittest.mock import patch
 
 import ddt
-from django.conf import settings
+from django.test import override_settings
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
@@ -43,7 +43,7 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
         assert isinstance(grade, ZeroSubsectionGrade)
         self.assert_grade(grade, 0.0, 1.0)
 
-    @patch.dict(settings.FEATURES, {'ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL': True})
+    @override_settings(ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL=True)
     def test_update(self):
         """
         Assuming the underlying score reporting methods work,

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -909,7 +909,7 @@ class ProblemResponses:
         ])
 
         student_data = []
-        max_count = settings.FEATURES.get('MAX_PROBLEM_RESPONSES_COUNT')
+        max_count = settings.MAX_PROBLEM_RESPONSES_COUNT
 
         store = modulestore()
         user_state_client = DjangoXBlockUserStateClient()

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -518,7 +518,7 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         finally:
             ProblemBlock.generate_report_data = generate_report_data
 
-    @patch.dict('django.conf.settings.FEATURES', {'MAX_PROBLEM_RESPONSES_COUNT': 4})
+    @override_settings(MAX_PROBLEM_RESPONSES_COUNT=4)
     def test_build_student_data_limit(self):
         """
         Ensure that the _build_student_data method respects the global setting for

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1028,7 +1028,7 @@ urlpatterns += [
 ]
 
 # Bulk User Retirement API urls
-if settings.FEATURES.get('ENABLE_BULK_USER_RETIREMENT'):
+if settings.ENABLE_BULK_USER_RETIREMENT:
     urlpatterns += [
         path('', include('lms.djangoapps.bulk_user_retirement.urls')),
     ]

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -417,14 +417,14 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
             target_status_code=302
         )
 
-    @override_settings(FEATURES=dict(settings.FEATURES, THIRD_PARTY_AUTH_HINT='oa2-google-oauth2'))
+    @override_settings(THIRD_PARTY_AUTH_HINT='oa2-google-oauth2')
     @ddt.data(
         'signin_user',
         'register_user',
     )
     def test_settings_tpa_hinted_login(self, url_name):
         """
-        Ensure that settings.FEATURES['THIRD_PARTY_AUTH_HINT'] can set third_party_auth_hint.
+        Ensure that settings.THIRD_PARTY_AUTH_HINT can set third_party_auth_hint.
         """
         params = [("next", "/courses/something/")]
         response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
@@ -442,7 +442,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
         assert response.content.decode('utf-8') not in tpa_hint
 
-    @override_settings(FEATURES=dict(settings.FEATURES, THIRD_PARTY_AUTH_HINT='oa2-google-oauth2'))
+    @override_settings(THIRD_PARTY_AUTH_HINT='oa2-google-oauth2')
     @ddt.data(
         ('signin_user', 'login'),
         ('register_user', 'register'),

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1167,6 +1167,12 @@ ENABLE_PREREQUISITE_COURSES = False
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/7315
 LICENSING = False
 
+# .. setting_name: THIRD_PARTY_AUTH_HINT
+# .. setting_default: ''
+# .. setting_description: Default third-party auth provider hint (tpa_hint) to append to login/registration
+#   redirect URLs site-wide. Usually left empty and overridden per-site via site configuration.
+THIRD_PARTY_AUTH_HINT = ''
+
 # .. toggle_name: CERTIFICATES_HTML_VIEW
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False

--- a/openedx/tests/completion_integration/test_services.py
+++ b/openedx/tests/completion_integration/test_services.py
@@ -7,7 +7,6 @@ import ddt
 from completion.models import BlockCompletion
 from completion.services import CompletionService
 from completion.test_utils import CompletionWaffleTestMixin
-from django.conf import settings
 from django.test import override_settings
 from opaque_keys.edx.keys import CourseKey
 
@@ -180,7 +179,7 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
         assert self.completion_service.can_mark_block_complete_on_view(self.html) is True
         assert self.completion_service.can_mark_block_complete_on_view(self.problem) is False
 
-    @override_settings(FEATURES={**settings.FEATURES, 'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': True})
+    @override_settings(MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW=True)
     def test_can_mark_library_content_complete_on_view(self):
         library = LibraryFactory.create(modulestore=self.store)
         lib_vertical = BlockFactory.create(parent=self.sequence, category='vertical', publish_item=False)

--- a/xmodule/item_bank_block.py
+++ b/xmodule/item_bank_block.py
@@ -87,7 +87,7 @@ class ItemBankMixin(
 
         This is a property, so it can be dynamically overridden in tests, as it is not evaluated at runtime.
         """
-        if settings.FEATURES.get('MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW', False):
+        if settings.MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW:
             return XBlockCompletionMode.COMPLETABLE
 
         return XBlockCompletionMode.AGGREGATOR

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -44,7 +44,7 @@ class VerticalFields:
     discussion_enabled = Boolean(
         display_name=_("Enable in-context discussions for the Unit"),
         help=_("Add discussion for the Unit."),
-        default=settings.FEATURES.get('IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT', True),
+        default=getattr(settings, 'IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT', True),
         scope=Scope.settings,
     )
 


### PR DESCRIPTION
## Summary

Migrates 10 more feature flags off `settings.FEATURES['X']` dict-style access onto flat settings (`settings.X`) with `@override_settings(X=Y)` in tests. Follows the pattern established in #38772.

Each commit migrates a single flag:

- ENABLE_BULK_USER_RETIREMENT
- ENABLE_CERTIFICATES_IDV_REQUIREMENT
- ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL
- ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES
- FRONTEND_APP_PUBLISHER_URL
- IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT
- MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW
- MAX_PROBLEM_RESPONSES_COUNT
- MODE_CREATION_FOR_TESTING
- THIRD_PARTY_AUTH_HINT

Notes on a few flags:

- `FRONTEND_APP_PUBLISHER_URL` and `THIRD_PARTY_AUTH_HINT` had no flat definition in any `envs/common.py`, so those commits add an annotated definition (matching the prior inline default) before switching the readers.
- `IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT` and `MODE_CREATION_FOR_TESTING` are only defined in one process's settings but are read from shared code, so those readers use `getattr(settings, 'X', default)`.
