### PR TITLE
refactor: complete FEATURES-as-dict migration for callers missed via indirection

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -77,7 +77,7 @@ class SearchIndexerBase(metaclass=ABCMeta):
         """
         Checks to see if the indexing feature is enabled
         """
-        return settings.FEATURES.get(cls.ENABLE_INDEXING_KEY, False)
+        return getattr(settings, cls.ENABLE_INDEXING_KEY, False)
 
     @classmethod
     @abstractmethod

--- a/cms/djangoapps/contentstore/rest_api/v3/views/home.py
+++ b/cms/djangoapps/contentstore/rest_api/v3/views/home.py
@@ -122,7 +122,7 @@ class HomeViewSet(StandardizedErrorMixin, viewsets.ViewSet):
             ),
             'studio_name': settings.STUDIO_NAME,
             'studio_short_name': settings.STUDIO_SHORT_NAME,
-            'studio_request_email': settings.FEATURES.get('STUDIO_REQUEST_EMAIL', ''),
+            'studio_request_email': settings.STUDIO_REQUEST_EMAIL,
             'tech_support_email': settings.TECH_SUPPORT_EMAIL,
             'platform_name': settings.PLATFORM_NAME,
             'user_is_active': request.user.is_active,

--- a/lms/djangoapps/program_enrollments/rest_api/v1/constants.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/constants.py
@@ -12,10 +12,6 @@ MAX_ENROLLMENT_RECORDS = 25
 # The name of the key that identifies students for POST/PATCH requests
 REQUEST_STUDENT_KEY = 'student_key'
 
