### PR TITLE
refactor: migrate leftover FEATURES-as-dict test overrides off the dict

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/git_export.py
+++ b/cms/djangoapps/contentstore/management/commands/git_export.py
@@ -10,7 +10,7 @@ repository before attempting to export the XML, add, and commit changes if
 any have taken place.
 
 This functionality is also available as an export view in studio if the giturl
-attribute is set and the FEATURE['ENABLE_EXPORT_GIT'] is set.
+attribute is set and the ENABLE_EXPORT_GIT setting is enabled.
 """
 
 

--- a/cms/djangoapps/contentstore/management/commands/tests/test_git_export.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_git_export.py
@@ -22,14 +22,11 @@ import cms.djangoapps.contentstore.git_export_utils as git_export_utils
 from cms.djangoapps.contentstore.git_export_utils import GitExportError
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 
-FEATURES_WITH_EXPORT_GIT = settings.FEATURES.copy()
-FEATURES_WITH_EXPORT_GIT['ENABLE_EXPORT_GIT'] = True
 TEST_DATA_CONTENTSTORE = copy.deepcopy(settings.CONTENTSTORE)
 TEST_DATA_CONTENTSTORE['DOC_STORE_CONFIG']['db'] = 'test_xcontent_%s' % uuid4().hex  # noqa: UP031
 
 
-@override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
-@override_settings(FEATURES=FEATURES_WITH_EXPORT_GIT)
+@override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE, ENABLE_EXPORT_GIT=True)
 class TestGitExport(CourseTestCase):
     """
     Excercise the git_export django management command with various inputs.

