### PR TITLE
refactor: migrate DISABLE_START_DATES off FEATURES-as-dict

### DIFF
--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -192,8 +192,8 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
     EMAIL_SETTINGS_ELEMENT_ID = "#actions-item-email-settings-0"
     ENABLED_SIGNALS = ['course_published']
     MOCK_SETTINGS = {
+        'DISABLE_START_DATES': False,
         'FEATURES': {
-            'DISABLE_START_DATES': False,
             'DISABLE_SET_JWT_COOKIES_FOR_TESTS': True,
         },
         'SOCIAL_SHARING_SETTINGS': {

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -6,7 +6,6 @@ Tests for branding page
 import datetime
 from unittest.mock import Mock, patch
 
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponseRedirect
 from django.test.client import RequestFactory
@@ -25,11 +24,6 @@ from xmodule.modulestore.tests.django_utils import (
     ModuleStoreTestCase,  # pylint: disable=wrong-import-order
 )
 from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable=wrong-import-order
-
-FEATURES_WITH_STARTDATE = settings.FEATURES.copy()
-FEATURES_WITH_STARTDATE['DISABLE_START_DATES'] = False
-FEATURES_WO_STARTDATE = settings.FEATURES.copy()
-FEATURES_WO_STARTDATE['DISABLE_START_DATES'] = True
 
 
 def mock_render_to_response(*args, **kwargs):
@@ -67,7 +61,7 @@ class AnonymousIndexPageTest(ModuleStoreTestCase):
 
         return headers
 
-    @override_settings(FEATURES=FEATURES_WITH_STARTDATE)
+    @override_settings(DISABLE_START_DATES=False)
     def test_none_user_index_access_with_startdate_fails(self):
         """
         This is a regression test for a bug where the incoming user is
@@ -78,12 +72,12 @@ class AnonymousIndexPageTest(ModuleStoreTestCase):
         response = self.client.get(reverse('root'))
         assert response.status_code == 200
 
-    @override_settings(FEATURES=FEATURES_WITH_STARTDATE)
+    @override_settings(DISABLE_START_DATES=False)
     def test_anon_user_with_startdate_index(self):
         response = self.client.get('/')
         assert response.status_code == 200
 
-    @override_settings(FEATURES=FEATURES_WO_STARTDATE)
+    @override_settings(DISABLE_START_DATES=True)
     def test_anon_user_no_startdate_index(self):
         response = self.client.get('/')
         assert response.status_code == 200

--- a/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
@@ -4,9 +4,9 @@ Tests for StartDateTransformer.
 
 
 from datetime import timedelta
-from unittest.mock import patch
 
 import ddt
+from django.test.utils import override_settings
 from django.utils.timezone import now
 
 from common.djangoapps.student.tests.factories import BetaTesterFactory
@@ -63,7 +63,7 @@ class StartDateTransformerTestCase(BlockParentsMapTestCase):
     #  3   4   /   5
     #       \ /
     #        6
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     @ddt.data(
         (STUDENT, {}, {}, {}),
         (STUDENT, {0: StartDateType.default}, {}, {}),

--- a/lms/djangoapps/course_home_api/progress/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/progress/tests/test_views.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import dateutil
 import ddt
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.timezone import now
 from edx_toggles.toggles.testutils import override_waffle_flag
@@ -160,7 +161,7 @@ class ProgressTabTestViews(BaseCourseHomeTests):
         assert response.status_code == 200
         assert get_subsection_show_grades(response) is False
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_has_scheduled_content_data(self):
         CourseEnrollment.enroll(self.user, self.course.id)
         future = now() + timedelta(days=30)

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -77,7 +77,7 @@ def check_start_date(user, days_early_for_beta, start, course_key, display_error
     Returns:
         AccessResponse: Either ACCESS_GRANTED or StartDateError.
     """
-    start_dates_disabled = settings.FEATURES["DISABLE_START_DATES"]
+    start_dates_disabled = settings.DISABLE_START_DATES
     masquerading_as_student = is_masquerading_as_student(user, course_key)
 
     if start_dates_disabled and not masquerading_as_student:

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -5,7 +5,6 @@ Test the about xblock
 
 import datetime
 from unittest import mock
-from unittest.mock import patch
 
 import ddt
 import pytz
@@ -273,14 +272,14 @@ class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         # common/test/data/2014/about/overview.html
         self.xml_data = "about page 463139"
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_logged_in_xml(self):
         self.setup_user()
         url = reverse('about_course', args=[str(self.xml_course_id)])
         resp = self.client.get(url)
         self.assertContains(resp, self.xml_data)
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_anonymous_user_xml(self):
         url = reverse('about_course', args=[str(self.xml_course_id)])
         resp = self.client.get(url)

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -420,7 +420,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         (False, TOMORROW, access_response.StartDateError)
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test__has_access_to_block_staff_lock(self, visible_to_staff_only, start, expected_error_type=None):
         """
         Tests that "visible_to_staff_only" overrides start date.
@@ -450,7 +450,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         (YESTERDAY, None)
     )  # ddt throws an error if I don't put the None argument there
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test__has_access_to_block_with_start_date(self, start, expected_error_type):
         """
         Tests that block access follows start date rules.
@@ -479,7 +479,7 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         (True, True, TOMORROW, False),  # Masquerading, future start date - no access
     )
     @ddt.unpack
-    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_START_DATES": False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_enforce_masquerade_start_dates_flag(self, flag_active, is_masquerading, start, expected_access=True):
         """
         Test that the ENFORCE_MASQUERADE_START_DATES flag controls whether masquerading bypasses start date
@@ -862,7 +862,7 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
 
     @ddt.data(*(COURSE_TEST_DATA + LOAD_MOBILE_TEST_DATA + PREREQUISITES_TEST_DATA))
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_course_overview_access(self, user_attr_name, action, course_attr_name):
         """
         Check that a user's access to a course is equal to the user's access to
@@ -902,7 +902,7 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
         )
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_course_catalog_access_num_queries(self, user_attr_name, action, course_attr_name):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime.datetime(2018, 1, 1))
 

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -7,7 +7,6 @@ import pickle
 from datetime import datetime
 from importlib import import_module
 from operator import itemgetter  # pylint: disable=wrong-import-order
