### PR TITLE
chore: bump openedx-authz 1.22.0 → 1.23.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -835,7 +835,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.22.0
+openedx-authz==1.23.0
     # via -r requirements/edx/kernel.in
 openedx-calc==5.0.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1376,7 +1376,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.22.0
+openedx-authz==1.23.0
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1014,7 +1014,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.22.0
+openedx-authz==1.23.0
     # via -r requirements/edx/base.txt
 openedx-calc==5.0.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1053,7 +1053,7 @@ openedx-atlas==0.7.0
     #   enterprise-integrated-channels
     #   openedx-authz
     #   openedx-forum
-openedx-authz==1.22.0
+openedx-authz==1.23.0
     # via -r requirements/edx/base.txt
 openedx-calc==5.0.0
     # via


### PR DESCRIPTION
## Description

Bumps `openedx-authz` from 1.22.0 to 1.23.0 across all requirement files (base, testing, doc, development).

**1.23.0:**
- Added `courses.view_advanced_settings` permission for read-only access to advanced settings.
- Added `courses.view_certificates` permission for read-only access to certificates.
- Added `courses.view_group_configurations` permission for read-only access to group configurations.
- Added `courses.view_library_updates` permission for read-only access to library updates.
- All four view permissions are granted to all four course roles (Admin, Staff, Editor, Auditor).

**User roles impacted:** Course Editor, Course Auditor. These roles will gain the ability to view pages that were previously fully blocked (advanced settings, certificates, group configurations, library updates) once the corresponding enforcement changes land in follow-up PRs.

This PR is purely additive — the new permission constants exist in the library but are not yet consumed by any enforcement point in this repo. No behavior change until follow-up PRs land.

## Supporting information

- [openedx-authz CHANGELOG](https://github.com/openedx/openedx-authz/blob/main/CHANGELOG.rst)
- [openedx-authz PR #385: add view permissions](https://github.com/openedx/openedx-authz/issues/385)

## Testing instructions

1. Verify the platform boots successfully with the new version (`tutor dev start`)
2. Run the authz test suite: `pytest openedx/core/djangoapps/authz/ --no-migrations`
3. Run the contentstore test suite: `pytest cms/djangoapps/contentstore/ --no-migrations` (existing tests should pass unchanged since no enforcement points use the new constants yet)

## Deadline

None — but this unblocks four follow-up PRs that split read/write permission enforcement.

## Other information

- **Depends on:** openedx-authz 1.23.0 being published to PyPI.
- **No migrations** — purely a library version bump.
- **No deprecations** — all changes in 1.23.0 are backwards-compatible additions.
- **Follow-up PRs** (depend on this): enforcement changes for view_advanced_settings, view_certificates, view_group_configurations, and view_library_updates.