### PR TITLE
feat: Support IdP-initiated SAML auth with redirect destination in RelayState

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -16,7 +16,7 @@ from onelogin.saml2.settings import OneLogin_Saml2_Settings
 from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAMLIdentityProvider
 from social_core.exceptions import AuthForbidden, AuthInvalidParameter, AuthMissingParameter
 
-from common.djangoapps.student.helpers import is_safe_login_or_logout_redirect
+from openedx.core.djangoapps.user_authn.utils import is_safe_login_or_logout_redirect
 from common.djangoapps.third_party_auth.exceptions import IncorrectConfigurationException
 from openedx.core.djangoapps.theming.helpers import get_current_request
 
@@ -147,6 +147,9 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
             require_https=request.is_secure(),
         ):
             request.session['next'] = next_decoded
+        else:
+            # RelayState included an unsafe destination; clear any stale 'next' value
+            request.session.pop('next', None)
 
         # Always rewrite RelayState to just the IdP slug so the SAML backend can locate the provider.
         post_copy = request.POST.copy()

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -3,6 +3,7 @@ Slightly customized python-social-auth backend for SAML 2.0 support
 """
 
 import logging
+from urllib.parse import unquote
 from copy import deepcopy
 
 import requests
@@ -15,6 +16,7 @@ from onelogin.saml2.settings import OneLogin_Saml2_Settings
 from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAMLIdentityProvider
 from social_core.exceptions import AuthForbidden, AuthInvalidParameter, AuthMissingParameter
 
+from common.djangoapps.student.helpers import is_safe_login_or_logout_redirect
 from common.djangoapps.third_party_auth.exceptions import IncorrectConfigurationException
 from openedx.core.djangoapps.theming.helpers import get_current_request
 
@@ -88,12 +90,68 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
         """
         Handle exceptions that happen during SAML authentication
         """
+        # For IdP-initiated flows (where the user doesn't first hit /auth/login/...),
+        # allow callers to provide a post-auth redirect by packing it into RelayState.
+        # Store it in the session so the rest of the pipeline behaves consistently.
+        try:
+            request = get_current_request()
+            # Allow RelayState to carry both IdP slug and a post-auth destination.
+            # Format: "<idp_slug>|<next>", where <next> is typically a relative LMS path.
+            self._maybe_set_next_url_from_relay_state(request)
+        except Exception:  # pylint: disable=broad-exception-caught  # pragma: no cover
+            # Never fail auth due to redirect bookkeeping.
+            pass
+
         try:
             return super().auth_complete(*args, **kwargs)
         # We are seeing errors of MultiValueDictKeyError looking for the parameter 'RelayState'.
         # We would like to have a more specific error to handle for observability purposes.
         except MultiValueDictKeyError as e:
-            raise AuthMissingParameter(self.name, e.args[0]) from e
+            raise AuthMissingParameter(self.name, e.args[0] if e.args else '') from e
+
+    @staticmethod
+    def _maybe_set_next_url_from_relay_state(request):
+        """Optionally extract a safe `next` from RelayState and rewrite RelayState to the IdP slug.
+
+        This is specifically to support IdP-initiated flows where Auth0 (and some IdPs) can only
+        reliably influence the SAML POST via RelayState.
+        """
+        if request is None or not hasattr(request, 'POST'):
+            return
+        if not hasattr(request, 'session'):
+            return
+
+        relay_state = None
+        try:
+            relay_state = request.POST.get('RelayState')
+        except Exception:  # pylint: disable=broad-exception-caught  # pragma: no cover
+            relay_state = None
+
+        if not relay_state or '|' not in str(relay_state):
+            return
+
+        slug_part, next_part = str(relay_state).split('|', 1)
+        slug_part = slug_part.strip()
+        next_part = next_part.strip()
+        if not slug_part or not next_part:
+            return
+
+        # URL-decode next (Auth0 or callers may URL-encode it).
+        next_decoded = unquote(next_part)
+
+        # Only store next if it's safe per existing Open edX redirect policy.
+        if is_safe_login_or_logout_redirect(
+            redirect_to=next_decoded,
+            request_host=request.get_host(),
+            dot_client_id=(request.GET.get('client_id') if hasattr(request, 'GET') else None),
+            require_https=request.is_secure(),
+        ):
+            request.session['next'] = next_decoded
+
+        # Always rewrite RelayState to just the IdP slug so the SAML backend can locate the provider.
+        post_copy = request.POST.copy()
+        post_copy['RelayState'] = slug_part
+        request._post = post_copy  # pylint: disable=protected-access
 
     def get_user_id(self, details, response):
         """

--- a/common/djangoapps/third_party_auth/tests/test_saml.py
+++ b/common/djangoapps/third_party_auth/tests/test_saml.py
@@ -4,7 +4,9 @@ Unit tests for third_party_auth SAML auth providers
 
 from unittest import mock
 
