### PR TITLE
refactor: migrate 6 more flags off FEATURES-as-dict (batch 11)

### DIFF
--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -1004,7 +1004,7 @@ class LoginFailures(models.Model):
         """
         Returns whether the feature flag around this functionality has been set
         """
-        return settings.FEATURES['ENABLE_MAX_FAILED_LOGIN_ATTEMPTS']
+        return settings.ENABLE_MAX_FAILED_LOGIN_ATTEMPTS
 
     @classmethod
     def is_user_locked_out(cls, user):

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -1313,7 +1313,7 @@ def log_successful_login(sender, request, user, **kwargs):  # pylint: disable=un
             'event_type': "login",
         }
     )
-    if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
+    if settings.SQUELCH_PII_IN_LOGS:
         AUDIT_LOG.info(f"Login success - user.id: {user.id}")
     else:
         AUDIT_LOG.info(f"Login success - {user.username} ({user.email})")
@@ -1330,7 +1330,7 @@ def log_successful_logout(sender, request, user, **kwargs):  # pylint: disable=u
                 'event_type': "logout",
             }
         )
-        if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
+        if settings.SQUELCH_PII_IN_LOGS:
             AUDIT_LOG.info(f'Logout - user.id: {request.user.id}')  # pylint: disable=logging-format-interpolation
         else:
             AUDIT_LOG.info(f'Logout - {request.user}')  # pylint: disable=logging-format-interpolation

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -353,7 +353,7 @@ class LoginFailuresAdminTest(TestCase):
         assert str(LoginFailures.objects.get(user=self.user)) == f'§: 10 - {self.user_lockout_until.isoformat()}'
         assert str(LoginFailures.objects.get(user=self.user2)) == 'Zażółć gęślą jaźń: 2 - -'
 
-    @override_settings(FEATURES={'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': True})
+    @override_settings(ENABLE_MAX_FAILED_LOGIN_ATTEMPTS=True)
     def test_feature_enabled(self):
         url = reverse('admin:student_loginfailures_changelist')
         response = self.client.get(url)
@@ -372,7 +372,7 @@ class LoginFailuresAdminTest(TestCase):
         response = self.client.post(url)
         assert response.status_code == 403
 
-    @override_settings(FEATURES={'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': True})
+    @override_settings(ENABLE_MAX_FAILED_LOGIN_ATTEMPTS=True)
     def test_unlock_student_accounts(self):
         """Test batch unlock student accounts."""
         url = reverse('admin:student_loginfailures_changelist')
@@ -387,7 +387,7 @@ class LoginFailuresAdminTest(TestCase):
         count = LoginFailures.objects.count()
         assert count == 0
 
-    @override_settings(FEATURES={'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': True})
+    @override_settings(ENABLE_MAX_FAILED_LOGIN_ATTEMPTS=True)
     def test_unlock_account(self):
         """Test unlock single student account."""
         url = reverse('admin:student_loginfailures_change', args=(1, ))

--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -86,7 +86,7 @@ def _filter_by_search(course_queryset, search_term, mobile_search=False):
     """
     Filters a course queryset by the specified search term.
     """
-    if not settings.FEATURES['ENABLE_COURSEWARE_SEARCH'] or not search_term:
+    if not settings.ENABLE_COURSEWARE_SEARCH or not search_term:
         return course_queryset
 
     # Return all the results, 10K is the maximum allowed value for ElasticSearch.

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2696,8 +2696,7 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
         },
     )
     @ddt.unpack
