### PR TITLE
feat: Adding redirection changes for enterprise users (#134)

### DIFF
--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -2,7 +2,7 @@
 Waffle flags and switches for user authn.
 """
 
-from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles import WaffleFlag, WaffleSwitch
 
 _WAFFLE_NAMESPACE = 'user_authn'
 
@@ -30,4 +30,20 @@ ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = WaffleSwitch(
 # .. toggle_tickets: VAN-664
 ENABLE_PWNED_PASSWORD_API = WaffleSwitch(
     f'{_WAFFLE_NAMESPACE}.enable_pwned_password_api', __name__
+)
+
+# .. toggle_name: user_authn.enable_enterprise_redirect_to_authn
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, allows Enterprise/B2B customers to be redirected to the AuthN MFE instead of
+#   the legacy Django login templates. This flag provides an incremental rollout mechanism for migrating Enterprise
+#   customers to the modern authentication experience. The flag has no effect on users with external authentication
+#   providers (SAML/TPA), who always remain on the legacy flow. B2C users are redirected to the MFE by default
+#   regardless of this flag.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2026-02-18
+# .. toggle_warning: This flag only affects Enterprise customers without external auth providers (SAML/TPA).
+#   Enabling this flag for an Enterprise customer with complex SSO requirements may break authentication flows.
+ENABLE_ENTERPRISE_REDIRECT_TO_AUTHN = WaffleFlag(
+    f'{_WAFFLE_NAMESPACE}.enable_enterprise_redirect_to_authn', __name__
 )

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -25,10 +25,8 @@ from openedx.core.djangoapps.user_api import accounts
 from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled
 from openedx.core.djangoapps.user_api.helpers import FormDescription
 from openedx.core.djangoapps.user_authn.cookies import set_logged_in_cookies
-from openedx.core.djangoapps.user_authn.toggles import (
-    is_require_third_party_auth_enabled,
-    should_redirect_to_authn_microfrontend,
-)
+from openedx.core.djangoapps.user_authn.config.waffle import ENABLE_ENTERPRISE_REDIRECT_TO_AUTHN
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
 from openedx.core.djangoapps.user_authn.views.password_reset import get_password_reset_form
 from openedx.core.djangoapps.user_authn.views.registration_form import RegistrationFormFactory
 from openedx.core.djangoapps.user_authn.views.utils import third_party_auth_context
@@ -202,10 +200,24 @@ def login_and_registration_form(request, initial_mode="login"):
 
     enterprise_customer = enterprise_customer_for_request(request)
 
+    # Check for external providers (SAML/TPA) which must NEVER redirect to MFE
+    has_external_provider = bool(tpa_hint_provider or saml_provider)
+
+    # Determine eligibility based on segment
+    if enterprise_customer:
+        # Enterprise/B2B: Requires the specific rollout waffle flag
+        is_segment_eligible = ENABLE_ENTERPRISE_REDIRECT_TO_AUTHN.is_enabled()
+    else:
+        # B2C: Eligible by default
+        is_segment_eligible = True
+
+    # Redirect to authn MFE if all conditions are met:
+    # 1. MFE is globally enabled (should_redirect_to_authn_microfrontend)
+    # 2. User segment is eligible (B2C by default, or Enterprise with flag enabled)
+    # 3. No external auth provider is present (SAML/TPA must use legacy flow)
     if should_redirect_to_authn_microfrontend() and \
-            not enterprise_customer and \
-            not tpa_hint_provider and \
-            not saml_provider:
+            is_segment_eligible and \
+            not has_external_provider:
 
         # This is to handle a case where a logged-in cookie is not present but the user is authenticated.
         # Note: If we don't handle this learner is redirected to authn MFE and then back to dashboard


### PR DESCRIPTION
* feat: Adding redirection changes for enterprise users

* fix: removed request from the waffle flag arguements

(cherry picked from commit 2e2ea9a14eefe408e0bbd87bf31345f049b7fa21)

Description
This PR backports edx/edx-platform PR #134 to openedx/openedx-platform:master.

It updates logistration redirect behavior for users hitting the legacy Django login/registration page when the AuthN MFE redirect path is enabled.

Changes included in this backport:

Adds a new waffle flag: user_authn.enable_enterprise_redirect_to_authn
Allows Enterprise/B2B users to be redirected to the AuthN MFE only when that flag is enabled
Keeps B2C users eligible for AuthN MFE redirect by default, as before
Prevents redirect to the AuthN MFE for flows involving external auth providers such as SAML or other TPA-based login
Preserves the legacy Django login flow for Enterprise users unless explicitly opted in via the new flag

Impacted user roles:

Learner: affected, because login and registration entry behavior can change depending on user segment and authentication setup
Operator: affected, because rollout is controlled through a waffle flag and needs operational awareness
Developer: affected, because login redirect behavior is now segmented for Enterprise vs B2C users
Implications for consumers of this change:

Enterprise customers can be migrated to the AuthN MFE incrementally instead of all at once
Enterprise customers using external auth providers remain on the legacy flow
Operators must enable the new waffle flag deliberately for Enterprise rollout
B2C users continue to follow the MFE redirect path when the global AuthN redirect setting is enabled

Supporting information
Original PR: [https://github.com/edx/edx-platform/pull/134](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Original merge commit: 2e2ea9a

This is a backport from edx/edx-platform/release-ulmo into openedx/openedx-platform:master.