-from unittest.mock import patch
 
 import ddt
 import pytest
@@ -302,7 +301,7 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         'john',  # Non-unicode username
         'fôô@bar',  # Unicode username with @, which is what the ENABLE_UNICODE_USERNAME feature allows
     )
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_masquerade_as_specific_student(self, username):
         """
         Test masquerading as a specific user.
@@ -408,7 +407,7 @@ class TestGetMasqueradingGroupId(StaffMasqueradeTestCase):
         self.course.user_partitions.append(self.user_partition)
         modulestore().update_item(self.course, self.test_user.id)
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_get_masquerade_group(self):
         """
         Tests that a staff member can masquerade as being in a group in a user partition

--- a/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
@@ -1,7 +1,6 @@
 """Tests for self-paced course due date overrides."""
 
 import datetime
-from unittest.mock import patch
 
 import pytz
 from django.test.utils import override_settings
@@ -88,7 +87,7 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
         __, sp_section = self.setup_course(display_name="Self-Paced Course", self_paced=True)
         assert sp_section.due is None
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_course_access_to_beta_users(self):
         """
         Test that beta testers can access `self_paced` course prior to start date.
@@ -116,7 +115,7 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
         assert has_access(beta_tester, 'load', self_paced_course)
         assert has_access(beta_tester, 'load', self_paced_section, self_paced_course.id)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_instructor_paced_discussion_xblock_visibility(self):
         """
         Verify that discussion xblocks scheduled for release in the future are
@@ -129,7 +128,7 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
         xblocks = get_accessible_discussion_xblocks(course, self.non_staff_user)
         assert all((xblock.display_name == 'released') for xblock in xblocks)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_self_paced_discussion_xblock_visibility(self):
         """
         Regression test. Verify that discussion xblocks scheduled for release

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -322,14 +322,14 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.xml_data = "static 463139"
         self.xml_url = "8e4cce2b4aaf4ba28b1220804619e41f"
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_logged_in_xml(self):
         self.setup_user()
         url = reverse('static_tab', args=[str(self.xml_course_key), self.xml_url])
         resp = self.client.get(url)
         self.assertContains(resp, self.xml_data)
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_anonymous_user_xml(self):
         url = reverse('static_tab', args=[str(self.xml_course_key), self.xml_url])
         resp = self.client.get(url)

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -4,9 +4,9 @@ Check that view authentication works properly.
 
 
 import datetime
-from unittest.mock import patch
 
 import pytz
+from django.test.utils import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
 
@@ -387,7 +387,7 @@ class TestViewAuth(ModuleStoreTestCase, LoginEnrollmentTestCase):
         # Test the _check_staff_legacy method which includes instructor dashboard checks
         self._check_staff_legacy(self.course)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_dark_launch_enrolled_student(self):
         """
         Make sure that before course start, students can't access course