--- a/common/djangoapps/third_party_auth/saml_configuration/tests/test_saml_configuration.py
+++ b/common/djangoapps/third_party_auth/saml_configuration/tests/test_saml_configuration.py
@@ -8,7 +8,7 @@ from rest_framework.test import APITestCase
 
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth.models import SAMLConfiguration
-from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 SAML_CONFIGURATIONS = [
     {
@@ -43,7 +43,7 @@ PRIV_CONFIGURATIONS = [
 TEST_PASSWORD = 'testpwd'
 
 
-@skip_unless_thirdpartyauth()
+@skip_unless_lms
 class SAMLConfigurationTests(APITestCase):
     """
     API Tests for SAMLConfiguration objects retrieval.

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -3,7 +3,6 @@ Base integration test for provider implementations.
 """
 
 import json
-import unittest
 from contextlib import contextmanager
 from unittest import mock
 
@@ -31,6 +30,7 @@ from openedx.core.djangoapps.site_configuration.tests.factories import SiteFacto
 from openedx.core.djangoapps.user_authn.views.login import login_user
 from openedx.core.djangoapps.user_authn.views.login_form import login_and_registration_form
 from openedx.core.djangoapps.user_authn.views.register import RegistrationView
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
 def create_account(request):
@@ -575,9 +575,7 @@ class IntegrationTestMixin(testutil.TestCase, test.TestCase, HelperMixin):
         return reverse("social:complete", kwargs={"backend": self.PROVIDER_BACKEND})
 
 
-@unittest.skipUnless(
-    testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + " not enabled"
-)
+@skip_unless_lms
 @django_utils.override_settings()  # For settings reversion on a method-by-method basis.
 class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
     """Abstract base class for provider integration tests."""

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -576,7 +576,7 @@ class IntegrationTestMixin(testutil.TestCase, test.TestCase, HelperMixin):
 
 
 @unittest.skipUnless(
-    testutil.AUTH_FEATURES_KEY in django_settings.FEATURES, testutil.AUTH_FEATURES_KEY + " not in settings.FEATURES"
+    testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + " not enabled"
 )
 @django_utils.override_settings()  # For settings reversion on a method-by-method basis.
 class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):

--- a/common/djangoapps/third_party_auth/tests/specs/test_generic.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_generic.py
@@ -2,12 +2,12 @@
 Use the 'Dummy' auth provider for generic integration tests of third_party_auth.
 """
 from common.djangoapps.third_party_auth.tests import testutil
-from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 from .base import IntegrationTestMixin
 
 
-@skip_unless_thirdpartyauth()
+@skip_unless_lms
 class GenericIntegrationTest(IntegrationTestMixin, testutil.TestCase):
     """
     Basic integration tests of third_party_auth using Dummy provider

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -28,6 +28,7 @@ from common.djangoapps.third_party_auth.tasks import fetch_saml_metadata
 from common.djangoapps.third_party_auth.tests import testutil, utils
 from common.test.utils import assert_dict_contains_subset
 from openedx.core.djangoapps.user_authn.views.login import login_user
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 from .base import IntegrationTestMixin
 
@@ -160,7 +161,7 @@ class SamlIntegrationTestUtilities:
 
 
 @ddt.ddt
-@utils.skip_unless_thirdpartyauth()
+@skip_unless_lms
 class TestIndexExceptionTest(SamlIntegrationTestUtilities, IntegrationTestMixin, testutil.SAMLTestCase):
     """
     To test SAML error handling when presented with an empty-list attribute value
@@ -199,7 +200,7 @@ class TestIndexExceptionTest(SamlIntegrationTestUtilities, IntegrationTestMixin,
 
 
 @ddt.ddt
-@utils.skip_unless_thirdpartyauth()
+@skip_unless_lms
 class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin, testutil.SAMLTestCase):
     """
     TestShib provider Integration Test, to test SAML functionality
@@ -404,7 +405,7 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
             self._test_return_login(previous_session_timed_out=True)
 
 
-@utils.skip_unless_thirdpartyauth()
+@skip_unless_lms
 class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin, testutil.SAMLTestCase):
     """
     Test basic SAML capability using the TestShib details, and then check that we're able

--- a/common/djangoapps/third_party_auth/tests/test_admin.py
+++ b/common/djangoapps/third_party_auth/tests/test_admin.py
@@ -11,13 +11,13 @@ from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth.admin import OAuth2ProviderConfigAdmin
 from common.djangoapps.third_party_auth.models import OAuth2ProviderConfig
 from common.djangoapps.third_party_auth.tests import testutil
-from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 TEST_PASSWORD = 'Password1234'
 
 
 # This is necessary because cms does not implement third party auth
-@skip_unless_thirdpartyauth()
+@skip_unless_lms
 class Oauth2ProviderConfigAdminTest(testutil.TestCase):
     """
     Tests for oauth2 provider config admin

--- a/common/djangoapps/third_party_auth/tests/test_decorators.py
+++ b/common/djangoapps/third_party_auth/tests/test_decorators.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory
 
 from common.djangoapps.third_party_auth.decorators import xframe_allow_whitelisted
 from common.djangoapps.third_party_auth.tests.testutil import TestCase
-from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
 @xframe_allow_whitelisted
@@ -17,7 +17,7 @@ def mock_view(_request):
     return HttpResponse()
 
 
-@skip_unless_thirdpartyauth()
+@skip_unless_lms
 @ddt.ddt
 class TestXFrameWhitelistDecorator(TestCase):
     """ Test the xframe_allow_whitelisted decorator. """

--- a/common/djangoapps/third_party_auth/tests/test_identityserver3.py
+++ b/common/djangoapps/third_party_auth/tests/test_identityserver3.py
@@ -7,11 +7,11 @@ import ddt
 
 from common.djangoapps.third_party_auth.identityserver3 import IdentityServer3
 from common.djangoapps.third_party_auth.tests import testutil
-from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
 from common.test.utils import assert_dict_contains_subset
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
-@skip_unless_thirdpartyauth()
+@skip_unless_lms
 @ddt.ddt
 class IdentityServer3Test(testutil.TestCase):
     """

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -11,10 +11,10 @@ from common.djangoapps.third_party_auth.tests import testutil
 from common.djangoapps.third_party_auth.tests.specs.base import IntegrationTestMixin
 from common.djangoapps.third_party_auth.tests.specs.test_testshib import SamlIntegrationTestUtilities
 from common.djangoapps.third_party_auth.tests.testutil import simulate_running_pipeline
-from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
-@skip_unless_thirdpartyauth()
+@skip_unless_lms
 @ddt.ddt
 class ProviderUserStateTestCase(testutil.TestCase):
     """Tests ProviderUserState behavior."""
@@ -54,7 +54,7 @@ class ProviderUserStateTestCase(testutil.TestCase):
             assert idp_config['logout_url'] == logout_url
 
 
-@skip_unless_thirdpartyauth()
+@skip_unless_lms
 @ddt.ddt
 class PipelineOverridesTest(SamlIntegrationTestUtilities, IntegrationTestMixin, testutil.SAMLTestCase):
     """

--- a/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
@@ -15,15 +15,15 @@ from social_django import models as social_models
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth import pipeline, provider
 from common.djangoapps.third_party_auth.tests import testutil
-from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
 from lms.djangoapps.verify_student.models import SSOVerification
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 # Get Django User model by reference from python-social-auth. Not a type
 # constant, pylint.
 User = social_models.DjangoStorage.user.user_model()  # pylint: disable=invalid-name
 
 
-@skip_unless_thirdpartyauth()
+@skip_unless_lms
 class TestCase(testutil.TestCase, test.TestCase):
     """Base test case."""
 

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -10,17 +10,17 @@ from django.test.utils import CaptureQueriesContext
 
 from common.djangoapps.third_party_auth import provider
 from common.djangoapps.third_party_auth.tests import testutil
-from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
 from openedx.core.djangoapps.site_configuration.tests.test_util import (
     with_site_configuration,
     with_site_configuration_context,
 )
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 SITE_DOMAIN_A = 'professionalx.example.com'
 SITE_DOMAIN_B = 'somethingelse.example.com'
 
 
-@skip_unless_thirdpartyauth()
+@skip_unless_lms
 class RegistryTest(testutil.TestCase):
     """Tests registry discovery and operation."""
 

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.test import TestCase, override_settings
 
 from common.djangoapps.third_party_auth import provider
-from common.djangoapps.third_party_auth.tests.utils import skip_unless_thirdpartyauth
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
@@ -20,7 +19,7 @@ class SettingsUnitTest(TestCase):
         """Verify FIELDS_STORED_IN_SESSION is defined with expected values."""
         assert settings.FIELDS_STORED_IN_SESSION == ['auth_entry', 'next']
 
-    @skip_unless_thirdpartyauth()
+    @skip_unless_lms
     def test_no_providers_enabled_by_default(self):
         """Providers are only enabled via ConfigurationModels in the database."""
         assert provider.Registry.enabled() == []

--- a/common/djangoapps/third_party_auth/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/tests/test_views.py
@@ -3,7 +3,6 @@ Test the views served by third_party_auth.
 """
 
 
-import unittest
 from unittest.mock import patch
 
 import ddt
@@ -22,13 +21,14 @@ from common.djangoapps.third_party_auth import pipeline
 # Define some XML namespaces:
 from common.djangoapps.third_party_auth.utils import SAML_XML_NS
 from common.djangoapps.third_party_auth.views import inactive_user_view
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 
-from .testutil import AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY, SAMLTestCase
+from .testutil import SAMLTestCase
 
 XMLDSIG_XML_NS = 'http://www.w3.org/2000/09/xmldsig#'
 
 
-@unittest.skipUnless(AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_lms
 @ddt.ddt
 class SAMLMetadataTest(SAMLTestCase):
     """
@@ -146,7 +146,7 @@ class SAMLMetadataTest(SAMLTestCase):
         assert support_email_node.text == support_email
 
 
-@unittest.skipUnless(AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_lms
 class SAMLAuthTest(SAMLTestCase):
     """
     Test the SAML auth views
@@ -166,7 +166,7 @@ class SAMLAuthTest(SAMLTestCase):
         assert response.status_code == 404
 
 
-@unittest.skipUnless(AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_lms
 class IdPRedirectViewTest(SAMLTestCase):
     """
         Test IdPRedirectView.
@@ -206,7 +206,7 @@ class IdPRedirectViewTest(SAMLTestCase):
         )
 
 
-@unittest.skipUnless(AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_lms
 class InactiveUserViewTests(TestCase):
     """Test inactive user view """
     @patch('common.djangoapps.third_party_auth.views.redirect')

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 from unittest import mock
 
 import django.test
-from django.conf import settings
 from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site
 from mako.template import Template
@@ -25,9 +24,6 @@ from common.djangoapps.third_party_auth.models import (
 from common.djangoapps.third_party_auth.models import cache as config_cache
 from openedx.core.djangolib.testing.utils import CacheIsolationMixin
 from openedx.core.storage import OverwriteStorage
-
-AUTH_FEATURES_KEY = 'ENABLE_THIRD_PARTY_AUTH'
-AUTH_FEATURE_ENABLED = hasattr(settings, AUTH_FEATURES_KEY)
 
 
 def patch_mako_templates():

--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -3,7 +3,6 @@
 
 import json
 from base64 import b64encode
-from unittest import skip
 
 import httpretty
 from oauth2_provider.models import Application
@@ -14,7 +13,7 @@ from social_django.models import Partial, UserSocialAuth
 
 from common.djangoapps.student.tests.factories import UserFactory
 
-from .testutil import AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY, ThirdPartyAuthTestMixin
+from .testutil import ThirdPartyAuthTestMixin
 
 
 @httpretty.activate
@@ -144,12 +143,3 @@ def prepare_saml_response_from_xml(xml, relay_state='testshib'):
         relay_state=OneLogin_Saml2_Utils.escape_url(relay_state),
         saml_response=OneLogin_Saml2_Utils.escape_url(b64encoded_xml)
     )
-
-
-def skip_unless_thirdpartyauth():
-    """
-    Wraps unittest.skip in consistent logic to skip certain third_party_auth tests in CMS.
-    """
-    if AUTH_FEATURE_ENABLED:
-        return lambda func: func
-    return skip("%s not enabled" % AUTH_FEATURES_KEY)  # noqa: UP031

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import ddt
 import pytest
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
@@ -45,9 +44,6 @@ from xmodule.modulestore.tests.factories import CourseFactory  # pylint: disable
 
 ENROLLMENT_METHOD = 'common.djangoapps.student.models.course_enrollment.CourseEnrollment.enrollment_mode_for_user'
 PROFILE_METHOD = 'common.djangoapps.student.models_api.get_name'
-
-FEATURES_INVALID_FILE_PATH = settings.FEATURES.copy()
-FEATURES_INVALID_FILE_PATH['CERTS_HTML_VIEW_CONFIG_PATH'] = 'invalid/path/to/config.json'
 
 TEST_DIR = path(__file__).dirname()
 TEST_DATA_DIR = 'common/test/data/'
@@ -175,7 +171,7 @@ class CertificateHtmlViewConfigurationTest(OpenEdxEventsTestMixin, TestCase):
         self.config.save()
         assert len(self.config.get_config()) == 0
 
-    @override_settings(FEATURES=FEATURES_INVALID_FILE_PATH)
+    @override_settings(CERTS_HTML_VIEW_CONFIG_PATH='invalid/path/to/config.json')
     def test_get_no_database_no_file(self):
         """
         Tests get configuration that is not enabled.

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -615,11 +615,11 @@ class CourseTabListTestCase(TabListTestCase):
         assert not self.has_tab(self.course.tabs, 'external_discussion')
         assert self.has_tab(self.course.tabs, 'discussion')
 
-    @override_settings(ENABLE_DISCUSSION_SERVICE=True)
-    @patch.dict("django.conf.settings.FEATURES", {
-        "ENABLE_TEXTBOOK": True,
-        "ENABLE_EDXNOTES": True,
-    })
+    @override_settings(
+        ENABLE_DISCUSSION_SERVICE=True,
+        ENABLE_TEXTBOOK=True,
+        ENABLE_EDXNOTES=True,
+    )
     def test_iterate_displayable(self):
         self.course.hide_progress_tab = False
 

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -178,11 +178,9 @@ class ExperimentDataViewSetTests(APITestCase, ModuleStoreTestCase):  # pylint: d
 
 def cross_domain_config(func):
     """Decorator for configuring a cross-domain request. """
-    feature_flag_decorator = patch.dict(settings.FEATURES, {
-        'ENABLE_CORS_HEADERS': True,
-        'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': True
-    })
     settings_decorator = override_settings(
+        ENABLE_CORS_HEADERS=True,
+        ENABLE_CROSS_DOMAIN_CSRF_COOKIE=True,
         CORS_ORIGIN_WHITELIST=['https://ecommerce.edx.org'],
         CSRF_COOKIE_NAME="prod-edx-csrftoken",
         CROSS_DOMAIN_CSRF_COOKIE_NAME="prod-edx-csrftoken",
@@ -190,10 +188,8 @@ def cross_domain_config(func):
     )
     is_secure_decorator = patch.object(WSGIRequest, 'is_secure', return_value=True)
 
-    return feature_flag_decorator(
-        settings_decorator(
-            is_secure_decorator(func)
-        )
+    return settings_decorator(
+        is_secure_decorator(func)
     )
 
 

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -792,7 +792,7 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin, Tes
         self.assertContains(response, "verification deadline")
         self.assertContains(response, verification_deadline_in_past)
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     @ddt.data("verify_student_start_flow", "verify_student_begin_flow")
     def test_embargo_restrict(self, payment_flow):
         course = self._create_course("verified")
@@ -802,7 +802,7 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin, Tes
             response = self._get_page(payment_flow, course.id, expected_status_code=302)
             self.assertRedirects(response, redirect_url)
 
-    @patch.dict(settings.FEATURES, {'EMBARGO': True})
+    @override_settings(EMBARGO=True)
     @ddt.data("verify_student_start_flow", "verify_student_begin_flow")
     def test_embargo_allow(self, payment_flow):
         course = self._create_course("verified")

--- a/openedx/core/djangoapps/cors_csrf/tests/test_authentication.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_authentication.py
@@ -1,8 +1,6 @@
 """Tests for the CORS CSRF version of Django Rest Framework's SessionAuthentication."""
 
 
-from unittest.mock import patch
-
 from django.conf import settings
 from django.middleware.csrf import get_token
 from django.test import TestCase
@@ -34,11 +32,9 @@ class CrossDomainAuthTest(TestCase):
         with self.assertRaisesRegex(PermissionDenied, 'CSRF'):  # noqa: PT027
             self.auth.enforce_csrf(request)
 
-    @patch.dict(settings.FEATURES, {
-        'ENABLE_CORS_HEADERS': True,
-        'ENABLE_CROSS_DOMAIN_CSRF_COOKIE': True
-    })
     @override_settings(
+        ENABLE_CORS_HEADERS=True,
+        ENABLE_CROSS_DOMAIN_CSRF_COOKIE=True,
         CORS_ORIGIN_WHITELIST=["https://www.edx.org"],
         CROSS_DOMAIN_CSRF_COOKIE_NAME="prod-edx-csrftoken",
         CROSS_DOMAIN_CSRF_COOKIE_DOMAIN=".edx.org"

--- a/openedx/core/djangoapps/embargo/middleware.py
+++ b/openedx/core/djangoapps/embargo/middleware.py
@@ -16,7 +16,7 @@ Embargo can restrict by states and whitelist/blacklist (IP Addresses
 
 Usage:
 
-1) Enable embargo by setting `settings.FEATURES['EMBARGO']` to True.
+1) Enable embargo by setting `settings.EMBARGO` to True.
 
 2) In Django admin, create a new `IPFilter` model to block or whitelist
     an IP address from accessing the site.

--- a/openedx/core/djangoapps/user_authn/views/auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/auto_auth.py
@@ -43,7 +43,7 @@ def auto_auth(request):  # pylint: disable=too-many-statements
     Create or configure a user account, then log in as that user.
 
     Enabled only when
-    settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] is true.
+    settings.AUTOMATIC_AUTH_FOR_TESTING is true.
 
     Accepts the following querystring parameters:
     * `username`, `email`, and `password` for the user account

