### PR TITLE
feat: allow search by display number for courses (#38963) Backport

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
+++ b/cms/djangoapps/contentstore/rest_api/v2/views/tests/test_home.py
@@ -189,6 +189,22 @@ class HomePageCoursesViewV2Test(CourseTestCase):
         ])])
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
 
+    def test_search_query_matches_display_number(self):
+        """Search must match course display number values."""
+        course_key = self.store.make_course_key("search-org", "opaque-number", "run")
+        searchable_course = CourseOverviewFactory.create(
+            id=course_key,
+            org=course_key.org,
+            display_name="Unrelated Title",
+            display_number_with_default="Friendly Number 42",
+        )
+
+        response = self.client.get(self.api_v2_url, {"search": "Friendly Number"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["results"]["courses"]) == 1
+        assert response.data["results"]["courses"][0]["course_key"] == str(searchable_course.id)
+
     def test_order_query_if_passed(self):
         """Get list of courses when order filter passed as a query param.
 

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -727,6 +727,7 @@ class CourseOverview(TimeStampedModel):
         """
         return course_overviews.filter(
             Q(display_name__icontains=query) |
+            Q(display_number_with_default__icontains=query) |
             Q(org__icontains=query) |
             Q(id__icontains=query)
         )


### PR DESCRIPTION
## Description
Recently was fixed the issue to correctly add course display number on https://github.com/openedx/openedx-platform/pull/38899, but we also find out that the ability to search on the main course search bar by display number was missing, so we added it back

## Supporting information
Backports https://github.com/openedx/openedx-platform/pull/38963