-# This flag should only be enabled on sandboxes.
-# It enables the endpoint that wipes all program enrollments.
-ENABLE_ENROLLMENT_RESET_FLAG = 'ENABLE_ENROLLMENT_RESET'
-
 
 class CourseRunProgressStatuses:
     """

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -9,7 +9,6 @@ from unittest import mock
 from uuid import UUID, uuid4
 
 import ddt
-from django.conf import settings
 from django.core.cache import cache
 from django.test import override_settings
 from django.urls import reverse
@@ -61,7 +60,6 @@ from xmodule.modulestore.tests.factories import CourseFactory as ModulestoreCour
 
 from .. import views
 from ..constants import (
-    ENABLE_ENROLLMENT_RESET_FLAG,
     MAX_ENROLLMENT_RECORDS,
     REQUEST_STUDENT_KEY,
     CourseRunProgressStatuses,
@@ -2358,9 +2356,6 @@ class UserProgramCourseEnrollmentViewGetTests(ProgramCourseEnrollmentOverviewGet
 class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
     """ Tests endpoint for resetting enrollments in integration environments """
 
-    FEATURES_WITH_ENABLED = settings.FEATURES.copy()
-    FEATURES_WITH_ENABLED[ENABLE_ENROLLMENT_RESET_FLAG] = True
-
     reset_enrollments_cmd = 'reset_enrollment_data'
     reset_users_cmd = 'remove_social_auth_users'
 
@@ -2395,7 +2390,7 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
         assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
         mock_call_command.assert_has_calls([])
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     @patch_call_command
     def test_403_for_non_staff(self, mock_call_command):
         student = UserFactory.create(username='student', password='password')
@@ -2404,7 +2399,7 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
         assert response.status_code == status.HTTP_403_FORBIDDEN
         mock_call_command.assert_has_calls([])
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     @patch_call_command
     def test_reset(self, mock_call_command):
         programs = [str(uuid4()), str(uuid4())]
@@ -2417,7 +2412,7 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
             mock.call(self.reset_enrollments_cmd, ','.join(programs), force=True),
         ])
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     @patch_call_command
     def test_reset_with_multiple_idp(self, mock_call_command):
         programs = [str(uuid4()), str(uuid4())]
@@ -2436,7 +2431,7 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
             mock.call(self.reset_enrollments_cmd, ','.join(programs), force=True),
         ])
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     @patch_call_command
     def test_reset_without_idp(self, mock_call_command):
         organization = LMSOrganizationFactory()
@@ -2449,14 +2444,14 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
             mock.call(self.reset_enrollments_cmd, ','.join(programs), force=True),
         ])
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     @patch_call_command
     def test_organization_not_found(self, mock_call_command):
         response = self.request('yyz')
         assert response.status_code == status.HTTP_404_NOT_FOUND
         mock_call_command.assert_has_calls([])
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     @patch_call_command
     def test_no_programs_doesnt_break(self, mock_call_command):
         programs = []
@@ -2468,7 +2463,7 @@ class EnrollmentDataResetViewTests(ProgramCacheMixin, APITestCase):
             mock.call(self.reset_users_cmd, self.provider.slug, force=True),
         ])
 
-    @override_settings(FEATURES=FEATURES_WITH_ENABLED)
+    @override_settings(ENABLE_ENROLLMENT_RESET=True)
     @patch_call_command
     def test_missing_body_content(self, mock_call_command):
         response = self.client.post(

--- a/lms/djangoapps/program_enrollments/rest_api/v1/views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/views.py
@@ -45,7 +45,7 @@ from openedx.core.djangoapps.catalog.utils import (
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, PaginatedAPIView
 
-from .constants import ENABLE_ENROLLMENT_RESET_FLAG, MAX_ENROLLMENT_RECORDS
+from .constants import MAX_ENROLLMENT_RECORDS
 from .serializers import (
     CourseRunOverviewListSerializer,
     CourseRunOverviewSerializer,
@@ -980,7 +980,7 @@ class EnrollmentDataResetView(APIView):
         """
         Reset enrollment and user data for organization
         """
-        if not settings.FEATURES.get(ENABLE_ENROLLMENT_RESET_FLAG):
+        if not settings.ENABLE_ENROLLMENT_RESET:
             return Response('reset not enabled on this environment', status.HTTP_501_NOT_IMPLEMENTED)
 
         try:

--- a/lms/djangoapps/teams/search_indexes.py
+++ b/lms/djangoapps/teams/search_indexes.py
@@ -131,7 +131,7 @@ class CourseTeamIndexer:
         """
         Return boolean of whether course team indexing is enabled.
         """
-        return settings.FEATURES.get(cls.ENABLE_SEARCH_KEY, False)
+        return getattr(settings, cls.ENABLE_SEARCH_KEY, False)
 
 
 @receiver(post_save, sender=CourseTeam, dispatch_uid='teams.signals.course_team_post_save_callback')


### PR DESCRIPTION
Completes migrations that shipped incomplete in earlier merged batches. Each of these readers accessed its flag through **indirection** — a named constant or a per-subclass class attribute — so the flag name never appeared as a quoted literal at the call site, and the reference greps used in the original batches (which key on the quoted name) never matched them. The `FeaturesProxy` bridge routed `FEATURES.get('X')` to the flat `settings.X`, so the readers kept working and CI stayed green — masking the miss.

This surfaced during a full audit of what's left before the bridge/`FEATURES` dict can be deleted.

## Flags (one commit each)

- **ENABLE_ENROLLMENT_RESET** — `program_enrollments/rest_api/v1/views.py` read it via `settings.FEATURES.get(ENABLE_ENROLLMENT_RESET_FLAG)` (constant from `constants.py`). Migrated to bare `settings.ENABLE_ENROLLMENT_RESET`; converted the test's whole-dict `@override_settings(FEATURES=...)` to `@override_settings(ENABLE_ENROLLMENT_RESET=True)`; dropped the now-dead constant. (Missed by #38903.)
- **ENABLE_COURSEWARE_INDEX / ENABLE_LIBRARY_INDEX** — `SearchIndexerBase.indexing_is_enabled()` read `settings.FEATURES.get(cls.ENABLE_INDEXING_KEY, False)`. Migrated to `getattr(settings, cls.ENABLE_INDEXING_KEY, False)`. (COURSEWARE_INDEX missed by #38904; LIBRARY_INDEX never picked up.)
- **ENABLE_TEAMS** — `TeamsSearchIndexer.search_is_enabled()` read `settings.FEATURES.get(cls.ENABLE_SEARCH_KEY, False)`. Migrated to `getattr(settings, cls.ENABLE_SEARCH_KEY, False)`.
- **STUDIO_REQUEST_EMAIL** — the v3 studio-home view still read `settings.FEATURES.get('STUDIO_REQUEST_EMAIL', '')` (a plain duplicate-view miss; the v1 view and `course_creators/admin.py` were already migrated). Migrated to `settings.STUDIO_REQUEST_EMAIL`.

Each flag already had a flat definition in the appropriate `envs/common.py`, and the existing tests exercise the enabled/disabled paths via flat settings (verified locally).