### PR TITLE
build: bump xblocks-contrib to 1.0.3 

### DIFF
--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -19,7 +19,7 @@ from django.utils.translation import gettext as _
 from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
-from xblocks_contrib.problem.capa.tests.response_xml_factory import StringResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import StringResponseXMLFactory
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -51,7 +51,7 @@ from xblock.runtime import (  # pylint: disable=wrong-import-order
     Mixologist,  # pylint: disable=wrong-import-order
 )
 from xblock.test.tools import TestRuntime  # pylint: disable=wrong-import-order
-from xblocks_contrib.problem.capa.tests.response_xml_factory import (
+from xblocks_contrib.problem.capa.testing.response_xml_factory import (
     OptionResponseXMLFactory,  # pylint: disable=reimported
 )
 

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -7,7 +7,7 @@ from crum import set_current_request
 from django.test import override_settings
 from django.urls import reverse
 from milestones.tests.utils import MilestonesTestCaseMixin
-from xblocks_contrib.problem.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import MultipleChoiceResponseXMLFactory
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import (

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -16,7 +16,7 @@ from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from pytz import UTC
 from xblock.runtime import DictKeyValueStore
-from xblocks_contrib.problem.capa.tests.response_xml_factory import OptionResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import OptionResponseXMLFactory
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import StaffFactory, UserFactory

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -21,13 +21,13 @@ from django.test.client import RequestFactory
 from django.urls import reverse
 from django.utils.timezone import now
 from submissions import api as submissions_api
-from xblocks_contrib.problem.capa.tests.response_xml_factory import (
+from xblocks_contrib.problem.capa.testing.codejail import UseUnsafeCodejail
+from xblocks_contrib.problem.capa.testing.response_xml_factory import (
     CodeResponseXMLFactory,
     CustomResponseXMLFactory,
     OptionResponseXMLFactory,
     SchematicResponseXMLFactory,
 )
-from xblocks_contrib.problem.capa.tests.test_util import UseUnsafeCodejail
 from xblocks_contrib.problem.capa.xqueue_interface import XQueueInterface
 
 from common.djangoapps.course_modes.models import CourseMode

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -35,7 +35,7 @@ from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Scope, String
 from xblock.scorable import ShowCorrectness
-from xblocks_contrib.problem.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import MultipleChoiceResponseXMLFactory
 
 import lms.djangoapps.courseware.views.views as views
 from common.djangoapps.course_modes.models import CourseMode

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_grading_policy_view.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_grading_policy_view.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import ddt
 from django.urls import reverse
 from pytz import UTC
-from xblocks_contrib.problem.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import MultipleChoiceResponseXMLFactory
 
 from common.djangoapps.student.tests.factories import GlobalStaffFactory, StaffFactory, UserFactory
 from openedx.core.djangoapps.oauth_dispatch.tests.factories import AccessTokenFactory, ApplicationFactory

--- a/lms/djangoapps/grades/tests/base.py
+++ b/lms/djangoapps/grades/tests/base.py
@@ -4,7 +4,7 @@ Base file for Grades tests
 
 
 from crum import set_current_request
-from xblocks_contrib.problem.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import MultipleChoiceResponseXMLFactory
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory

--- a/lms/djangoapps/grades/tests/integration/test_access.py
+++ b/lms/djangoapps/grades/tests/integration/test_access.py
@@ -4,7 +4,7 @@ Test grading with access changes.
 
 
 from crum import set_current_request
-from xblocks_contrib.problem.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import MultipleChoiceResponseXMLFactory
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory

--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import ddt
 from crum import set_current_request
-from xblocks_contrib.problem.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import MultipleChoiceResponseXMLFactory
 
 import openedx.core.djangoapps.content.block_structure.api as bs_api
 from common.djangoapps.student.models import CourseEnrollment

--- a/lms/djangoapps/grades/tests/integration/test_problems.py
+++ b/lms/djangoapps/grades/tests/integration/test_problems.py
@@ -6,7 +6,7 @@ import ddt
 import pytz
 from crum import set_current_request
 from django.test.utils import override_settings
-from xblocks_contrib.problem.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import MultipleChoiceResponseXMLFactory
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -17,7 +17,7 @@ from django.utils.translation import get_language
 from django.utils.translation import override as override_language
 from opaque_keys.edx.locator import CourseLocator
 from submissions import api as sub_api
-from xblocks_contrib.problem.capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import MultipleChoiceResponseXMLFactory
 
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed, anonymous_id_for_user
 from common.djangoapps.student.roles import CourseCcxCoachRole

--- a/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
@@ -2,7 +2,7 @@
 Tests of the instructor dashboard spoc gradebook
 """
 from django.urls import reverse
-from xblocks_contrib.problem.capa.tests.response_xml_factory import StringResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import StringResponseXMLFactory
 
 from common.djangoapps.student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.courseware.tests.factories import StudentModuleFactory

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -19,7 +19,7 @@ from django.contrib.auth.models import User  # pylint: disable=imported-auth-use
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import Location
-from xblocks_contrib.problem.capa.tests.response_xml_factory import OptionResponseXMLFactory
+from xblocks_contrib.problem.capa.testing.response_xml_factory import OptionResponseXMLFactory
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.courseware.model_data import StudentModule

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -20,8 +20,8 @@ from django.contrib.auth.models import User  # pylint: disable=imported-auth-use
 from django.test.utils import override_settings
 from django.urls import reverse
 from xblocks_contrib.problem.capa.responsetypes import StudentInputError
-from xblocks_contrib.problem.capa.tests.response_xml_factory import CodeResponseXMLFactory, CustomResponseXMLFactory
-from xblocks_contrib.problem.capa.tests.test_util import UseUnsafeCodejail
+from xblocks_contrib.problem.capa.testing.codejail import UseUnsafeCodejail
+from xblocks_contrib.problem.capa.testing.response_xml_factory import CodeResponseXMLFactory, CustomResponseXMLFactory
 
 from common.test.utils import assert_dict_contains_subset
 from lms.djangoapps.courseware.model_data import StudentModule

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -23,7 +23,7 @@ from django.test.utils import override_settings
 from edx_django_utils.cache import RequestCache
 from freezegun import freeze_time
 from pytz import UTC
-from xblocks_contrib.problem.capa.tests.response_xml_factory import (
+from xblocks_contrib.problem.capa.testing.response_xml_factory import (
     MultipleChoiceResponseXMLFactory,  # pylint: disable=wrong-import-order
 )
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1311,7 +1311,7 @@ xblock-google-drive==0.8.2
     # via -r requirements/edx/bundled.in
 xblock-poll==1.16.1
     # via -r requirements/edx/bundled.in
-xblocks-contrib==0.17.0
+xblocks-contrib @ git+https://github.com/AhtishamShahid/xblocks-core@f532c455cd7210511075c6eaf7d0a265a43ebb65
     # via -r requirements/edx/bundled.in
 xmlsec==1.3.14
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -2319,7 +2319,7 @@ xblock-poll==1.16.1
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-xblocks-contrib==0.17.0
+xblocks-contrib @ git+https://github.com/AhtishamShahid/xblocks-core@f532c455cd7210511075c6eaf7d0a265a43ebb65
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1651,7 +1651,7 @@ xblock-google-drive==0.8.2
     # via -r requirements/edx/base.txt
 xblock-poll==1.16.1
     # via -r requirements/edx/base.txt
-xblocks-contrib==0.17.0
+xblocks-contrib @ git+https://github.com/AhtishamShahid/xblocks-core@f532c455cd7210511075c6eaf7d0a265a43ebb65
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1730,7 +1730,7 @@ xblock-google-drive==0.8.2
     # via -r requirements/edx/base.txt
 xblock-poll==1.16.1
     # via -r requirements/edx/base.txt
-xblocks-contrib==0.17.0
+xblocks-contrib @ git+https://github.com/AhtishamShahid/xblocks-core@f532c455cd7210511075c6eaf7d0a265a43ebb65
     # via -r requirements/edx/base.txt
 xmlsec==1.3.14
     # via

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -29,7 +29,7 @@ from xblock.scorable import Score
 from xblocks_contrib.problem.capa import responsetypes
 from xblocks_contrib.problem.capa.correctmap import CorrectMap
 from xblocks_contrib.problem.capa.responsetypes import LoncapaProblemError, ResponseError, StudentInputError
-from xblocks_contrib.problem.capa.tests.test_util import UseUnsafeCodejail
+from xblocks_contrib.problem.capa.testing.codejail import UseUnsafeCodejail
 from xblocks_contrib.problem.capa.xqueue_interface import XQueueInterface
 
 from lms.djangoapps.courseware.user_state_client import XBlockUserState


### PR DESCRIPTION
> **Draft — do not merge.** Blocked on openedx/xblocks-core#286. See "Sequencing" below.

### What this fixes

A problem added to a graded subsection displays as `0 points / ungraded` — but **only to the author who created it**. Everyone else sees it correctly, and duplicating the problem also renders correctly.

`get_progress()` reads grading off the persisted user-state score, and the author ends up with a stale one:

1. Author adds a problem. Nothing is filled in yet, so `max_score()` is 0.
2. Studio renders it. `lcp` sees `score is None` and persists `Score(0, 0)` — for **this author only**.
3. Author fills the problem in and saves. `max_score()` is now 1.
4. `lcp` will not refresh the score, because `score` is no longer `None`, so `raw_possible` stays 0.
5. `get_progress()` returns `None`, and the author sees `0 points, ungraded`.

Any other user has no persisted state, so their score reflects the current problem (`Score(0, 1)`) and they correctly see `1 point possible (graded)`. That asymmetry is what made this confusing to report.

Fixed upstream in openedx/xblocks-core#272, released in `xblocks-contrib` 1.0.3 on 2026-07-29. It has never reached a deployment because this repo is still pinned to 0.17.0.

This affects the code that actually runs: `USE_EXTRACTED_PROBLEM_BLOCK` defaults to `True`, so `xmodule.capa_block.ProblemBlock` resolves to `xblocks_contrib.problem.capa_block.ProblemBlock` at runtime.

### Why the pin is stuck at 0.17.0

Not lag — a deliberate revert. [2d315ebd69](https://github.com/openedx/openedx-platform/commit/2d315ebd69) ("*build: downgrade xblocks-contrib — The renaming is causing some conflicts and causing tests to fail*") reverted the bot's bump from 1.0.1, because no 1.0.x wheel ships `xblocks_contrib.problem.capa.tests`, which this repo imports from 17 of its own test modules.

Pinning the released 1.0.3 fails every unit-test shard with `ModuleNotFoundError: No module named 'xblocks_contrib.problem.capa.tests'` — demonstrated on this branch earlier, [run 31097321942](https://github.com/openedx/openedx-platform/actions/runs/31097321942). The blast radius is wider than the direct importers, since `lms/djangoapps/grades/tests/base.py` is imported transitively.

That is an upstream packaging bug, fixed by openedx/xblocks-core#286.

### The two commits

| commit | what |
|---|---|
| `937130356a` | update all 17 importers to the relocated fixture paths |
| `8c7c17a4fe` | bump the requirement — the only commit that changes when 286 releases |

Import changes, per openedx/xblocks-core#286:

```python
capa.tests.response_xml_factory         →  capa.testing.response_xml_factory
capa.tests.test_util.UseUnsafeCodejail  →  capa.testing.codejail.UseUnsafeCodejail
```

The requirement currently points at that PR's branch ([`f532c455cd`](https://github.com/openedx/xblocks-core/commit/f532c455cd7210511075c6eaf7d0a265a43ebb65)) so CI can run green against the fix. That commit is tagged `v1.0.4rc1`, so the version it resolves to differs from the released 1.0.3 — without that, pip builds the fork and then silently declines to install it over an existing `xblocks-contrib==1.0.3`, leaving you on the broken package. Verified locally with that wheel installed (Py3.12): the previously-erroring modules collect with **0 errors**, `xmodule/tests/test_capa_block.py` passes **201/201**, and the reported bug is gone — the author now gets `Progress(0, 1)` / `(0, 1)` instead of `None` / `(0, 0)`.

`Compile requirements` and `check_dependencies` are expected to fail while a VCS requirement sits in the compiled files.

### Sequencing

1. openedx/xblocks-core#286 merges and releases as 1.0.4 (CI green there).
2. This PR swaps the VCS reference for `xblocks-contrib==1.0.4` — a one-commit amend — and comes out of draft.

No changes to this repo's own source are needed — only test imports and the pin.

### Note on the built-in copy

`xmodule/capa_block.py`'s `_BuiltInProblemBlock.get_progress` has the same defect, so deployments running `USE_EXTRACTED_PROBLEM_BLOCK = False` stay affected after this bump. Left alone here since #38751 removes that implementation — happy to port the guard across if you'd prefer an interim fix.



