### PR TITLE
refactor: migrate remaining FEATURES-as-dict flags (batch 12)

### DIFF
--- a/common/djangoapps/util/file.py
+++ b/common/djangoapps/util/file.py
@@ -115,9 +115,8 @@ def course_filename_prefix_generator(course_id, separator='_'):
         course_id.run
     ])
 
-    enable_course_filename_ccx_suffix = settings.FEATURES.get(
-        'ENABLE_COURSE_FILENAME_CCX_SUFFIX',
-        False
+    enable_course_filename_ccx_suffix = getattr(
+        settings, 'ENABLE_COURSE_FILENAME_CCX_SUFFIX', False
     )
 
     if enable_course_filename_ccx_suffix and getattr(course_id, 'ccx', None):

--- a/common/djangoapps/util/tests/test_file.py
+++ b/common/djangoapps/util/tests/test_file.py
@@ -56,7 +56,7 @@ class FilenamePrefixGeneratorTestCase(TestCase):
         [CCXLocator.from_course_locator(CourseLocator(org='foo', course='bar', run='baz'), '1'), 'foo_bar_baz_ccx_1'],
     )
     @ddt.unpack
-    @override_settings(FEATURES={'ENABLE_COURSE_FILENAME_CCX_SUFFIX': True})
+    @override_settings(ENABLE_COURSE_FILENAME_CCX_SUFFIX=True)
     def test_include_ccx_id(self, course_key, expected_filename):
         """
         Test filename prefix genaration from multiple course key formats.
@@ -82,7 +82,7 @@ class FilenamePrefixGeneratorTestCase(TestCase):
         [CCXLocator.from_course_locator(CourseLocator(org='foo', course='bar', run='baz'), '1'), 'foo-bar-baz-ccx-1'],
     )
     @ddt.unpack
-    @override_settings(FEATURES={'ENABLE_COURSE_FILENAME_CCX_SUFFIX': True})
+    @override_settings(ENABLE_COURSE_FILENAME_CCX_SUFFIX=True)
     def test_custom_separator_including_ccx_id(self, course_key, expected_filename):
         """
         Test filename prefix is generated with a custom separator.

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -182,7 +182,7 @@ class SendEmailWithMockedUgettextMixin:
         return mail.outbox[0]
 
 
-@patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
+@override_settings(ENABLE_INSTRUCTOR_EMAIL=True, REQUIRE_COURSE_EMAIL_AUTH=False)
 @ddt.ddt
 class LocalizedFromAddressPlatformLangTestCase(SendEmailWithMockedUgettextMixin, EmailSendFromDashboardTestCase):
     """
@@ -210,7 +210,7 @@ class LocalizedFromAddressPlatformLangTestCase(SendEmailWithMockedUgettextMixin,
             self.assertRegex(message.from_email, f'{language_code.upper()} .* Course Staff')  # noqa: PT009
 
 
-@patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
+@override_settings(ENABLE_INSTRUCTOR_EMAIL=True, REQUIRE_COURSE_EMAIL_AUTH=False)
 @ddt.ddt
 class AceEmailTestCase(SendEmailWithMockedUgettextMixin, EmailSendFromDashboardTestCase):
     """
