### PR TITLE
feat: return detailed error from proctoring provider

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
@@ -13,7 +13,7 @@ from edx_proctoring.api import (
     create_exam_attempt,
     get_allowances_for_course,
 )
-from edx_proctoring.exceptions import BackendProviderCannotRemoveAttempt
+from edx_proctoring.exceptions import ProctoredBaseException
 from edx_proctoring.models import ProctoredExamStudentAttempt
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -229,9 +229,14 @@ class SpecialExamResetViewTest(ModuleStoreTestCase):
             'The proctoring provider is temporarily unavailable, so this attempt '
             'could not be fully reset. Please try again in a few minutes.'
         )
+        # Simulate a proctoring-provider failure during removal (e.g. edx-proctoring's
+        # BackendProviderCannotRemoveAttempt), which resolves to a 502. Using a base
+        # ProctoredBaseException keeps the test independent of the edx-proctoring release.
+        provider_error = ProctoredBaseException(message)
+        provider_error.http_status = status.HTTP_502_BAD_GATEWAY
         with patch(
             'lms.djangoapps.instructor.views.api_v2.remove_exam_attempt',
-            side_effect=BackendProviderCannotRemoveAttempt(message),
+            side_effect=provider_error,
         ):
             response = self.client.post(self._url())
         assert response.status_code == status.HTTP_502_BAD_GATEWAY

--- a/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
@@ -13,6 +13,7 @@ from edx_proctoring.api import (
     create_exam_attempt,
     get_allowances_for_course,
 )
+from edx_proctoring.exceptions import BackendProviderCannotRemoveAttempt
 from edx_proctoring.models import ProctoredExamStudentAttempt
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -216,6 +217,25 @@ class SpecialExamResetViewTest(ModuleStoreTestCase):
     def test_reset_no_attempts(self):
         response = self.client.post(self._url())
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_reset_provider_unavailable_returns_descriptive_error(self):
+        """
+        When removing the attempt raises a ProctoredBaseException (e.g. the proctoring
+        provider is unavailable), the view surfaces the exception's HTTP status and
+        message so the instructor dashboard shows a descriptive error rather than a 500.
+        """
+        create_exam_attempt(self.exam_id, self.student.id)
+        message = (
+            'The proctoring provider is temporarily unavailable, so this attempt '
+            'could not be fully reset. Please try again in a few minutes.'
+        )
+        with patch(
+            'lms.djangoapps.instructor.views.api_v2.remove_exam_attempt',
+            side_effect=BackendProviderCannotRemoveAttempt(message),
+        ):
+            response = self.client.post(self._url())
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
+        assert response.json()['detail'] == message
 
 
 @override_settings(**PROCTORING_SETTINGS)

--- a/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
+++ b/lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py
@@ -240,7 +240,9 @@ class SpecialExamResetViewTest(ModuleStoreTestCase):
         ):
             response = self.client.post(self._url())
         assert response.status_code == status.HTTP_502_BAD_GATEWAY
+        # message is returned under both keys so the consumer surfaces it either way
         assert response.json()['detail'] == message
+        assert response.json()['error'] == message
 
 
 @override_settings(**PROCTORING_SETTINGS)

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -4270,8 +4270,15 @@ class SpecialExamResetView(DeveloperErrorViewMixin, APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        for attempt in user_attempts:
-            remove_exam_attempt(attempt['id'], requesting_user=request.user)
+        try:
+            for attempt in user_attempts:
+                remove_exam_attempt(attempt['id'], requesting_user=request.user)
+        except ProctoredBaseException as err:
+            # The proctoring provider (or another proctoring-layer error) prevented the
+            # attempt from being removed. Surface the typed exception's status and message
+            # (e.g. a 502 when the provider is unavailable) so the instructor dashboard can
+            # display a descriptive error instead of a generic 500.
+            return Response({'detail': str(err)}, status=err.http_status)
 
         return Response(
             {'success': True, 'message': f'Exam attempt reset for user {username}'},

--- a/lms/djangoapps/instructor/views/api_v2.py
+++ b/lms/djangoapps/instructor/views/api_v2.py
@@ -4278,7 +4278,11 @@ class SpecialExamResetView(DeveloperErrorViewMixin, APIView):
             # attempt from being removed. Surface the typed exception's status and message
             # (e.g. a 502 when the provider is unavailable) so the instructor dashboard can
             # display a descriptive error instead of a generic 500.
-            return Response({'detail': str(err)}, status=err.http_status)
+            # Return the message under both ``detail`` (DRF convention, and what the
+            # instructor-dashboard MFE reads) and ``error`` (the key used by the other
+            # error branches in this view), so it is surfaced regardless of which the
+            # consumer looks at.
+            return Response({'detail': str(err), 'error': str(err)}, status=err.http_status)
 
         return Response(
             {'success': True, 'message': f'Exam attempt reset for user {username}'},


### PR DESCRIPTION
## Description

Resetting a proctored exam attempt from the new instructor dashboard previously failed with a generic **500** when the proctoring provider was slow/unavailable, leaving the attempt "stuck" with no explanation.

This PR updates the Instructor v2 reset endpoint (`SpecialExamResetView` in `lms/djangoapps/instructor/views/api_v2.py`) to catch `ProctoredBaseException` from `remove_exam_attempt` and return the exception's own status + message:

```python
except ProctoredBaseException as err:
    return Response({'detail': str(err)}, status=err.http_status)
```

Now a provider failure returns a **502** with a clear `detail` (e.g. "The proctoring provider is temporarily unavailable… please try again in a few minutes."), which the instructor-dashboard MFE already displays. Same pattern as the existing `ProctoredBaseException` handling in this file.

**Impacted roles:** Instructor/Course Staff (clear error instead of a 500), Operator (failure is now logged/typed).

## Supporting information

- Bug: instructor dashboard "reset exam attempt error" (reset 500s, attempt remains) with the Proctortrack provider.
- **Depends on** `openedx/edx-proctoring#1337`, which raises the typed `BackendProviderCannotRemoveAttempt` (502) this view relies on.
- Screenshot
  
<img width="1512" height="757" alt="Screenshot 2026-07-28 at 1 15 00 PM" src="https://github.com/user-attachments/assets/d4df05bc-4fb0-47a9-971c-214ad126a84f" />


## Testing instructions

**Automated:**
```
pytest lms/djangoapps/instructor/tests/views/test_special_exams_api_v2.py::SpecialExamResetViewTest
```

**Manual** (needs `edx-proctoring >= 6.1.0`):
1. Create a proctored exam (REST backend) and have a learner start an attempt.
2. Make the provider fail — point the backend `base_url` at an unreachable host (or stub `remove_exam_attempt` to raise).
3. As instructor, reset the attempt (dashboard → Special Exams → Exam Attempts).
4. **Expect:** 502 with `{"detail": "…temporarily unavailable…"}`, the message shown in the UI, attempt still present, error logged.
5. **Regression:** with a healthy provider, reset still returns 200 and removes the attempt.

## Deadline

None, though it fixes a production-visible bug.

## Other information

- Depends on https://github.com/openedx/edx-proctoring/pull/1337 (safe to merge without it — the `except` branch just won't trigger).
- No DB migrations. No required config changes.
- Only affects the legacy edx-proctoring reset path, not the edx-exams IDA.
