### PR TITLE
fix: don't scroll the page when toggling anchor-driven widgets

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -138,6 +138,14 @@ ${HTML(fragment.foot_html())}
             // the href attribute is an id or name, the page will scroll the id or name.
             $('a').on("click", function(event){
               if ($(this).attr('href')[0] === '#') {
+                // Anchors that operate a widget (like accordions, tabs, dropdowns)
+                // point at the region they control rather than navigating to it, and
+                // handle the click themselves. Scrolling that region to the top of
+                // the page jumps the surrounding learning MFE viewport every time the
+                // widget is toggled, so we can leave these anchors alone.
+                if (this.hasAttribute('aria-controls') || this.hasAttribute('data-toggle')) {
+                  return;
+                }
                 var targetId = $(this).attr('href');
                 // Checks if the href attribute is auto scrolling video transcripts.
                 // The scroll behavior for transcript scrolling requires the viewport


### PR DESCRIPTION
## Description

Toggling an accordion inside an XBlock jumps the Learning MFE viewport so that
the accordion's panel lands at the top of the screen. Reproduces with any
Bootstrap disclosure widget driven by an anchor, e.g.:

```html
<a data-toggle="collapse" href="#foo" role="button" aria-expanded="false" aria-controls="foo">Hello</a>
<div class="collapse" id="foo">...</div>
```

## Testing instructions

1. Add an HTML XBlock containing the accordion markup above. Insert a long Lorem Ipsum below to ensure that the XBlock's content exceeds the viewport.
1. Go to the LMS (the current version of Studio does not seem to be handling accordions correctly).
1. Expand the accordion, and then collapse it. There should be no "scroll" event.
1. Add a plain in-page link (`<a href="#target"> / <div id="target">`) in the same XBlock and confirm it still jumps to its target.


## Deadline

"None"