### PR TITLE
feat: let operators enable xblocks in every course's advanced list

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -26,7 +26,7 @@ from cms.djangoapps.contentstore.toggles import libraries_v1_enabled, libraries_
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import load_services_for_studio
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_course_author_access
-from common.djangoapps.xblock_django.api import authorable_xblocks, disabled_xblocks
+from common.djangoapps.xblock_django.api import authorable_xblocks, default_advanced_xblocks, disabled_xblocks
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
 from openedx.core.djangoapps.content_tagging.api import get_object_tags
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
@@ -73,6 +73,9 @@ CONTAINER_TEMPLATES = [
     "edit-title-button", "edit-upstream-alert",
 ]
 
+# Advanced modules which are offered in every course, in addition to the ones each course lists in its own
+# Advanced Module List. Operators can add to this list without forking the platform by marking XBlocks as
+# advanced by default in XBlockStudioConfiguration (see `default_advanced_xblocks`).
 DEFAULT_ADVANCED_MODULES = [
     'google-calendar',
     'google-document',
@@ -444,8 +447,10 @@ def get_component_templates(courselike, library=False):  # pylint: disable=too-m
     # Check if there are any advanced modules specified in the course policy.
     # These modules should be specified as a list of strings, where the strings
     # are the names of the modules in ADVANCED_COMPONENT_TYPES that should be
-    # enabled for the course.
-    course_advanced_keys = list(dict.fromkeys(courselike.advanced_modules + DEFAULT_ADVANCED_MODULES))
+    # enabled for the course. They are combined with the modules which are enabled for every course: the
+    # platform-wide DEFAULT_ADVANCED_MODULES, plus any which this operator has marked as advanced by default.
+    default_advanced_keys = DEFAULT_ADVANCED_MODULES + [block.name for block in default_advanced_xblocks()]
+    course_advanced_keys = list(dict.fromkeys(courselike.advanced_modules + default_advanced_keys))
     advanced_component_templates = {
         "type": "advanced",
         "templates": [],

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -2945,6 +2945,69 @@ class TestComponentTemplates(CourseTestCase):
         self.templates = get_component_templates(self.course)
         self.assertTrue((not any(item.get("category") == "done" for item in self.get_templates_of_type("advanced"))))  # noqa: PT009, UP034  # pylint: disable=line-too-long
 
+    def test_advanced_by_default_components(self):
+        """
+        Test that an xblock which an operator has marked as advanced by default is offered to a course
+        which does not list it in its own Advanced Module List.
+        """
+        advanced_categories = [
+            template.get("category") for template in self.get_templates_of_type("advanced")
+        ]
+        self.assertNotIn("done", advanced_categories)  # noqa: PT009
+
+        XBlockStudioConfiguration.objects.create(
+            name="done", enabled=True, support_level="fs", advanced_by_default=True
+        )
+        self.templates = get_component_templates(self.course)
+        advanced_templates = self.get_templates_of_type("advanced")
+        self.assertEqual(len(advanced_templates), len(DEFAULT_ADVANCED_MODULES) + 1)  # noqa: PT009
+        done_template = self.get_template(advanced_templates, "Completion")
+        self.assertEqual(done_template.get("category"), "done")  # noqa: PT009
+        self.assertIsNone(done_template.get("boilerplate_name", None))  # noqa: PT009
+
+        # Verify that the component is not added twice if the course lists it as well.
+        self.course.advanced_modules.append("done")
+        self.templates = get_component_templates(self.course)
+        self.assertEqual(  # noqa: PT009
+            len(self.get_templates_of_type("advanced")), len(DEFAULT_ADVANCED_MODULES) + 1
+        )
+
+        # Now fully disable done through XBlockConfiguration.
+        XBlockConfiguration.objects.create(name="done", enabled=False)
+        self.templates = get_component_templates(self.course)
+        self.assertTrue((not any(item.get("category") == "done" for item in self.get_templates_of_type("advanced"))))  # noqa: PT009, UP034  # pylint: disable=line-too-long
+
+    def test_advanced_by_default_components_support_levels(self):
+        """
+        Test that an xblock which is advanced by default still honors Studio support levels, so that
+        opting an unsupported xblock into every course requires course author opt-in as usual.
+        """
+        XBlockStudioConfiguration.objects.create(
+            name="done", enabled=True, support_level="us", advanced_by_default=True
+        )
+        XBlockStudioConfigurationFlag.objects.create(enabled=True)
+
+        self.templates = get_component_templates(self.course)
+        self.assertTrue((not any(item.get("category") == "done" for item in self.get_templates_of_type("advanced"))))  # noqa: PT009, UP034  # pylint: disable=line-too-long
+
+        self.course.allow_unsupported_xblocks = True
+        self.templates = get_component_templates(self.course)
+        done_template = self.get_template(self.get_templates_of_type("advanced"), "Completion")
+        self.assertEqual(done_template.get("category"), "done")  # noqa: PT009
+        self.assertEqual(done_template.get("support_level"), "us")  # noqa: PT009
+
+    def test_advanced_by_default_components_not_offered_to_libraries(self):
+        """
+        Test that xblocks which are advanced by default are not offered to libraries, which do not
+        support advanced components at all.
+        """
+        XBlockStudioConfiguration.objects.create(
+            name="done", enabled=True, support_level="fs", advanced_by_default=True
+        )
+        library = LibraryFactory.create()
+        self.templates = get_component_templates(library, library=True)
+        self.assertIsNone(self.get_templates_of_type("advanced"))  # noqa: PT009
+
     def test_deprecated_no_advance_component_button(self):
         """
         Test that there will be no `Advanced` button on unit page if xblocks have disabled

--- a/common/djangoapps/xblock_django/admin.py
+++ b/common/djangoapps/xblock_django/admin.py
@@ -58,6 +58,15 @@ class XBlockStudioConfigurationAdmin(KeyedConfigurationModelAdmin):
             ),
             'fields': ('support_level',)
         }),
+        ('Enable in All Courses', {
+            'description': _(
+                "XBlocks that are advanced by default are offered in the Advanced component list of every course, "
+                "so that course teams do not have to add them to each course's Advanced Module List. The XBlock "
+                "must also be enabled above and in XBlockConfiguration, and, if XBlockStudioConfigurationFlag is "
+                "enabled, have a support level which allows course authors to create it."
+            ),
+            'fields': ('advanced_by_default',)
+        }),
     )
 
 

--- a/common/djangoapps/xblock_django/api.py
+++ b/common/djangoapps/xblock_django/api.py
@@ -7,6 +7,7 @@ from common.djangoapps.xblock_django.models import XBlockConfiguration, XBlockSt
 from openedx.core.lib.cache_utils import CacheInvalidationManager
 
 cacher = CacheInvalidationManager(model=XBlockConfiguration)
+studio_config_cacher = CacheInvalidationManager(model=XBlockStudioConfiguration)
 
 
 @cacher
@@ -25,6 +26,21 @@ def disabled_xblocks():
     Note that this method is independent of `XBlockStudioConfigurationFlag` and `XBlockStudioConfiguration`.
     """
     return XBlockConfiguration.objects.current_set().filter(enabled=False)
+
+
+@studio_config_cacher
+def default_advanced_xblocks():
+    """
+    Return the QuerySet of XBlock types which operators have marked as advanced by default, meaning that
+    Studio offers them in the Advanced component list of every course, without course teams having to add
+    them to the course's Advanced Module List.
+
+    Note that this method is independent of `XBlockStudioConfigurationFlag`: the flag governs whether support
+    levels are enforced, not whether an operator has opted an XBlock into every course. It does not take into
+    account fully disabled xblocks (as returned by `disabled_xblocks`) or deprecated xblocks (as returned by
+    `deprecated_xblocks`); callers are expected to filter those out, as `get_component_templates` does.
+    """
+    return XBlockStudioConfiguration.objects.current_set().filter(enabled=True, advanced_by_default=True)
 
 
 def authorable_xblocks(allow_unsupported=False, name=None):

--- a/common/djangoapps/xblock_django/migrations/0005_xblockstudioconfiguration_advanced_by_default.py
+++ b/common/djangoapps/xblock_django/migrations/0005_xblockstudioconfiguration_advanced_by_default.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('xblock_django', '0004_delete_xblock_disable_config'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='xblockstudioconfiguration',
+            name='advanced_by_default',
+            field=models.BooleanField(default=False, help_text="Offer this XBlock in the Advanced component list of every course, without course teams having to add it to the course's Advanced Module List. Has no effect on XBlocks that are already offered as basic components."),
+        ),
+    ]

--- a/common/djangoapps/xblock_django/models.py
+++ b/common/djangoapps/xblock_django/models.py
@@ -71,11 +71,19 @@ class XBlockStudioConfiguration(ConfigurationModel):
     name = models.CharField(max_length=255, null=False, db_index=True)
     template = models.CharField(max_length=255, blank=True, default='')
     support_level = models.CharField(max_length=2, choices=SUPPORT_CHOICES, default=UNSUPPORTED)
+    advanced_by_default = models.BooleanField(
+        default=False,
+        help_text=_(
+            "Offer this XBlock in the Advanced component list of every course, without course teams having to "
+            "add it to the course's Advanced Module List. Has no effect on XBlocks that are already offered as "
+            "basic components."
+        )
+    )
 
     class Meta:
         app_label = "xblock_django"
 
     def __str__(self):
         return (  # noqa: UP032
-            "XBlockStudioConfiguration(name={}, template={}, enabled={}, support_level={})"
-        ).format(self.name, self.template, self.enabled, self.support_level)
+            "XBlockStudioConfiguration(name={}, template={}, enabled={}, support_level={}, advanced_by_default={})"
+        ).format(self.name, self.template, self.enabled, self.support_level, self.advanced_by_default)