-    @override_settings(DISABLE_START_DATES=False)
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_ENTERPRISE_INTEGRATION': True})
+    @override_settings(DISABLE_START_DATES=False, ENABLE_ENTERPRISE_INTEGRATION=True)
     def test_is_course_open_for_learner(
         self,
         start_date_modifier,

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_send_program_course_nudge_email.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_send_program_course_nudge_email.py
@@ -108,7 +108,7 @@ class TestSendProgramCourseNudgeEmailCommand(SharedModuleStoreTestCase):
     @patch('common.djangoapps.student.models.course_enrollment.segment.track')
     @patch('lms.djangoapps.program_enrollments.management.commands.send_program_course_nudge_email.get_programs')
     @patch('lms.djangoapps.certificates.api.certificates_viewable_for_course', return_value=True)
-    @override_settings(FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
     def test_email_send(self, add_no_commit, __, get_programs_mock, mock_track):  # noqa: PT019
         """
         Test Segment fired as expected.
@@ -145,7 +145,7 @@ class TestSendProgramCourseNudgeEmailCommand(SharedModuleStoreTestCase):
     )
     @patch('common.djangoapps.student.models.course_enrollment.segment.track')
     @patch('lms.djangoapps.program_enrollments.management.commands.send_program_course_nudge_email.get_programs')
-    @override_settings(FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
     def test_email_no_course_recommendation(self, add_no_commit, get_programs_mock, mock_track):
         """
         Test Segment fired as expected.

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -400,7 +400,7 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
         assert len(data) == 1
         assert data[0]['source_system'] == 'commercetools'
 
-    @override_settings(FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
     @enterprise_is_enabled()
     def test_get_enrollments_enterprise_enabled(self):
         url = reverse(

--- a/openedx/core/djangoapps/programs/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/programs/rest_api/v1/tests/test_views.py
@@ -186,7 +186,7 @@ class TestProgramsEnterpriseView(SharedModuleStoreTestCase, ProgramCacheMixin):
         )
 
     @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
-    @override_settings(FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
     @enterprise_is_enabled()
     def test_program_list_enterprise(self):
         """
@@ -217,7 +217,7 @@ class TestProgramsEnterpriseView(SharedModuleStoreTestCase, ProgramCacheMixin):
         }
 
     @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
-    @override_settings(FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
     @enterprise_is_enabled()
     def test_program_empty_list_if_no_enterprise_enrollments(self):
         """

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -239,7 +239,7 @@ def login_and_registration_form(request, initial_mode="login"):
         'combined_login_and_register': True,
         'disable_footer': not configuration_helpers.get_value(
             'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER',
-            settings.FEATURES['ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER']
+            getattr(settings, 'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER', False)
         ),
     }
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -686,7 +686,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
             response_content = json.loads(response.content.decode('utf-8'))
         assert response_content.get('success')
 
-    @patch.dict(settings.FEATURES, {"ENABLE_MAX_FAILED_LOGIN_ATTEMPTS": True})
+    @override_settings(ENABLE_MAX_FAILED_LOGIN_ATTEMPTS=True)
     @override_settings(PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG={'ENFORCE_COMPLIANCE_ON_LOGIN': True})
     def test_check_password_policy_compliance_exception(self):
         """

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -203,7 +203,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
         self._assert_response(response, success=True)
         self._assert_redirect_url(response, expected_redirect)
 
-    @patch.dict("django.conf.settings.FEATURES", {'SQUELCH_PII_IN_LOGS': True})
+    @override_settings(SQUELCH_PII_IN_LOGS=True)
     def test_login_success_no_pii(self):
         response, mock_audit_log = self._login_response(
             self.user_email, self.password, patched_audit_log='common.djangoapps.student.models.user.AUDIT_LOG'
@@ -235,7 +235,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
         )
         self._assert_audit_log(mock_audit_log, 'warning', ['Login failed', 'Unknown user email', email_hash])
 
-    @patch.dict("django.conf.settings.FEATURES", {'SQUELCH_PII_IN_LOGS': True})
+    @override_settings(SQUELCH_PII_IN_LOGS=True)
     def test_login_fail_no_user_exists_no_pii(self):
         nonexistent_email = 'not_a_user@edx.org'
         response, mock_audit_log = self._login_response(
@@ -255,7 +255,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
         self._assert_audit_log(mock_audit_log, 'warning',
                                ['Login failed', 'password for', str(self.user.id), 'invalid'])
 
-    @patch.dict("django.conf.settings.FEATURES", {'SQUELCH_PII_IN_LOGS': True})
+    @override_settings(SQUELCH_PII_IN_LOGS=True)
     def test_login_fail_wrong_password_no_pii(self):
         response, mock_audit_log = self._login_response(self.user_email, 'wrong_password')
         self._assert_response(response, success=False, value=self.LOGIN_FAILED_WARNING)
@@ -425,7 +425,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
         }
         assert_dict_contains_subset(self, expected, response.context_data)
 
-    @patch.dict("django.conf.settings.FEATURES", {'SQUELCH_PII_IN_LOGS': True})
+    @override_settings(SQUELCH_PII_IN_LOGS=True)
     def test_logout_logging_no_pii(self):
         response, _ = self._login_response(self.user_email, self.password)
         self._assert_response(response, success=True)

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -694,7 +694,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         self.assertRaises(Http404, PasswordResetConfirmWrapper.as_view(), reset_request, uidb36=self.uidb36,  # noqa: PT027  # pylint: disable=line-too-long
                           token=self.token)
 
-    @override_settings(FEATURES={'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': True}, MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED=1)
+    @override_settings(ENABLE_MAX_FAILED_LOGIN_ATTEMPTS=True, MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED=1)
     def test_password_reset_with_login_failures_feature_enabled(self):
         """
         Tests that user's login failures lockout counter is reset upon successful password reset.
@@ -1013,7 +1013,7 @@ class ResetPasswordAPITests(EventTestMixin, CacheIsolationTestCase):
         response = self.client.post(path, request_param)
         assert response.status_code == 429
 
-    @override_settings(FEATURES={'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': True}, MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED=1)
+    @override_settings(ENABLE_MAX_FAILED_LOGIN_ATTEMPTS=True, MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED=1)
     def test_password_reset_request_with_login_failures_feature_enabled(self):
         """
         Tests that user's login failures lockout counter is reset upon successful password reset.

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -328,7 +328,7 @@ def enterprise_enabled():
     """
     Determines whether the Enterprise app is installed
     """
-    return django_apps.is_installed('enterprise') and settings.FEATURES.get('ENABLE_ENTERPRISE_INTEGRATION', False)
+    return django_apps.is_installed('enterprise') and getattr(settings, 'ENABLE_ENTERPRISE_INTEGRATION', False)
 
 
 def enterprise_is_enabled(otherwise=None):

--- a/openedx/features/enterprise_support/tests/__init__.py
+++ b/openedx/features/enterprise_support/tests/__init__.py
@@ -3,11 +3,6 @@ Things commonly needed in Enterprise tests.
 """
 
 
-from django.conf import settings
-
-FEATURES_WITH_ENTERPRISE_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_ENTERPRISE_ENABLED['ENABLE_ENTERPRISE_INTEGRATION'] = True
-
 FAKE_ENTERPRISE_CUSTOMER = {
     'active': True,
     'branding_configuration': None,

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -40,7 +40,6 @@ from openedx.features.enterprise_support.api import (
     get_enterprise_learner_data_from_db,
     get_enterprise_learner_portal_enabled_message,
 )
-from openedx.features.enterprise_support.tests import FEATURES_WITH_ENTERPRISE_ENABLED
 from openedx.features.enterprise_support.tests.factories import (
     EnterpriseCourseEnrollmentFactory,
     EnterpriseCustomerIdentityProviderFactory,
@@ -59,7 +58,7 @@ class MockEnrollment(mock.MagicMock):
 
 
 @ddt.ddt
-@override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
+@override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
 @skip_unless_lms
 class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
     """
@@ -579,7 +578,7 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
         else:
             assert notification_string == ''
 
-    @override_settings(FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=False))
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=False)
     def test_utils_with_enterprise_disabled(self):
         """
         Test that disabling the enterprise integration flag causes

--- a/openedx/features/enterprise_support/tests/test_context.py
+++ b/openedx/features/enterprise_support/tests/test_context.py
@@ -7,7 +7,6 @@ from django.test.utils import override_settings
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.features.enterprise_support.context import get_enterprise_event_context
-from openedx.features.enterprise_support.tests import FEATURES_WITH_ENTERPRISE_ENABLED
 from openedx.features.enterprise_support.tests.factories import (
     EnterpriseCourseEnrollmentFactory,
     EnterpriseCustomerUserFactory,
@@ -15,7 +14,7 @@ from openedx.features.enterprise_support.tests.factories import (
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
 
 
-@override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
+@override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
 @skip_unless_lms
 class TestEnterpriseContext(EnterpriseServiceMockMixin, CacheIsolationTestCase):
     """

--- a/openedx/features/enterprise_support/tests/test_logout.py
+++ b/openedx/features/enterprise_support/tests/test_logout.py
@@ -16,14 +16,13 @@ from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_un
 from openedx.features.enterprise_support.api import enterprise_enabled
 from openedx.features.enterprise_support.tests import (
     FAKE_ENTERPRISE_CUSTOMER,
-    FEATURES_WITH_ENTERPRISE_ENABLED,
     factories,
 )
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
 
 
 @ddt.ddt
-@override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
+@override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
 @skip_unless_lms
 class EnterpriseLogoutTests(EnterpriseServiceMockMixin, CacheIsolationTestCase, UrlResetMixin):
     """ Tests for the enterprise logout functionality. """

--- a/openedx/features/enterprise_support/tests/test_signals.py
+++ b/openedx/features/enterprise_support/tests/test_signals.py
@@ -22,7 +22,6 @@ from lms.djangoapps.certificates.signals import listen_for_passing_grade
 from openedx.core.djangoapps.commerce.utils import ECOMMERCE_DATE_FORMAT
 from openedx.core.djangoapps.credit.tests.test_api import TEST_ECOMMERCE_WORKER
 from openedx.core.djangoapps.signals.signals import COURSE_ASSESSMENT_GRADE_CHANGED, COURSE_GRADE_NOW_PASSED
-from openedx.features.enterprise_support.tests import FEATURES_WITH_ENTERPRISE_ENABLED
 from openedx.features.enterprise_support.tests.factories import (
     EnterpriseCourseEnrollmentFactory,
     EnterpriseCustomerFactory,
@@ -42,7 +41,7 @@ TEST_EMAIL = "test@edx.org"
 
 
 @ddt.ddt
-@override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
+@override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
 @override_settings(ECOMMERCE_SERVICE_WORKER_USERNAME=TEST_ECOMMERCE_WORKER)
 class EnterpriseSupportSignals(SharedModuleStoreTestCase):
     """

--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -21,7 +21,6 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from openedx.features.enterprise_support.tests import FEATURES_WITH_ENTERPRISE_ENABLED
 from openedx.features.enterprise_support.tests.factories import (
     EnterpriseCustomerBrandingConfigurationFactory,
     EnterpriseCustomerFactory,
@@ -59,7 +58,7 @@ TEST_PASSWORD = 'test'
 
 
 @ddt.ddt
-@override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
+@override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
 @skip_unless_lms
 class TestEnterpriseUtils(TestCase):
     """
@@ -594,7 +593,7 @@ class TestEnterpriseUtils(TestCase):
         assert not mock_user_social_auth.objects.select_related.called
 
 
-@override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
+@override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
 @skip_unless_lms
 class TestCourseAccessed(SharedModuleStoreTestCase, CompletionWaffleTestMixin):
     """

--- a/xmodule/html_block.py
+++ b/xmodule/html_block.py
@@ -116,7 +116,7 @@ class _BuiltinHtmlBlockMixin(  # pylint: disable=abstract-method
         """
         Return a JSON representation of the student_view of this XBlock.
         """
-        if getattr(settings, 'FEATURES', {}).get(self.ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA, False):
+        if getattr(settings, self.ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA, False):
             return {'enabled': True, 'html': self.get_html()}
         else:
             return {

--- a/xmodule/tests/test_html_block.py
+++ b/xmodule/tests/test_html_block.py
@@ -33,8 +33,7 @@ class _HtmlBlockCourseApiTestCaseBase(TestCase):
 
     @ddt.data(
         {},
-        dict(FEATURES={}),
-        dict(FEATURES=dict(ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA=False))
+        dict(ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA=False),
     )
     def test_disabled(self, settings):
         """
@@ -58,7 +57,7 @@ class _HtmlBlockCourseApiTestCaseBase(TestCase):
         '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">',  # Images allowed
         'short string ' * 100,  # May contain long strings
     )
-    @override_settings(FEATURES=dict(ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA=True))
+    @override_settings(ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA=True)
     def test_common_values(self, html):
         """
         Ensure that student_view_data will return HTML data when enabled,


### PR DESCRIPTION
## Summary

Migrates 6 more feature flags off `settings.FEATURES['X']` dict-style access onto flat settings (`settings.X`) with `@override_settings(X=Y)` in tests. Follows the pattern established in #38772.

This batch targets the **subscript readers** (`settings.FEATURES['X']`) plus one medium flag — several of these were invisible to the earlier `.get()`-only reference query.

Each `refactor:` commit migrates a single flag:

- SQUELCH_PII_IN_LOGS
- ENABLE_MAX_FAILED_LOGIN_ATTEMPTS
- ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER
- ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA
- ENABLE_COURSEWARE_SEARCH
- ENABLE_ENTERPRISE_INTEGRATION

Plus one `docs:` commit removing a stale `FEATURES['ORGANIZATIONS_APP']` reference from a docstring (that flag is a removed pre-Lilac flag with no reader or setting).

Notes on a few flags:

- `SQUELCH_PII_IN_LOGS` and `ENABLE_MAX_FAILED_LOGIN_ATTEMPTS` are already flat settings in both `lms/envs/common.py` and `cms/envs/common.py` (different per-process defaults); the readers just needed to stop going through the dict.
- `ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER` and `ENABLE_ENTERPRISE_INTEGRATION` are LMS-only settings read from shared code, so those readers use `getattr(settings, 'X', default)`.
- `ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA`: the reader moves to `getattr(settings, ...)`, but the user-facing `To enable, set FEATURES["..."]` message is intentionally left unchanged — the extracted `xblocks_contrib.HtmlBlock` (exercised by the same tests) still emits it, and flat `@override_settings` reaches that external reader through the FeaturesProxy bridge.
- `ENABLE_ENTERPRISE_INTEGRATION` removes the shared `FEATURES_WITH_ENTERPRISE_ENABLED` test helper in favor of `@override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)` at each call site.