@@ -414,7 +414,7 @@ class TestViewAuth(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self._check_non_staff_light(self.test_course)
         self._check_non_staff_dark(self.test_course)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_dark_launch_instructor(self):
         """
         Make sure that before course start instructors can access the
@@ -437,7 +437,7 @@ class TestViewAuth(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self._check_non_staff_light(self.test_course)
         self._check_non_staff_dark(self.test_course)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_dark_launch_global_staff(self):
         """
         Make sure that before course start staff can access
@@ -459,7 +459,7 @@ class TestViewAuth(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self._check_staff(self.course)
         self._check_staff(self.test_course)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_enrollment_period(self):
         """
         Check that enrollment periods work.
@@ -495,7 +495,7 @@ class TestViewAuth(ModuleStoreTestCase, LoginEnrollmentTestCase):
         assert self.enroll(self.course)
 
     @override_waffle_flag(LEGACY_INSTRUCTOR_DASHBOARD, active=True)
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_dark_launch_instructor_legacy(self):
         """
         Make sure that before course start instructors can access the
@@ -518,7 +518,7 @@ class TestViewAuth(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self._check_non_staff_dark(self.test_course)
 
     @override_waffle_flag(LEGACY_INSTRUCTOR_DASHBOARD, active=True)
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_dark_launch_global_staff_legacy(self):
         """
         Make sure that before course start staff can access
@@ -558,7 +558,7 @@ class TestBetatesterAccess(ModuleStoreTestCase, CourseAccessTestMixin):
         self.normal_student = UserFactory()
         self.beta_tester = BetaTesterFactory(course_key=self.course.id)  # pylint: disable=no-member
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_course_beta_period(self):
         """
         Check that beta-test access works for courses.
@@ -567,7 +567,7 @@ class TestBetatesterAccess(ModuleStoreTestCase, CourseAccessTestMixin):
         self.assertCannotAccessCourse(self.normal_student, 'load', self.course)
         self.assertCanAccessCourse(self.beta_tester, 'load', self.course)
 
-    @patch.dict('lms.djangoapps.courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_content_beta_period(self):
         """
         Check that beta-test access works for content.

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2696,7 +2696,8 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
         },
     )
     @ddt.unpack
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False, 'ENABLE_ENTERPRISE_INTEGRATION': True})
+    @override_settings(DISABLE_START_DATES=False)
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_ENTERPRISE_INTEGRATION': True})
     def test_is_course_open_for_learner(
         self,
         start_date_modifier,

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -5,10 +5,10 @@ Common test utilities for courseware functionality
 
 from abc import ABCMeta, abstractmethod
 from datetime import datetime, timedelta
-from unittest.mock import patch
 from urllib.parse import urlencode
 
 import ddt
+from django.test.utils import override_settings
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
@@ -206,7 +206,7 @@ class RenderXBlockTestMixin(MasqueradeMixin, metaclass=ABCMeta):
         self.setup_user(admin=False, enroll=False, login=True)
         self.verify_response(expected_response_code=404)
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_fail_block_unreleased(self):
         self.setup_course()
         self.setup_user(admin=False, enroll=True, login=True)

--- a/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
@@ -4197,7 +4197,7 @@ class CourseTopicsV2Test(ModuleStoreTestCase):
             )
 
 
-@mock.patch.dict("django.conf.settings.FEATURES", {"DISABLE_START_DATES": False})
+@override_settings(DISABLE_START_DATES=False)
 @override_settings(ENABLE_DISCUSSION_SERVICE=True)
 class GetCourseTopicsTest(ForumMockUtilsMixin, UrlResetMixin, ModuleStoreTestCase):
     """Test for get_course_topics"""

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import ddt
 import pytest
+from django.test.utils import override_settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
 from freezegun import freeze_time
@@ -2222,7 +2223,7 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
 
         assert status.HTTP_403_FORBIDDEN == resp.status_code
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_get_override_for_unreleased_block(self):
         self.login_course_staff()
         unreleased_subsection = BlockFactory.create(

--- a/lms/djangoapps/grades/tests/test_course_data.py
+++ b/lms/djangoapps/grades/tests/test_course_data.py
@@ -4,6 +4,7 @@ Tests for CourseData utility class.
 from unittest.mock import patch
 
 import pytest
+from django.test.utils import override_settings
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.course_blocks.api import get_course_blocks
@@ -88,7 +89,7 @@ class CourseDataTest(ModuleStoreTestCase):
         with pytest.raises(ValueError):  # noqa: PT011
             _ = CourseData(self.user)
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_full_string(self):
         empty_structure = get_course_blocks(self.user, self.course.location)
         assert not empty_structure

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1922,7 +1922,7 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         )
         self.define_option_problem('Unreleased', parent=self.unreleased_section)
 
-    @patch.dict(settings.FEATURES, {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_grade_report(self):
         self.submit_student_answer(self.student.username, 'Problem1', ['Option 1'])
 

--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -13,10 +13,10 @@ Test utilities for mobile API tests:
 
 
 import datetime
-from unittest.mock import patch
 
 import ddt
 import pytz
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from opaque_keys.edx.keys import CourseKey
@@ -176,7 +176,7 @@ class MobileCourseAccessTestMixin(MobileAPIMilestonesMixin):
         response = self.api_response(expected_response_code=None, course_id=non_existent_course_id)
         self.verify_failure(response)  # allow subclasses to override verification
 
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_unreleased_course(self):
         # ensure the course always starts in the future
         self.course = CourseFactory.create(mobile_available=True, static_asset_path="needed_for_split")

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -11,7 +11,6 @@ import ddt
 import pytz
 from completion.models import BlockCompletion
 from completion.test_utils import CompletionWaffleTestMixin, submit_completions_for_testing
-from django.conf import settings
 from django.db import transaction
 from django.template import defaultfilters
 from django.test import RequestFactory, override_settings
@@ -167,10 +166,7 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
                    str(courses[((num_courses - course_index) - 1)].id)
 
     @ddt.data(API_V05, API_V1, API_V2)
-    @override_settings(ENABLE_PREREQUISITE_COURSES=True)
-    @patch.dict(settings.FEATURES, {
-        'DISABLE_START_DATES': False,
-    })
+    @override_settings(ENABLE_PREREQUISITE_COURSES=True, DISABLE_START_DATES=False)
     def test_courseware_access(self, api_version):
         self.login()
 
@@ -229,7 +225,7 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         ('default_start_date', None, None, "empty", API_V2),
     )
     @ddt.unpack
-    @patch.dict(settings.FEATURES, {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_start_type_and_display(self, start, advertised_start, expected_display, expected_type, api_version):
         """
         Tests that the correct start_type and start_display are returned in the

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -7,6 +7,7 @@ Test the partitions and partitions service
 from unittest.mock import patch
 
 import django.test
+from django.test.utils import override_settings
 
 from common.djangoapps.student.tests.factories import UserFactory
 from lms.djangoapps.courseware.tests.test_masquerade import StaffMasqueradeTestCase
@@ -364,7 +365,7 @@ class TestMasqueradedGroup(StaffMasqueradeTestCase):
         self._verify_masquerade_for_group(None)
 
     @skip_unless_lms
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_group_masquerade(self):
         """
         Tests that a staff member can masquerade as being in a particular group.
@@ -372,7 +373,7 @@ class TestMasqueradedGroup(StaffMasqueradeTestCase):
         self._verify_masquerade_for_all_groups()
 
     @skip_unless_lms
-    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    @override_settings(DISABLE_START_DATES=False)
     def test_group_masquerade_with_cohort(self):
         """
         Tests that a staff member can masquerade as being in a particular group


### PR DESCRIPTION
## Summary

Migrates the `DISABLE_START_DATES` feature flag off `settings.FEATURES['DISABLE_START_DATES']` dict-style access onto the flat setting `settings.DISABLE_START_DATES`, with `@override_settings(DISABLE_START_DATES=...)` in tests. Follows the pattern established in #38772.

`DISABLE_START_DATES` gets its own PR (rather than a batch) because of its heavy test usage.

## What changed

- **Production reader** — the single reader in `lms/djangoapps/courseware/access_utils.py` now reads `settings.DISABLE_START_DATES`. The flag is already defined in `openedx/envs/common.py` (default `False`; `lms/envs/test.py` sets `True`), so bare access resolves in every process.
- **~35 test overrides** across the courseware, grades, mobile_api, discussion, course_blocks, course_groups, branding, and student test suites converted from `patch.dict(settings.FEATURES, {'DISABLE_START_DATES': ...})` (and the `override_settings(FEATURES=...)` / `patch.multiple` variants) to `@override_settings(DISABLE_START_DATES=...)`.

## Notes

- Where a test's `FEATURES` dict also set a flag that is **not** yet migrated (`ENABLE_MKTG_SITE`, `ENABLE_ENTERPRISE_INTEGRATION`, `ENABLE_PREREQUISITE_COURSES`), only `DISABLE_START_DATES` is pulled out to `@override_settings`; the other flag stays on the `patch.dict` for its own migration.
- The `branding` module-level `FEATURES_*_STARTDATE` dict copies and the student-dashboard `MOCK_SETTINGS` `patch.multiple` dict had `DISABLE_START_DATES` flattened out to the top level / a flat override.