--- a/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
@@ -47,7 +47,7 @@ class AutoAuthEnabledTestCase(AutoAuthTestCase, ModuleStoreTestCase):
 
     @override_settings(AUTOMATIC_AUTH_FOR_TESTING=True)
     def setUp(self):
-        # Patching the settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING']
+        # Patching the AUTOMATIC_AUTH_FOR_TESTING setting
         # value affects the contents of urls.py,
         # so we need to call super.setUp() which reloads urls.py (because
         # of the UrlResetMixin)
@@ -305,7 +305,7 @@ class AutoAuthDisabledTestCase(AutoAuthTestCase):
 
     @override_settings(AUTOMATIC_AUTH_FOR_TESTING=False)
     def setUp(self):
-        # Patching the settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING']
+        # Patching the AUTOMATIC_AUTH_FOR_TESTING setting
         # value affects the contents of urls.py,
         # so we need to call super.setUp() which reloads urls.py (because
         # of the UrlResetMixin)
@@ -329,7 +329,7 @@ class AutoAuthRestrictedTestCase(AutoAuthTestCase):
 
     @override_settings(AUTOMATIC_AUTH_FOR_TESTING=True)
     def setUp(self):
-        # Patching the settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING']
+        # Patching the AUTOMATIC_AUTH_FOR_TESTING setting
         # value affects the contents of urls.py,
         # so we need to call super.setUp() which reloads urls.py (because
         # of the UrlResetMixin)

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -111,9 +111,7 @@ class LoginTest(OpenEdxEventsTestMixin, SiteMixin, CacheIsolationTestCase):
             mock_audit_log, 'warning', ['Login failed - Account not active for user.id: 1, resending activation']
         )
 
