### PR TITLE
feat: split read vs write authz checks for group configurations

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/serializers/group_configurations.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers/group_configurations.py
@@ -57,3 +57,4 @@ class CourseGroupConfigurationsSerializer(serializers.Serializer):
     )
     should_show_enrollment_track = serializers.BooleanField()
     should_show_experiment_groups = serializers.BooleanField()
+    can_manage = serializers.BooleanField(default=False, read_only=True)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/group_configurations.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/group_configurations.py
@@ -2,7 +2,7 @@
 
 import edx_api_doc_tools as apidocs
 from opaque_keys.edx.keys import CourseKey
-from openedx_authz.constants.permissions import COURSES_MANAGE_GROUP_CONFIGURATIONS
+from openedx_authz.constants.permissions import COURSES_MANAGE_GROUP_CONFIGURATIONS, COURSES_VIEW_GROUP_CONFIGURATIONS
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -10,7 +10,7 @@ from rest_framework.views import APIView
 from cms.djangoapps.contentstore.rest_api.v1.serializers import CourseGroupConfigurationsSerializer
 from cms.djangoapps.contentstore.utils import get_group_configurations_context
 from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
-from openedx.core.djangoapps.authz.decorators import authz_permission_required
+from openedx.core.djangoapps.authz.decorators import authz_permission_required, user_has_course_permission
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
 from xmodule.modulestore.django import modulestore
 
@@ -36,7 +36,7 @@ class CourseGroupConfigurationsView(DeveloperErrorViewMixin, APIView):
     )
     @verify_course_exists()
     @authz_permission_required(
-        authz_permission=COURSES_MANAGE_GROUP_CONFIGURATIONS.identifier,
+        authz_permission=COURSES_VIEW_GROUP_CONFIGURATIONS.identifier,
         legacy_permission=LegacyAuthoringPermission.READ
     )
     def get(self, request: Request, course_key: CourseKey):
@@ -144,5 +144,11 @@ class CourseGroupConfigurationsView(DeveloperErrorViewMixin, APIView):
         with store.bulk_operations(course_key):
             course = modulestore().get_course(course_key)
             group_configurations_context = get_group_configurations_context(course, store)
+            group_configurations_context['can_manage'] = user_has_course_permission(
+                request.user,
+                COURSES_MANAGE_GROUP_CONFIGURATIONS.identifier,
+                course_key,
+                LegacyAuthoringPermission.WRITE
+            )
             serializer = CourseGroupConfigurationsSerializer(group_configurations_context)
             return Response(serializer.data)

--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_group_configurations.py
@@ -2,7 +2,7 @@
 Unit tests for the course's setting group configuration.
 """
 from django.urls import reverse
-from openedx_authz.constants.roles import COURSE_DATA_RESEARCHER, COURSE_STAFF
+from openedx_authz.constants.roles import COURSE_AUDITOR, COURSE_DATA_RESEARCHER, COURSE_EDITOR, COURSE_STAFF
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -111,3 +111,31 @@ class CourseGroupConfigurationsAuthzTest(CourseAuthzTestMixin, BaseCourseViewTes
 
         resp = non_staff_client.get(self.get_url(self.course_key))
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)  # noqa: PT009
+
+    def test_staff_has_can_manage_true(self):
+        """User with COURSE_STAFF role gets can_manage=True in response."""
+        resp = self.authorized_client.get(self.get_url(self.course_key))
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["can_manage"] is True
+
+    def test_editor_can_view_group_configurations(self):
+        """User with COURSE_EDITOR role can view group configurations."""
+        editor_user = UserFactory()
+        editor_client = APIClient()
+        self.add_user_to_role(editor_user, COURSE_EDITOR.external_key)
+        editor_client.force_authenticate(user=editor_user)
+
+        resp = editor_client.get(self.get_url(self.course_key))
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["can_manage"] is True  # editor has manage_group_configurations
+
+    def test_auditor_can_view_group_configurations(self):
+        """User with COURSE_AUDITOR role can view group configurations."""
+        auditor_user = UserFactory()
+        auditor_client = APIClient()
+        self.add_user_to_role(auditor_user, COURSE_AUDITOR.external_key)
+        auditor_client.force_authenticate(user=auditor_user)
+
+        resp = auditor_client.get(self.get_url(self.course_key))
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["can_manage"] is False  # auditor has view only

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -42,6 +42,7 @@ from openedx_authz.constants.permissions import (
     COURSES_PUBLISH_COURSE_CONTENT,
     COURSES_VIEW_COURSE,
     COURSES_VIEW_COURSE_UPDATES,
+    COURSES_VIEW_GROUP_CONFIGURATIONS,
     COURSES_VIEW_PAGES_AND_RESOURCES,
 )
 from organizations.api import add_organization_course, ensure_organization
@@ -1913,13 +1914,25 @@ def group_configurations_list_handler(request, course_key_string):
         json: create new group configuration
     """
     course_key = CourseKey.from_string(course_key_string)
