### PR TITLE
feat: allow search by display number

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
@@ -188,6 +188,25 @@ class HomePageCoursesViewV2Test(CourseTestCase):
         ])])
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
 
+    def test_search_query_matches_display_number(self):
+        """Search must match course display number values."""
+        course_key = self.store.make_course_key("search-org", "opaque-number", "run")
+        searchable_course = CourseOverviewFactory.create(
+            id=course_key,
+            org=course_key.org,
+            display_name="Unrelated Title",
+            display_number_with_default="Friendly Number 42",
+        )
+
+        response = self.client.get(self.api_v2_url, {"search": "Friendly Number"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
+        self.assertEqual(len(response.data["results"]["courses"]), 1)  # noqa: PT009
+        self.assertEqual(  # noqa: PT009
+            response.data["results"]["courses"][0]["course_key"],
+            str(searchable_course.id),
+        )
+
     def test_order_query_if_passed(self):
         """Get list of courses when order filter passed as a query param.
 

--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
@@ -200,12 +200,9 @@ class HomePageCoursesViewV2Test(CourseTestCase):
 
         response = self.client.get(self.api_v2_url, {"search": "Friendly Number"})
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
-        self.assertEqual(len(response.data["results"]["courses"]), 1)  # noqa: PT009
-        self.assertEqual(  # noqa: PT009
-            response.data["results"]["courses"][0]["course_key"],
-            str(searchable_course.id),
-        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]["courses"]) == 1
+        assert response.data["results"]["courses"][0]["course_key"] == str(searchable_course.id)
 
     def test_order_query_if_passed(self):
         """Get list of courses when order filter passed as a query param.

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -727,6 +727,7 @@ class CourseOverview(TimeStampedModel):
         """
         return course_overviews.filter(
             Q(display_name__icontains=query) |
+            Q(display_number_with_default__icontains=query) |
             Q(org__icontains=query) |
             Q(id__icontains=query)
         )


### PR DESCRIPTION
## Description

Recently was fixed the issue to correctly add course display number on https://github.com/openedx/openedx-platform/pull/38899, but we also find out that the ability to search on the main course search bar by display number was missing, so we added it back

## Screenshot
<img width="1136" height="593" alt="Screenshot 2026-08-10 at 1 49 38 p m" src="https://github.com/user-attachments/assets/e8a0e715-fd7a-4a57-924f-436a11cd07cf" />

<img width="1141" height="375" alt="Screenshot 2026-08-10 at 1 02 40 p m" src="https://github.com/user-attachments/assets/a2e9f6fb-c564-4322-ae82-543a38b28ea4" />


## Testing instructions
- pull the branch
- On studio verify you have enabled course number display, change it manually on some course to validate
- test it on studio course search bar


