### PR TITLE
fix(rtl): use CSS logical properties for problem blocks and remove ha…

### DIFF
--- a/common/static/sass/_builtin-block-variables.scss
+++ b/common/static/sass/_builtin-block-variables.scss
@@ -12,7 +12,6 @@
 @import 'cms/static/sass/partials/cms/theme/_variables';
 @import 'cms/static/sass/partials/cms/theme/_variables-v1';
 @import 'bootstrap/scss/variables';
-@import 'vendor/bi-app/bi-app-ltr';
 @import 'edx-pattern-library-shims/base/_variables.scss';
 
 :root {

--- a/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
+++ b/xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css
@@ -322,7 +322,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input[type="checkbox"],
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input[type="checkbox"] {
     margin: calc((var(--baseline, 20px) / 4));
-    margin-right: calc((var(--baseline, 20px) / 2));
+    margin-inline-end: calc((var(--baseline, 20px) / 2));
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input:focus + label,
@@ -885,7 +885,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup label {
     padding: calc((var(--baseline, 20px) / 2));
-    padding-left: calc((var(--baseline, 20px) * 2.3));
+    padding-inline-start: calc((var(--baseline, 20px) * 2.3));
     position: relative;
     font-size: var(--base-font-size, 18px);
     line-height: normal;
@@ -894,7 +894,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input[type="radio"],
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input[type="checkbox"] {
-    left: 0.5625em;
+    inset-inline-start: 0.5625em;
     position: absolute;
     top: 0.43em;
     width: calc(var(--baseline, 20px) * 1.1);


### PR DESCRIPTION
# Description

This PR fixes styling and alignment issues when the platform is rendered in Right-to-Left (RTL) languages within the Problem Blocks (choice groups, radio buttons, and checkboxes) .

Previously, the layout relied on physical CSS properties that forced elements to the left side regardless of the language direction.

## Changes Made

* **`xmodule/static/css-builtin-blocks/ProblemBlockDisplay.css`**:
  * Modernized the layout by replacing physical directional properties with CSS logical properties.
  * Replaced `margin-right` with `margin-inline-end`.
  * Replaced `padding-left` with `padding-inline-start`.
  * Replaced `left` with `inset-inline-start`.

## Impact

By delegating the alignment to the browser using logical properties, elements like radio buttons and checkboxes will now automatically mirror their position based on the `dir="rtl"` or `dir="ltr"` HTML attribute, fixing the UI without needing separate overriding stylesheets.

## How to Test

1. Checkout This branch
2. Set the following setting to `False`:    `USE_EXTRACTED_PROBLEM_BLOCK = False`

3. Compile assets:   `npm run compile-sass -- --skip-themes`

## Before
#### EN
<img width="1890" height="932" alt="image" src="https://github.com/user-attachments/assets/7d1b3eaf-db0a-4e77-9488-b9212ce61ad6" />

#### AR
<img width="1890" height="932" alt="image" src="https://github.com/user-attachments/assets/bd7c1348-13d9-481b-8c00-dcc37409aa24" />

## After
#### EN
<img width="1890" height="932" alt="image" src="https://github.com/user-attachments/assets/b3e453d2-6a10-41b6-b1db-dbca87691609" />


#### AR
<img width="1890" height="932" alt="image" src="https://github.com/user-attachments/assets/5cd91f4e-70e2-41ae-aeac-6093eb931497" />
