### PR TITLE
feat: split read vs write authz checks for certificates

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/certificates.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/certificates.py
@@ -50,3 +50,4 @@ class CourseCertificatesSerializer(serializers.Serializer):
     course_number = serializers.CharField(source="context_course.number")
     course_title = serializers.CharField(source="context_course.display_name_with_default")
     course_number_override = serializers.CharField(source="context_course.display_coursenumber")
+    can_manage = serializers.BooleanField(default=False, read_only=True)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/certificates.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/certificates.py
@@ -2,7 +2,7 @@
 
 import edx_api_doc_tools as apidocs
 from opaque_keys.edx.keys import CourseKey
-from openedx_authz.constants.permissions import COURSES_MANAGE_CERTIFICATES
+from openedx_authz.constants.permissions import COURSES_MANAGE_CERTIFICATES, COURSES_VIEW_CERTIFICATES
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -85,7 +85,8 @@ class CourseCertificatesView(DeveloperErrorViewMixin, APIView):
             "mfe_proctored_exam_settings_url": "",
             "course_number": "DemoX",
             "course_title": "Demonstration Course",
-            "course_number_override": "Course Number Display String"
+            "course_number_override": "Course Number Display String",
+            "can_manage": true
         }
         ```
         """
@@ -94,14 +95,22 @@ class CourseCertificatesView(DeveloperErrorViewMixin, APIView):
 
         if not user_has_course_permission(
             request.user,
+            COURSES_VIEW_CERTIFICATES.identifier,
+            course_key,
+            LegacyAuthoringPermission.READ
+        ):
+            self.permission_denied(request)
+
+        can_manage = user_has_course_permission(
+            request.user,
             COURSES_MANAGE_CERTIFICATES.identifier,
             course_key,
             LegacyAuthoringPermission.WRITE
-        ):
-            self.permission_denied(request)
+        )
 
         with store.bulk_operations(course_key):
             course = modulestore().get_course(course_key)
             certificates_context = get_certificates_context(course, request.user)
+            certificates_context['can_manage'] = can_manage
             serializer = CourseCertificatesSerializer(certificates_context)
             return Response(serializer.data)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_certificates.py
@@ -1,8 +1,9 @@
 """
 Unit tests for the course's certificate.
 """
+import ddt
 from django.urls import reverse
-from openedx_authz.constants.roles import COURSE_EDITOR, COURSE_STAFF
+from openedx_authz.constants.roles import COURSE_AUDITOR, COURSE_EDITOR, COURSE_STAFF
 from rest_framework import status
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
@@ -40,6 +41,7 @@ class CourseCertificatesViewTest(CourseTestCase, PermissionAccessMixin, HelperMe
         self.assertEqual(response_data["course_number"], self.course.number)  # noqa: PT009
 
 
+@ddt.ddt
 class CourseCertificatesAuthzViewTest(
         CourseAuthoringAuthzTestMixin, CourseTestCase, PermissionAccessMixin, HelperMethods
     ):
@@ -59,14 +61,27 @@ class CourseCertificatesAuthzViewTest(
         self._add_course_certificates(count=2, signatory_count=2)
         self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
         resp = self.authorized_client.get(self.url)
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)  # noqa: PT009
+        assert resp.status_code == status.HTTP_200_OK
 
-    def test_non_staff_user_cannot_access(self):
-        """
-        User without permissions should be denied.
-        This case validates that a non-staff user cannot access.
-        """
-        self._add_course_certificates(count=2, signatory_count=2)
-        self.add_user_to_role_in_course(self.authorized_user, COURSE_EDITOR.external_key, self.course.id)
+    def test_staff_role_has_can_manage_true(self):
+        """User with COURSE_STAFF role gets can_manage=True in response."""
+        self._add_course_certificates(count=1, signatory_count=1)
+        self.add_user_to_role_in_course(self.authorized_user, COURSE_STAFF.external_key, self.course.id)
         resp = self.authorized_client.get(self.url)
-        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)  # noqa: PT009
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["can_manage"] is True
+
+    @ddt.data(COURSE_EDITOR, COURSE_AUDITOR)
+    def test_view_only_role_can_view_without_manage(self, role):
+        """Course editor/auditor can view certificates but gets can_manage=False."""
+        self._add_course_certificates(count=1, signatory_count=1)
+        self.add_user_to_role_in_course(self.authorized_user, role.external_key, self.course.id)
+        resp = self.authorized_client.get(self.url)
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["can_manage"] is False
+
+    def test_unauthorized_user_cannot_access(self):
+        """User without any role cannot access."""
+        self._add_course_certificates(count=1, signatory_count=1)
+        resp = self.unauthorized_client.get(self.url)
+        assert resp.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
## Description

Updates the certificates REST API v1 endpoint to use `courses.view_certificates` for GET access and `courses.manage_certificates` for write access. Adds a `can_manage` flag to the API response so the frontend can conditionally render edit controls.

Previously, the GET handler checked `COURSES_MANAGE_CERTIFICATES` with `LegacyAuthoringPermission.WRITE`, which blocked Course Editors and Auditors from viewing certificates entirely. Per the design in openedx/openedx-authz#283 and openedx/openedx-authz#329, users with view access should see the page in read-only mode.

**User roles impacted:** Course Editor, Course Auditor — can now view (but not edit) certificates when authz is enabled.

**Changes:**
- `cms/djangoapps/contentstore/rest_api/v1/views/certificates.py`: Use `VIEW_CERTIFICATES` for access gate, add `can_manage` check
- `cms/djangoapps/contentstore/rest_api/v1/serializers/certificates.py`: Add `can_manage` field
- Tests: Updated and added tests for staff (`can_manage=True`), editor/auditor (`can_manage=False`), and unauthorized (403)

**Rollback:** Gated behind `AUTHZ_COURSE_AUTHORING_FLAG` — disabling the flag reverts to legacy behavior.

## Supporting information

- Closes openedx/openedx-authz#395
- Related: openedx/openedx-authz#329, openedx/openedx-authz#283

## Testing instructions

1. Enable `AUTHZ_COURSE_AUTHORING_FLAG` for a course
2. Assign a user the `course_editor` role
3. `GET /api/contentstore/v1/certificates/{course_id}` → 200 with `can_manage: false`
4. Assign `course_staff` role → 200 with `can_manage: true`
5. User with no role → 403

## Deadline

None

## AI Usage

Kiro was used as a development partner throughout this PR. I directed the implementation approach, defined scope, reviewed generated code, and made design decisions — Kiro researched the codebase, wrote the implementation and tests, ran lint/type checks, and iterated on fixes. I verified the changes manually against a local Tutor dev environment and reviewed the final diffs before submitting.