+
+    if request.method == 'GET':
+        # GET only redirects to the MFE (html) or returns 406 (json)
+        if not user_has_course_permission(
+            user=request.user,
+            authz_permission=COURSES_VIEW_GROUP_CONFIGURATIONS.identifier,
+            course_key=course_key,
+            legacy_permission=LegacyAuthoringPermission.READ,
+        ):
+            raise PermissionDenied()
+        if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
+            return redirect(get_group_configurations_url(course_key))
+        return HttpResponse(status=406)
+
     store = modulestore()
     with store.bulk_operations(course_key):
         course = get_course_and_check_manage_group_configurations_access(course_key, request.user)
 
-        if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
-            return redirect(get_group_configurations_url(course_key))
-        elif "application/json" in request.META.get('HTTP_ACCEPT'):
+        if "application/json" in request.META.get('HTTP_ACCEPT'):
             if request.method == 'POST':
                 # create a new group configuration for the course
                 try:

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import ddt
 from django.test import Client
-from openedx_authz.constants.roles import COURSE_DATA_RESEARCHER, COURSE_STAFF
+from openedx_authz.constants.roles import COURSE_AUDITOR, COURSE_DATA_RESEARCHER, COURSE_EDITOR, COURSE_STAFF
 from rest_framework import status
 
 from cms.djangoapps.contentstore.api.tests.base import BaseCourseViewTest
@@ -1235,6 +1235,7 @@ class GroupConfigurationsValidationTestCase(CourseTestCase, HelperMethods):
         """
         self.verify_validation_update_usage_info(None, None)  # pylint: disable=no-value-for-parameter
 
+@ddt.ddt
 class PostGroupConfigurationsListHandlerAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):
     """
     Tests endpoint used to create new Course Group Configurations
@@ -1342,6 +1343,43 @@ class PostGroupConfigurationsListHandlerAuthzTest(CourseAuthzTestMixin, BaseCour
             HTTP_ACCEPT='application/json',
         )
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)  # noqa: PT009
+
+    def test_editor_can_write(self):
+        """
+        Course editor has manage_group_configurations and can POST (create).
+        This is the write-side counterpart to the editor's view access.
+        """
+        editor = UserFactory(password=self.password)
+        self.add_user_to_role(editor, COURSE_EDITOR.external_key)
+        client = Client()
+        client.login(username=editor.username, password=self.password)
+
+        resp = client.post(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        assert resp.status_code == status.HTTP_201_CREATED
+
+    def test_auditor_cannot_write(self):
+        """
+        Course auditor has only view_group_configurations (no manage), so it can
+        read the list but must be denied POST (create). This is the write-side
+        counterpart to the auditor's view access.
+        """
+        auditor = UserFactory(password=self.password)
+        self.add_user_to_role(auditor, COURSE_AUDITOR.external_key)
+        client = Client()
+        client.login(username=auditor.username, password=self.password)
+
+        resp = client.post(
+            self.get_url(self.course_key),
+            data=json.dumps(GROUP_CONFIGURATION_JSON),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
 class PutGroupConfigurationsDetailHandlerAuthzTest(CourseAuthzTestMixin, BaseCourseViewTest):


### PR DESCRIPTION
## Description

Updates group configuration endpoints to use `courses.view_group_configurations` for GET access and `courses.manage_group_configurations` for write access. Adds a `can_manage` flag to the REST API v1 response so the frontend can conditionally render edit controls.

Previously, both the REST API v1 view and the legacy handler used `COURSES_MANAGE_GROUP_CONFIGURATIONS` for all access including reads. This blocked Course Auditors from viewing group configurations entirely. Per the design in openedx/openedx-authz#283, auditors should see the page in read-only mode.

**User roles impacted:** Course Auditor — can now view (but not edit) group configurations. Course Editor retains full access (has both view and manage permissions).

**Changes:**
- `cms/djangoapps/contentstore/rest_api/v1/views/group_configurations.py`: Use `VIEW_GROUP_CONFIGURATIONS` in decorator, add `can_manage` check
- `cms/djangoapps/contentstore/rest_api/v1/serializers/group_configurations.py`: Add `can_manage` field
- `cms/djangoapps/contentstore/views/course.py`: Check view permission on a GET request

**Rollback:** Gated behind `AUTHZ_COURSE_AUTHORING_FLAG` — disabling the flag reverts to legacy behavior.

## Supporting information

- Closes openedx/openedx-authz#401
- Related: openedx/openedx-authz#283

## Testing instructions

1. Enable `AUTHZ_COURSE_AUTHORING_FLAG` for a course
2. Assign a user the `course_auditor` role
3. `GET /api/contentstore/v1/group_configurations/{course_id}` → 200 with `can_manage: false`
4. Assign `course_editor` → 200 with `can_manage: true`
5. Assign `course_staff` → 200 with `can_manage: true`
6. User with no role → 403
7. Legacy handler: `GET /group_configurations/{course_key}` with auditor → should succeed

## Deadline

None

## AI Usage

Kiro was used as a development partner throughout this PR. I directed the implementation approach, defined scope, reviewed generated code, and made design decisions — Kiro researched the codebase, wrote the implementation and tests, ran lint/type checks, and iterated on fixes. I verified the changes manually against a local Tutor dev environment and reviewed the final diffs before submitting.