### PR TITLE
fix: add unittest patch back to special exams tests

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
@@ -1,6 +1,8 @@
 """
 Tests for Instructor API v2 Special Exams endpoints.
 """
+from unittest.mock import patch
+
 import ddt
 from django.test.utils import override_settings
 from django.urls import reverse


### PR DESCRIPTION
## Description

Adds back import that existed while https://github.com/openedx/openedx-platform/pull/38874 was developed, but was removed before that PR was merged.

## Supporting information

PR: https://github.com/openedx/openedx-platform/pull/38874
Failure on master: https://github.com/openedx/openedx-platform/actions/runs/29773720214/job/88457960448

## Testing instructions

Run ruff checks and see that there are no issues reported.

## Deadline

ASAP