### PR TITLE
refactor: migrate ENABLE_CSMH_EXTENDED off FEATURES-as-dict in the CSM bigint migration

### DIFF
--- a/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
+++ b/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
@@ -21,7 +21,7 @@ class CsmBigInt(AlterField):
         to_model = to_state.apps.get_model(app_label, self.model_name)
 
         if schema_editor.connection.alias == 'student_module_history':
-            if settings.FEATURES["ENABLE_CSMH_EXTENDED"]:
+            if settings.ENABLE_CSMH_EXTENDED:
                 if schema_editor.connection.vendor == 'mysql':
                     schema_editor.execute("ALTER TABLE `coursewarehistoryextended_studentmodulehistoryextended` MODIFY `student_module_id` bigint UNSIGNED NOT NULL;")
                 elif schema_editor.connection.vendor == 'postgresql':
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
         ('courseware', '0010_auto_20190709_1559'),
     ]
 
-    if settings.FEATURES["ENABLE_CSMH_EXTENDED"]:
+    if settings.ENABLE_CSMH_EXTENDED:
         dependencies.append(('coursewarehistoryextended', '0002_force_studentmodule_index'))
 
     operations = [


### PR DESCRIPTION
`ENABLE_CSMH_EXTENDED` is a flat setting (`openedx/envs/common.py`, default `True`); its app readers (`courseware/models.py`) and tests already use `settings.ENABLE_CSMH_EXTENDED`. The 2019 `0011_csm_id_bigint` data migration still read `settings.FEATURES["ENABLE_CSMH_EXTENDED"]` in two places:

- the `Migration` class body, evaluated at **import time** (on every `migrate` / `makemigrations` / test-DB build), gating an extra dependency; and
- `database_forwards()`, gating the `studentmodulehistoryextended` ALTER TABLE.

Switch both to bare `settings.ENABLE_CSMH_EXTENDED`, matching `models.py`. Behavior is identical, and reading the flat setting keeps the migration working for the deployments that still apply it.

Verified the migration module imports cleanly under LMS settings (the import-time dependency list resolves correctly) and the `coursewarehistoryextended` tests pass. (The pre-existing unused `models` import is left as-is; migrations are excluded from ruff.)