### PR TITLE
build: Drop the py2neo constraint.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -77,14 +77,6 @@ openai<=0.28.1
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35267
 path<16.12.0
 
-# Date: 2021-08-25
-# At the time of writing this comment, we do not know whether py2neo>=2022
-# will support our currently-deployed Neo4j version (3.5).
-# Feel free to loosen this constraint if/when it is confirmed that a later
-# version of py2neo will work with Neo4j 3.5.
-# Issue for unpinning: https://github.com/openedx/edx-platform/issues/35266
-py2neo<2022
-
 # Date: 2020-04-08
 # Adding pin to avoid any major upgrade
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/35265


### PR DESCRIPTION
We don't depend on this library anymore so we have no need to constrain
it.

Closes https://github.com/openedx/openedx-platform/issues/35266
