### PR TITLE
fix: swagger docs at /api-docs/ weren't loading due to ref_name conflict

### DIFF
--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -150,6 +150,7 @@ class CourseEnrollmentSerializer(serializers.ModelSerializer):
         model = CourseEnrollment
         fields = ('audit_access_expires', 'created', 'mode', 'is_active', 'course', 'certificate', 'course_modes')
         lookup_field = 'username'
+        ref_name = "MobileCourseEnrollment"  # Explicit ref_name to help avoid conflicts with other similar serializers
 
 
 class CourseEnrollmentSerializerv05(CourseEnrollmentSerializer):

--- a/openedx/core/djangoapps/enrollments/serializers.py
+++ b/openedx/core/djangoapps/enrollments/serializers.py
@@ -87,6 +87,7 @@ class CourseEnrollmentSerializer(serializers.ModelSerializer):
         model = CourseEnrollment
         fields = ("created", "mode", "is_active", "course_details", "user")
         lookup_field = "username"
+        ref_name = "CourseEnrollment"  # Explicit ref_name to help avoid conflicts with other similar serializers
 
 
 class CourseEnrollmentsApiListSerializer(CourseEnrollmentSerializer):


### PR DESCRIPTION
## Description

The REST API docs site at http://local.openedx.io:8000/api-docs/ wasn't working on my devstack:

<img width="1083" height="406" alt="swagger-error" src="https://github.com/user-attachments/assets/c23c58c6-d2a6-4d44-9839-adf3fbe0b0ce" />

```
[14/Aug/2026 22:23:45] "GET /api-docs/?format=openapi HTTP/1.1" 500 474011
...
  File "/openedx/venv/lib/python3.12/site-packages/drf_yasg/inspectors/field.py", line 167, in field_to_swagger_object
    raise SwaggerGenerationError(
drf_yasg.errors.SwaggerGenerationError: Schema for <class 'openedx.core.djangoapps.enrollments.serializers.CourseEnrollmentSerializer'> would override distinct serializer <class 'lms.djangoapps.mobile_api.users.serializers.CourseEnrollmentSerializer'> because they implicitly share the same ref_name; explicitly set the ref_name attribute on both serializers' Meta classes
```

## Cause

I believe the bug was introduced in https://github.com/openedx/openedx-platform/pull/38724 .

drf-yasg derives an implicit `ref_name` by stripping the `Serializer` suffix from the class name. Both of these resolve to `CourseEnrollment`:

- `openedx/core/djangoapps/enrollments/serializers.py:71`
- `lms/djangoapps/mobile_api/users/serializers.py:98`

That name collision has existed for years and was harmless, because drf-yasg only introspects a serializer that a view actually exposes via `serializer_class` / `get_serializer_class()`. Only the mobile one was reachable that way — through `UserCourseEnrollmentsList` (`lms/djangoapps/mobile_api/users/views.py:372`), a `ListAPIView`.

The enrollments one was never a `serializer_class`: every v1 view in `openedx/core/djangoapps/enrollments/views.py` is a plain `APIView` (invisible to drf-yasg's serializer introspection), and the one `ListAPIView` there uses the *subclass* `CourseEnrollmentsApiListSerializer` → ref_name `CourseEnrollmentsApiList`, which doesn't collide.

[The mention PR](https://github.com/openedx/openedx-platform/pull/38724) added the new `openedx/core/djangoapps/enrollments/v2/` app and mounted it unconditionally at `lms/urls.py:121` (no waffle flag). Two of its views set the enrollments serializer as a first-class `serializer_class`:

- `EnrollmentViewSet` — `openedx/core/djangoapps/enrollments/v2/views.py:229`
- `EnrollmentRetrieveView` — `openedx/core/djangoapps/enrollments/v2/views.py:441`

Now, both `CourseEnrollment` ref_names land in the same generated schema, and drf-yasg raises the error.

## Supporting information

n/a

## Testing instructions

Go to http://local.openedx.io:8000/api-docs/ before and after this commit.

https://sandbox.opencraft.com/api-docs/ is our sandbox tracking master, and you can observe the error there ("before" case).
