### PR TITLE
feat: Add observability for heartbeat checks

### DIFF
--- a/openedx/core/djangoapps/heartbeat/runchecks.py
+++ b/openedx/core/djangoapps/heartbeat/runchecks.py
@@ -7,6 +7,7 @@ from importlib import import_module
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from edx_django_utils.monitoring import set_custom_attribute
 
 
 def runchecks(include_extended=False):
@@ -34,6 +35,8 @@ def runchecks(include_extended=False):
                 'status': is_ok,
                 'message': message
             }
+            if not is_ok:
+                set_custom_attribute(f"heartbeat.failure.{path}", message)
         except ImportError as e:
             raise ImproperlyConfigured(f'Error importing module {module}: "{e}"')  # pylint: disable=raise-missing-from  # noqa: B904
         except AttributeError:

--- a/openedx/core/djangoapps/heartbeat/tests/test_heartbeat.py
+++ b/openedx/core/djangoapps/heartbeat/tests/test_heartbeat.py
@@ -24,11 +24,13 @@ class HeartbeatTestCase(ModuleStoreTestCase):
         self.heartbeat_url = reverse('heartbeat')
         return super().setUp()
 
-    def test_success(self):
+    @patch('openedx.core.djangoapps.heartbeat.runchecks.set_custom_attribute')
+    def test_success(self, mock_set_attribute):
         response = self.client.get(self.heartbeat_url + '?extended')
-        print(response)
 
         assert response.status_code == 200
+        # We only annotate failing requests
+        mock_set_attribute.assert_not_called()
 
     def test_sql_fail(self):
         with patch('openedx.core.djangoapps.heartbeat.default_checks.connection') as mock_connection:
@@ -38,8 +40,13 @@ class HeartbeatTestCase(ModuleStoreTestCase):
             response_dict = json.loads(response.content.decode('utf-8'))
             assert 'sql' in response_dict
 
-    def test_modulestore_fail(self):
+    @patch('openedx.core.djangoapps.heartbeat.runchecks.set_custom_attribute')
+    def test_modulestore_fail(self, mock_set_attribute):
         with patch('openedx.core.djangoapps.heartbeat.default_checks.modulestore') as mock_modulestore:
             mock_modulestore.return_value.heartbeat.side_effect = HeartbeatFailure('msg', 'service')
             response = self.client.get(self.heartbeat_url)
             assert response.status_code == 503
+        # Spot-checking a failure
+        mock_set_attribute.assert_any_call(
+            'heartbeat.failure.openedx.core.djangoapps.heartbeat.default_checks.check_modulestore', 'msg'
+        )


### PR DESCRIPTION
This is intended to help operators respond to situations where a failing heartbeat check due to an unhealthy backend service causes the entire edxapp cluster to be ejected from the load balancer.

Also remove a debugging print line from a unit test.

Cherry picked from commits 3956db35ea52bc13eefffc5d1e76ef9aa233527f and 4fc67f64c71a10c7ba94bf761414b299dfda762b (2U fork) to contribute upstream.