+from django.test import RequestFactory
 from django.utils.datastructures import MultiValueDictKeyError
+from django.contrib.sessions.middleware import SessionMiddleware
 from social_core.exceptions import AuthMissingParameter
 
 from common.djangoapps.third_party_auth.dummy import DummyBackend
@@ -41,6 +43,14 @@ class TestEdXSAMLIdentityProvider(SAMLTestCase):
 class TestSAMLAuthBackend(SAMLTestCase):
     """ Tests for the SAML backend. """
 
+    @staticmethod
+    def _add_session(request):
+        """Attach a Django session to a RequestFactory request."""
+        middleware = SessionMiddleware(lambda req: None)
+        middleware.process_request(request)
+        request.session.save()
+        return request
+
     @mock.patch('common.djangoapps.third_party_auth.saml.SAMLAuth.auth_complete')
     def test_saml_auth_complete(self, super_auth_complete):
         super_auth_complete.side_effect = MultiValueDictKeyError('RelayState')
@@ -49,3 +59,49 @@ class TestSAMLAuthBackend(SAMLTestCase):
             backend.auth_complete()
 
         assert cm.exception.parameter == 'RelayState'
+
+    @mock.patch('common.djangoapps.third_party_auth.saml.get_current_request')
+    @mock.patch('common.djangoapps.third_party_auth.saml.SAMLAuth.auth_complete')
+    def test_relaystate_splits_and_sets_next_when_safe(self, super_auth_complete, get_current_request_mock):
+        """RelayState may include both the IdP slug and a safe `next` destination."""
+        rf = RequestFactory()
+        request = rf.post(
+            '/auth/complete/tpa-saml/',
+            data={
+                'SAMLResponse': 'ignored',
+                'RelayState': 'example-idp|/courses/course-v1:edX+DemoX+Demo_Course/course/',
+            },
+            HTTP_HOST=self.hostname,
+        )
+        self._add_session(request)
+        get_current_request_mock.return_value = request
+
+        super_auth_complete.return_value = 'ok'
+        backend = SAMLAuthBackend()
+        assert backend.auth_complete() == 'ok'
+
+        assert request.POST.get('RelayState') == 'example-idp'
+        assert request.session.get('next') == '/courses/course-v1:edX+DemoX+Demo_Course/course/'
+
+    @mock.patch('common.djangoapps.third_party_auth.saml.get_current_request')
+    @mock.patch('common.djangoapps.third_party_auth.saml.SAMLAuth.auth_complete')
+    def test_relaystate_drops_unsafe_next(self, super_auth_complete, get_current_request_mock):
+        """If RelayState contains an unsafe `next`, it is ignored but the slug is preserved."""
+        rf = RequestFactory()
+        request = rf.post(
+            '/auth/complete/tpa-saml/',
+            data={
+                'SAMLResponse': 'ignored',
+                'RelayState': 'example-idp|https%3A%2F%2Fevil.example.com%2Fpwn',
+            },
+            HTTP_HOST=self.hostname,
+        )
+        self._add_session(request)
+        get_current_request_mock.return_value = request
+
+        super_auth_complete.return_value = 'ok'
+        backend = SAMLAuthBackend()
+        assert backend.auth_complete() == 'ok'
+
+        assert request.POST.get('RelayState') == 'example-idp'
+        assert request.session.get('next') is None


### PR DESCRIPTION
## Description

Backport of edx/edx-platform#108, originally merged to our `release-ulmo` release branch.

Adds support for IdP-initiated SAML login flows (where the user doesn't first hit `/auth/login/...`) to carry a post-auth redirect destination. Since some IdPs (e.g. Auth0) can only reliably influence the SAML POST via `RelayState`, `RelayState` may now encode both the IdP slug and a `next` destination as `"<idp_slug>|<next>"`. `SAMLAuthBackend.auth_complete` extracts and validates `next` (via the existing `is_safe_login_or_logout_redirect` safety check) before rewriting `RelayState` back down to just the slug so the rest of the SAML pipeline continues to work unmodified.

## Backport notes

`master` has diverged from where this was originally written (Feb 2026): `common/djangoapps/third_party_auth/saml.py`'s `EdXSAMLIdentityProvider.get_attr` and its test were independently reworked upstream in #37550 (social-auth-core unpinning) to handle the same social-core compatibility issue this PR's second commit also touched. Rather than reintroducing the older approach, this backport keeps `master`'s existing `get_attr` implementation as-is and carries forward only the new RelayState redirect logic, which applied cleanly on top of it.

## Testing

- Unit tests for the new RelayState handling (`test_relaystate_splits_and_sets_next_when_safe`, `test_relaystate_drops_unsafe_next`) are included.
- Original PR: edx/edx-platform#108