@@ -268,7 +268,7 @@ class AceEmailTestCase(SendEmailWithMockedUgettextMixin, EmailSendFromDashboardT
         self.assertIn(f'Welcome to {self.course.display_name}', html_message_body)  # noqa: PT009
 
 
-@patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
+@override_settings(ENABLE_INSTRUCTOR_EMAIL=True, REQUIRE_COURSE_EMAIL_AUTH=False)
 @ddt.ddt
 class LocalizedFromAddressCourseLangTestCase(SendEmailWithMockedUgettextMixin, EmailSendFromDashboardTestCase):
     """

--- a/lms/djangoapps/learner_home/test_views.py
+++ b/lms/djangoapps/learner_home/test_views.py
@@ -44,8 +44,6 @@ from openedx.core.djangoapps.site_configuration.tests.factories import SiteFacto
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-ENTERPRISE_ENABLED = "ENABLE_ENTERPRISE_INTEGRATION"
-
 
 @ddt.ddt
 class TestGetPlatformSettings(TestCase):
@@ -573,7 +571,7 @@ class TestDashboardView(BaseTestDashboardView):
 
         return (program, enrollment, entitlement)
 
-    @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
+    @override_settings(ENTERPRISE_ENABLED=False)
     def test_response_structure(self):
         """Basic test for correct response structure"""
 
@@ -600,7 +598,7 @@ class TestDashboardView(BaseTestDashboardView):
 
         assert expected_keys == response_data.keys()
 
-    @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
+    @override_settings(ENTERPRISE_ENABLED=False)
     def test_response_course_advertised_start(self):
         """Basic test for correct response structure"""
 
@@ -629,7 +627,7 @@ class TestDashboardView(BaseTestDashboardView):
             assert "advertisedStart" in course_run
             assert course_run["advertisedStart"] == advertised_start
 
-    @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
+    @override_settings(ENTERPRISE_ENABLED=False)
     @patch("lms.djangoapps.learner_home.views.get_user_account_confirmation_info")
     def test_email_confirmation(self, mock_user_conf_info):
         """Test that email confirmation info passes through correctly"""
@@ -658,7 +656,7 @@ class TestDashboardView(BaseTestDashboardView):
             },
         )
 
-    @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
+    @override_settings(ENTERPRISE_ENABLED=False)
     @patch("lms.djangoapps.learner_home.views.cert_info")
     def test_get_cert_statuses(self, mock_get_cert_info):
         """Test that cert information gets loaded correctly"""
@@ -699,7 +697,7 @@ class TestDashboardView(BaseTestDashboardView):
             },
         )
 
-    @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
+    @override_settings(ENTERPRISE_ENABLED=False)
     @patch("lms.djangoapps.learner_home.views.cert_info")
     def test_get_cert_statuses_exception(self, mock_get_cert_info):
         """Test that cert information gets loaded correctly"""
@@ -735,7 +733,7 @@ class TestDashboardView(BaseTestDashboardView):
             response_data["courses"][0]["certificate"], empty_cert_data
         )
 
-    @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
+    @override_settings(ENTERPRISE_ENABLED=False)
     @patch("openedx.core.djangoapps.programs.utils.get_programs")
     def test_get_for_one_of_course_programs(self, mock_get_programs):
         """Test that course programs get loaded correctly"""
@@ -758,7 +756,7 @@ class TestDashboardView(BaseTestDashboardView):
         assert programs[course_uuid][0] == program
         assert len(data) > len(programs)
 
-    @patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)
+    @override_settings(ENTERPRISE_ENABLED=False)
     @patch("openedx.core.djangoapps.programs.utils.get_programs")
     def test_get_multiple_course_programs(self, mock_get_programs):
         """Test that course programs get loaded correctly"""


### PR DESCRIPTION
The tail end of the FEATURES-as-dict migration: the flags the earlier quoted-name picker never surfaced (whole-dict `override_settings(FEATURES={...})`, kwarg-form `patch.dict`, and a `common/`-hosted reader). Found during a full audit of what's left before the `FeaturesProxy` bridge and `FEATURES` dict can be deleted.

## Flags (one commit per flag, except co-located pairs)

- **ENABLE_COURSE_FILENAME_CCX_SUFFIX** — reader in `common/djangoapps/util/file.py`. Setting is LMS-only but the reader is reachable from CMS, so migrated to `getattr(settings, 'ENABLE_COURSE_FILENAME_CCX_SUFFIX', False)`; tests converted from whole-dict `override_settings(FEATURES={...})` to flat. Verified under both `lms.envs.test` and `cms.envs.test`.
- **ENTERPRISE_ENABLED** — seven `@patch.dict(settings.FEATURES, ENTERPRISE_ENABLED=False)` in learner_home tests. This kwarg set a FEATURES key literally named `ENTERPRISE_ENABLED`, which nothing reads (the enterprise dashboard is gated by `ENABLE_ENTERPRISE_INTEGRATION`) — a latent no-op. Converted to the equivalent `@override_settings(ENTERPRISE_ENABLED=False)` and dropped a dead, misleading module constant. Behavior unchanged; a follow-up can decide whether these tests meant `ENABLE_ENTERPRISE_INTEGRATION`.
- **ENABLE_INSTRUCTOR_EMAIL / REQUIRE_COURSE_EMAIL_AUTH** — co-located in three bulk_email test-class decorators. Neither key is read anywhere anymore (bulk email is governed by the `BulkEmailFlag` waffle + `CourseAuthorization` model), so these are vestigial no-ops. Migrated together to `@override_settings(...)`.

Two of these (`ENTERPRISE_ENABLED`, `ENABLE_INSTRUCTOR_EMAIL`/`REQUIRE_COURSE_EMAIL_AUTH`) are no-op test overrides with no reader; they're migrated anyway so the `FEATURES` dict can eventually be deleted. See the per-commit messages for details.