### PR TITLE
fix: restore add-component buttons for content experiment groups

### DIFF
--- a/cms/static/js/spec/views/pages/container_spec.js
+++ b/cms/static/js/spec/views/pages/container_spec.js
@@ -160,6 +160,21 @@ function parameterized_suite(label, globalPageOptions) {
             });
         });
 
+        describe('Add component buttons when embedded in the authoring MFE', function() {
+            it('removes the buttons for a unit, since the MFE renders its own', function() {
+                renderContainerPage(this, mockContainerXBlockHtml, {isIframeEmbed: true});
+                expect(containerPage.$('.add-xblock-component').length).toBe(0);
+            });
+
+            it('keeps the buttons for a content experiment, where the MFE renders none', function() {
+                model.set('category', 'split_test');
+                renderContainerPage(this, mockContainerXBlockHtml, {isIframeEmbed: true});
+                // One panel per experiment group, each with its own component buttons.
+                expect(containerPage.$('.add-xblock-component').length).toBe(2);
+                expect(containerPage.$('.add-xblock-component-button').length).toBeGreaterThan(0);
+            });
+        });
+
         describe('Editing the container', function() {
             var updatedDisplayName = 'Updated Test Container',
                 getDisplayNameWrapper;

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -313,10 +313,13 @@ function($, _, Backbone, gettext, BasePage,
 
         renderAddXBlockComponents: function() {
             var self = this;
-            // When rendered inside the authoring MFE iframe, add buttons are always rendered
-            // natively by the MFE (for every container type, not just verticals), so the
-            // legacy add-button widgets must never be initialised here.
-            if (self.options.canEdit && !self.options.isIframeEmbed) {
+            // When rendered inside the authoring MFE iframe, add buttons are normally rendered
+            // natively by the MFE, so the legacy add-button widgets must not be initialised here.
+            // Content experiments (split_test) are the exception: the MFE renders no add buttons
+            // for them, because each group needs its own set of buttons next to its children,
+            // which only this page can place. The rest of that flow is already iframe-aware --
+            // see the split_test branches in createComponent() and in add_xblock.js.
+            if (self.options.canEdit && (!self.options.isIframeEmbed || self.isSplitTestContentPage)) {
                 this.$('.add-xblock-component').each(function(index, element) {
                     var component = new AddXBlockComponent({
                         el: element,


### PR DESCRIPTION
## Description

Content experiments (`split_test`) render no **Add New Component** panels in the authoring MFE, so Course Authors cannot add content to experiment groups at all. Regression from #38636, which narrowed the guard in `renderAddXBlockComponents()` to `canEdit && !isIframeEmbed` — correct for units and problem banks, which the MFE renders natively, but the MFE renders no add buttons for split_test (`AddComponent` only renders its button list for unit verticals). Each group needs its own panel beside its own children, which only the container page can place.

This restores `isSplitTestContentPage` to the guard, as it was before `3c5cc6fffd`. Deliberately narrower than reverting to `!model.isVertical()`, so problem banks stay on MFE-native rendering.

The rest of the flow was already iframe-aware and dead since the regression: `createComponent()` posts `addNewComponent`/`hideProcessingNotification` to the parent for split_test, `add_xblock.js` keeps template menus in the iframe when the parent is split_test, and frontend-app-authoring already handles both messages. Nothing changes server-side — the vertical author view always renders group children with `can_add=True`, so the panels were in the fragment and only JS removed them. **No frontend-app-authoring change is required.**

| Before | After |
|---|---|
| <img width="2880" height="2080" alt="split-test-before" src="https://github.com/user-attachments/assets/5739758b-95c8-4a6a-b3b0-5069ba9d5042" /> |<img width="2880" height="2080" alt="split-test-after" src="https://github.com/user-attachments/assets/c067ccf5-593b-4248-882d-b9ce6d5c0384" />  |

## Supporting information

- Regressed by #38636; guard last correct in `3c5cc6fffd`
- Expected behaviour: [managing content experiments](https://docs.openedx.org/en/latest/educators/how-tos/advanced_features/manage_content_experiments.html#create-content-for-groups-in-the-content-experiment)
- Related: #35261 (legacy unit editor removal)

## Testing instructions

Requires the new unit page (`legacy_studio.unit_editor` disabled — the default) and an asset rebuild, since `container.js` is bundled into the `js/factories/container` webpack entry:

```
npm run build-dev     # or `npm run webpack-dev`; Tutor: tutor dev exec cms npm run webpack-dev
```

Set up an experiment, if the course has none:

1. **Settings → Advanced Settings** → add `"split_test"` to *Advanced Module List*.
2. **Settings → Group Configurations** → create an *Experiment Group Configuration* with two groups.
3. In a unit: **Add Component → Advanced → Content Experiment**.

Verify the fix:

4. From the unit page, click into the Content Experiment to reach `/course/<course-id>/container/<split_test-id>/<subsection-id>`.
5. Each group shows an **Add New Component** panel. *(Before this change: no panels.)*
6. Click **Text** in Group A, pick a template → the MFE shows its "Adding…" spinner and the component appears **inside Group A**. Repeat in Group B and confirm it lands in B. Reload; both persist.
7. Click **Problem** → the template submenu renders inside the iframe, not as an MFE modal.
8. With v2 libraries enabled, **Library Content** → the picker opens as an MFE modal over the iframe.

Verify nothing else changed:

9. A normal unit → only the MFE's native add row; no duplicate legacy buttons in the iframe.
10. A Problem Bank container page → still MFE-native buttons only.
11. The legacy container page, `/container/<split_test-id>` → unchanged (never took the regressed branch).

Note on hard-refreshing: the iframe is a separate cross-origin document and dev builds emit an unhashed `container.js`, so reload the frame itself or use "Disable cache" — a hard reload of the outer page can leave the old bundle in place.

Automated tests: adds two specs to `container_spec.js` covering both branches. **They have not been executed** — `karma_cms_webpack.conf.js` fails to start (`ENOENT ... main_webpack.<hash>.js`, #35956) and `npm run test-karma` skips that suite for the same reason. Verification was manual in Chrome, both directions: regressed bundle → 0 panels / 0 buttons; fixed → 2 panels / 16 buttons; adding a component writes it under the clicked group in the modulestore.

## Deadline

None

## Other information

No dependent PRs, no MFE change, no migrations, no new settings. Limitation: this keeps the legacy per-group add widgets alive for content experiments; removing the legacy unit editor (#35261) will need per-group add UI rendered natively by the MFE.