-    @patch.dict(settings.FEATURES, {
-        "ENABLE_THIRD_PARTY_AUTH": True
-    })
+    @override_settings(ENABLE_THIRD_PARTY_AUTH=True)
     @patch(
         'openedx.core.djangoapps.user_authn.views.login.is_require_third_party_auth_enabled',
         Mock(return_value=True)

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -96,9 +96,7 @@ class RegistrationViewValidationErrorTest(
         super().setUp()
         self.url = reverse("user_api_registration")
 
-    @mock.patch.dict(settings.FEATURES, {
-        "ENABLE_THIRD_PARTY_AUTH": True,
-    })
+    @override_settings(ENABLE_THIRD_PARTY_AUTH=True)
     @mock.patch(
         'openedx.core.djangoapps.user_authn.views.register.is_require_third_party_auth_enabled',
         mock.Mock(return_value=True)

--- a/xmodule/modulestore/split_mongo/split.py
+++ b/xmodule/modulestore/split_mongo/split.py
@@ -1720,7 +1720,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
 
             parent = new_structure['blocks'][block_id]
 
-            # Originally added to support entrance exams (settings.FEATURES.get('ENTRANCE_EXAMS'))
+            # Originally added to support entrance exams (the ENTRANCE_EXAMS feature)
             if kwargs.get('position') is None:
                 parent.fields.setdefault('children', []).append(BlockKey.from_usage_key(xblock.location))
             else:


### PR DESCRIPTION
Clears the remaining `settings.FEATURES` **test overrides** — flags whose *production* readers were migrated in earlier batches, but whose test decorators were left on `patch.dict(settings.FEATURES, …)` / `override_settings(FEATURES=…)` / `settings.FEATURES.copy()`. These are currently harmless (the flat reader ignores the dict mutation) but each still references `settings.FEATURES`, so they'd break the moment the dict/`FeaturesProxy` bridge is removed.

Found via a repo-wide `settings.FEATURES` sweep (not the reader-only picker).

## Flags (one commit each; co-located pairs together)
- **EMBARGO** — two verify_student view tests.
- **ENABLE_CORS_HEADERS + ENABLE_CROSS_DOMAIN_CSRF_COOKIE** — cors_csrf + experiments tests; folded into the adjacent `override_settings`.
- **ENABLE_TEXTBOOK + ENABLE_EDXNOTES** — a courseware tabs test.
- **ENABLE_THIRD_PARTY_AUTH** — `test_login.py` / `test_register.py` (`@override_settings`), and `third_party_auth/tests/specs/base.py` switched from `'ENABLE_THIRD_PARTY_AUTH' in settings.FEATURES` to the flat-based `testutil.AUTH_FEATURE_ENABLED` (already the pattern in `test_views.py`).
- **ENABLE_EXPORT_GIT** — git-export test; the production reader is a flat `SettingToggle`.
- **CERTS_HTML_VIEW_CONFIG_PATH** — a certificates test override that nothing reads anymore (vestigial no-op); converted mechanically off the dict.

Plus a `docs:` commit updating stale `settings.FEATURES['X']` references in comments/docstrings (EMBARGO, ENABLE_EXPORT_GIT, AUTOMATIC_AUTH_FOR_TESTING, ENTRANCE_EXAMS) to the flat settings they now describe.

Each migrated flag's production reader already reads flat settings; the affected tests were run locally and pass.