--- a/common/djangoapps/xblock_django/tests/test_api.py
+++ b/common/djangoapps/xblock_django/tests/test_api.py
@@ -1,7 +1,12 @@
 """
 Tests related to XBlock support API.
 """
-from common.djangoapps.xblock_django.api import authorable_xblocks, deprecated_xblocks, disabled_xblocks
+from common.djangoapps.xblock_django.api import (
+    authorable_xblocks,
+    default_advanced_xblocks,
+    deprecated_xblocks,
+    disabled_xblocks,
+)
 from common.djangoapps.xblock_django.models import (  # pylint: disable=line-too-long
     XBlockConfiguration,
     XBlockStudioConfiguration,
@@ -64,6 +69,50 @@ class XBlockSupportTestCase(CacheIsolationTestCase):
 
         disabled_xblock_names = [block.name for block in disabled_xblocks()]
         self.assertCountEqual(["survey", "poll"], disabled_xblock_names)  # noqa: PT009
+
+    def test_default_advanced_blocks(self):
+        """ Tests the default_advanced_xblocks method """
+
+        # None of the xblocks configured in setUp are advanced by default.
+        assert [] == [block.name for block in default_advanced_xblocks()]
+
+        XBlockStudioConfiguration(
+            name="done", template="", enabled=True, support_level=XBlockStudioConfiguration.FULL_SUPPORT,
+            advanced_by_default=True
+        ).save()
+        # Note that support level is not taken into account: it is enforced by Studio (and only when
+        # XBlockStudioConfigurationFlag is enabled), not by this method.
+        XBlockStudioConfiguration(
+            name="split_module", template="", enabled=True, support_level=XBlockStudioConfiguration.UNSUPPORTED,
+            advanced_by_default=True
+        ).save()
+        default_advanced_xblock_names = [block.name for block in default_advanced_xblocks()]
+        self.assertCountEqual(["done", "split_module"], default_advanced_xblock_names)  # noqa: PT009
+
+        # An xblock which is disabled in XBlockStudioConfiguration cannot be created in Studio at all,
+        # so it is not advanced by default either.
+        XBlockStudioConfiguration(
+            name="done", template="", enabled=False, support_level=XBlockStudioConfiguration.FULL_SUPPORT,
+            advanced_by_default=True
+        ).save()
+        default_advanced_xblock_names = [block.name for block in default_advanced_xblocks()]
+        self.assertCountEqual(["split_module"], default_advanced_xblock_names)  # noqa: PT009
+
+    def test_default_advanced_blocks_ignores_studio_configuration_flag(self):
+        """
+        Tests that default_advanced_xblocks is independent of XBlockStudioConfigurationFlag, which governs
+        whether support levels are enforced rather than whether an operator has opted an xblock into all courses.
+        """
+        XBlockStudioConfiguration(
+            name="done", template="", enabled=True, support_level=XBlockStudioConfiguration.FULL_SUPPORT,
+            advanced_by_default=True
+        ).save()
+
+        assert not XBlockStudioConfigurationFlag.is_enabled()
+        assert ["done"] == [block.name for block in default_advanced_xblocks()]
+
+        XBlockStudioConfigurationFlag(enabled=True).save()
+        assert ["done"] == [block.name for block in default_advanced_xblocks()]
 
     def test_authorable_blocks_empty_model(self):
         """


### PR DESCRIPTION
## Description

Adds an `advanced_by_default` flag to `XBlockStudioConfiguration`, so an **operator** can offer an XBlock in
the **Advanced** component list of every course from Django admin — without **course authors** adding it to
each course's Advanced Module List, and without operators forking the platform.

### The problem

Studio decides which XBlocks appear under "Advanced" in a unit from two sources:

1. `courselike.advanced_modules` — the course's own Advanced Module List, edited per course in Studio's
   Advanced Settings.
2. `DEFAULT_ADVANCED_MODULES` in `cms/djangoapps/contentstore/views/component.py` — a hardcoded list added
   to every course by #36532.

Neither helps an operator who installs an XBlock for their whole site. Option 1 means every course team
repeats the same manual step for every new course, forever, and forgetting it is silent — the block just
isn't there. Option 2 is a Python constant, so the only way in is a fork of `component.py` or a monkey-patch
from a plugin.

This is one of the most repeated operator questions in the community, over several named releases:

- [Set default advanced modules list for courses](https://discuss.openedx.org/t/set-default-advanced-modules-list-for-courses/16614)
- [Configuring platform wide default advanced settings for new courses?](https://discuss.openedx.org/t/configuring-platform-wide-default-advanced-settings-for-new-courses/19179)
- [Set default advanced modules list in Open edX tutor Palm](https://discuss.openedx.org/t/set-default-advanced-modules-list-in-open-edx-tutor-palm/11810)
- [What is the preferred method to add advanced modules to all new courses?](https://discuss.openedx.org/t/what-is-the-preferred-method-to-add-advanced-modules-to-all-new-courses/5153)

### The change

`get_component_templates` already unions the course's `advanced_modules` with `DEFAULT_ADVANCED_MODULES`.
This adds the XBlocks the operator has flagged to that union. Everything downstream is untouched: the keys
still pass through `_advanced_component_types`, so `XBlockConfiguration` (fully disabled XBlocks), Studio
support levels, and the filtering of XBlocks already offered as basic components all continue to apply.

Both legacy Studio and the Authoring MFE build their component menu from `get_component_templates` (the MFE
via `get_container_handler_context`), so no frontend change is needed.

**Impacted roles:** Operators (new Django admin field); Course Authors (flagged XBlocks appear under Advanced
with no per-course setup). No learner-facing change.

**Backwards compatible:** the field defaults to `False`, so with an untouched table the behaviour of
`get_component_templates` is identical to before.

## Why it is shaped this way

**Why not a Django setting.** That was the original shape of `DEFAULT_ADVANCED_MODULES` in #36532, and it was
[moved out of `cms/envs/common.py` during review](https://github.com/openedx/openedx-platform/pull/36532):

> After speaking w/Kyle and Ed, we've come to the conclusion that this should not be a setting in `common.py`.
> That implies that it can be overridden by the end-user which creates a new interface we don't want. […]
> In the future we can figure out what configurable modifiable version of settings we want to expose to
> operators but for now just make it so this is visible on all deployments by adding it into the software
> instead in the settings file here.

This PR is that deferred follow-up, and it intentionally does not reopen the settings question.

**Why `XBlockStudioConfiguration`.** It was named in the same review thread as the place this belongs:

> In Studio's django configuration there is an xblocks table […] If we were to extend / improve this area of
> the platform configuration it would keep the "advanced" vs "common" configuration out of the code and in
> django where it is more easily modifiable.

It is also already the source of truth for "may course authors create this XBlock in Studio", with an admin
UI operators know. Introducing a separate model or setting would create a second answer to the same question.

**Why it does not consult `XBlockStudioConfigurationFlag`.** That flag governs whether *support levels* are
enforced, and it is disabled on most installs — reading the new field behind it would make the feature a
no-op almost everywhere. `disabled_xblocks()` is flag-independent for the same reason. Support levels are
still enforced downstream when the flag is on: an *Unsupported* XBlock flagged advanced-by-default is only
offered to courses that opted in to unsupported XBlocks, which is covered by a test.

**Why nothing is written to course policy.** An alternative design is to seed `advanced_modules` into each
course at creation time. That was rejected here because it does not help the courses that already exist, it
copies the same operator decision into every course's policy where it must then be un-set one by one, and it
would behave differently from `DEFAULT_ADVANCED_MODULES`. Like that list, these XBlocks are offered to
courses without appearing in any course's own Advanced Module List, so consumers of `course.advanced_modules`
are unaffected.

**Why `DEFAULT_ADVANCED_MODULES` is left alone.** The hardcoded list is the platform's own product decision
about what every site ships with; this PR only adds a second, operator-owned input to the same union.

## Supporting information

- #36532 — introduced `DEFAULT_ADVANCED_MODULES` and deferred the operator-configurable version.
- Forum threads linked in the Description above.

## Testing instructions

1. In Studio's Django admin, go to **Xblock django → Xblock studio configurations** and add a configuration
   for an installed XBlock that is not in `DEFAULT_ADVANCED_MODULES` (e.g. `done`, or any XBlock you have
   installed): set **Name**, leave **Template** empty, tick **Enabled**, set **Support level** to
   *Fully Supported*, and tick **Advanced by default**.
2. Open any course in Studio — including one created before step 1 — and open a unit.
3. Click **Add New Component** → the XBlock now appears under **Advanced**, even though the course's Advanced
   Module List (Settings → Advanced Settings) does not include it.
4. Untick **Advanced by default** (or **Enabled**) and reload the unit → it is gone again.
5. Check the escape hatches: disabling the XBlock in **Xblock configurations** removes it; and with
   `XBlockStudioConfigurationFlag` enabled, an *Unsupported* XBlock is only offered to courses that allow
   unsupported XBlocks.

Automated tests:

- `common/djangoapps/xblock_django/tests/test_api.py` — `default_advanced_xblocks` returns flagged, enabled
  rows only, ignores support level, and is unaffected by `XBlockStudioConfigurationFlag`.
- `cms/djangoapps/contentstore/views/tests/test_block.py` — a flagged XBlock appears in a course's Advanced
  list without the course listing it, is not duplicated when the course does list it, is removed by
  `XBlockConfiguration`, honors support levels when `XBlockStudioConfigurationFlag` is on, and is not offered
  to libraries.

## Deadline

None.

## Other information

- **Migration:** a single additive `AddField` with a default; safely reversible. Verified by applying both
  LMS and CMS migrations to an empty MySQL database, and by `makemigrations --check`.
- **Caching:** the query is cached with `CacheInvalidationManager` and invalidated on save/delete of
  `XBlockStudioConfiguration`, matching `deprecated_xblocks` / `disabled_xblocks`.
- **Possible follow-up (deliberately out of scope):** a management command so distributions can seed these
  rows during init without shelling into Django. Left out to keep this change minimal.
