### PR TITLE
fix: centralize authn MFE branding and remove duplicate context (#226)

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/utils.py
+++ b/openedx/core/djangoapps/user_authn/views/utils.py
@@ -119,15 +119,21 @@ def third_party_auth_context(request, redirect_to, tpa_hint=None):
 
 
 def get_mfe_context(request, redirect_to, tpa_hint=None):
-    """
-    Returns Authn MFE context.
-    """
+    """Return Authn MFE context including enterprise branding and country code."""
+    # Import enterprise functions INSIDE the function to avoid circular import
+    from openedx.features.enterprise_support.api import enterprise_customer_for_request
+    from openedx.features.enterprise_support.utils import build_enterprise_branding_for_authn_mfe
 
     ip_address = get_client_ip(request)[0]
     country_code = country_code_from_ip(ip_address)
     context = third_party_auth_context(request, redirect_to, tpa_hint)
+
+    enterprise_customer = enterprise_customer_for_request(request)
+    enterprise_branding = build_enterprise_branding_for_authn_mfe(enterprise_customer)
+
     context.update({
         'countryCode': country_code,
+        'enterpriseBranding': enterprise_branding,
     })
     return context
 

--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -30,6 +30,7 @@ from openedx.features.enterprise_support.tests.factories import (
 from openedx.features.enterprise_support.utils import (
     ENTERPRISE_HEADER_LINKS,
     _user_has_social_auth_record,
+    build_enterprise_branding_for_authn_mfe,
     clear_data_consent_share_cache,
     enterprise_fields_only,
     fetch_enterprise_customer_by_id,
@@ -174,6 +175,52 @@ class TestEnterpriseUtils(TestCase):
         expected_logo_url = branding_configuration.get('logo', '')
         assert expected_logo_url == actual_result['enterprise_logo_url']
         assert 'pied-piper' in str(actual_result['enterprise_branded_welcome_string'])
+
+    def test_build_enterprise_branding_for_authn_mfe_without_customer(self):
+        assert build_enterprise_branding_for_authn_mfe(None) is None
+
+    @mock.patch('openedx.features.enterprise_support.utils.get_enterprise_sidebar_context')
+    def test_build_enterprise_branding_for_authn_mfe(self, mock_sidebar_context):
+        enterprise_customer = {
+            'name': 'pied-piper',
+            'slug': 'pied-piper-slug',
+        }
+        mock_sidebar_context.return_value = {
+            'enterprise_name': 'pied-piper',
+            'enterprise_logo_url': 'https://example.com/logo.png',
+            'enterprise_branded_welcome_string': 'Welcome to Pied Piper',
+            'platform_welcome_string': 'Welcome to Open edX',
+            'enterprise_slug': 'sidebar-slug',
+        }
+
+        actual_result = build_enterprise_branding_for_authn_mfe(enterprise_customer)
+
+        assert actual_result == {
+            'enterpriseName': 'pied-piper',
+            'enterpriseLogoUrl': 'https://example.com/logo.png',
+            'enterpriseBrandedWelcomeString': 'Welcome to Pied Piper',
+            'platformWelcomeString': 'Welcome to Open edX',
+            'enterpriseSlug': 'sidebar-slug',
+        }
+        mock_sidebar_context.assert_called_once_with(enterprise_customer, is_proxy_login=False)
+
+    @mock.patch('openedx.features.enterprise_support.utils.get_enterprise_sidebar_context')
+    def test_build_enterprise_branding_for_authn_mfe_falls_back_to_customer_slug(self, mock_sidebar_context):
+        enterprise_customer = {
+            'name': 'pied-piper',
+            'slug': 'customer-slug',
+        }
+        mock_sidebar_context.return_value = {
+            'enterprise_name': 'pied-piper',
+            'enterprise_logo_url': '',
+            'enterprise_branded_welcome_string': 'Welcome to Pied Piper',
+            'platform_welcome_string': 'Welcome to Open edX',
+            'enterprise_slug': None,
+        }
+
+        actual_result = build_enterprise_branding_for_authn_mfe(enterprise_customer)
+
+        assert actual_result['enterpriseSlug'] == 'customer-slug'
 
     @ddt.data(
         ('notfoundpage', 0),

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -148,6 +148,37 @@ def get_enterprise_sidebar_context(enterprise_customer, is_proxy_login):
     }
 
 
+def build_enterprise_branding_for_authn_mfe(enterprise_customer):
+    """Build the enterpriseBranding payload for Authn MFE context.
+
+    Args:
+        enterprise_customer (dict): Serialized enterprise customer for the request.
+
+    Returns:
+        dict or None: Branding fields for the MFE, or None if there is no
+        customer.
+    """
+    if not enterprise_customer:
+        return None
+
+    sidebar_context = get_enterprise_sidebar_context(
+        enterprise_customer,
+        is_proxy_login=False,
+    )
+
+    return {
+        'enterpriseName': sidebar_context.get('enterprise_name'),
+        'enterpriseLogoUrl': sidebar_context.get('enterprise_logo_url'),
+        'enterpriseBrandedWelcomeString': str(
+            sidebar_context.get('enterprise_branded_welcome_string', '')
+        ),
+        'platformWelcomeString': str(
+            sidebar_context.get('platform_welcome_string', '')
+        ),
+        'enterpriseSlug': sidebar_context.get('enterprise_slug') or enterprise_customer.get('slug'),
+    }
+
+
 def enterprise_fields_only(fields):
     """
     Take the received field definition, and exclude those fields that we don't want
@@ -488,3 +519,11 @@ def is_course_accessed(user, course_id):
         return True
     except UnavailableCompletionData:
         return False
+
+
+def get_enterprise_dashboard_url(request, enterprise_customer):
+    """
+    Generate the enterprise-specific dashboard URL.
+    """
+    base_url = settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL
+    return f"{base_url}/{enterprise_customer['slug']}"


### PR DESCRIPTION
* fix: centralize authn MFE branding and remove duplicate context

* fix: add authn MFE branding helper tests and remove dead imports

(cherry picked from commit 95cb6804fe84a7b622aef812894878cbfd213e51)

## Description

This PR backports edx/edx-platform PR #226 to openedx/openedx-platform:master.

It centralizes AuthN MFE enterprise branding construction into a shared helper and removes duplicated branding logic from the AuthN view utilities. This keeps enterprise branding behavior consistent and reduces the risk of drift between implementations.

Impacted roles:
- Learner
- Developer
- Operator

## Supporting information

Original PR: https://github.com/edx/edx-platform/pull/226
Original commit: 95cb680

## Testing instructions

1. Verify non-enterprise authentication flows still behave as expected.
2. Verify enterprise-associated AuthN MFE context still includes the expected `enterpriseBranding` payload.
3. Confirm enterprise branding values remain correct in the authentication flow.
4. Run the relevant enterprise support and AuthN helper tests.

## Deadline

None.

## Other information

- No database migration.
- Refactor/cleanup plus test coverage.
- Centralizes enterprise branding logic for AuthN MFE.
