### PR TITLE
fix: submit_problem saving history before submission guards

### DIFF
--- a/xmodule/capa_block.py
+++ b/xmodule/capa_block.py
@@ -1752,7 +1752,6 @@ class _BuiltInProblemBlock(  # pylint: disable=too-many-public-methods,too-many-
         self.lcp.has_saved_answers = False
         answers = self.make_dict_of_responses(data)
         answers_without_files = convert_files_to_filenames(answers)
-        self.student_answers_history.append(answers_without_files)
         event_info["answers"] = answers_without_files
 
         # Can override current time
@@ -1812,6 +1811,9 @@ class _BuiltInProblemBlock(  # pylint: disable=too-many-public-methods,too-many-
             # self.lcp.context['attempt'] refers to the attempt number (1-based)
             self.lcp.context["attempt"] = self.attempts + 1
             correct_map = self.lcp.grade_answers(answers)
+            # recorded only once grading has succeeded, to stay aligned with the
+            # correct map history that grade_answers appends to
+            self.student_answers_history.append(answers_without_files)
             # self.attempts refers to the number of attempts that did not
             # raise an error (0-based)
             self.attempts = self.attempts + 1

--- a/xmodule/tests/test_capa_block.py
+++ b/xmodule/tests/test_capa_block.py
@@ -1367,6 +1367,48 @@ class ProblemBlockTest(unittest.TestCase):  # pylint: disable=too-many-public-me
             # but that this was considered attempt number 2 for grading purposes
             assert block.lcp.context["attempt"] == 2
 
+    def test_submit_problem_error_does_not_record_answer_history(self):
+        """
+        Verify that a submission that fails to grade is not recorded in `student_answers_history`, which keeps it
+        aligned with `correct_map_history`.
+        """
+        exception_classes = [StudentInputError, LoncapaProblemError, ResponseError]
+        for exception_class in exception_classes:
+            block = CapaFactory.create(attempts=1, user_is_staff=False)
+
+            with patch('xblocks_contrib.problem.capa.capa_problem.LoncapaProblem.grade_answers') as mock_grade:
+                mock_grade.side_effect = exception_class('test error')
+
+                get_request_dict = {CapaFactory.input_key(): '3.14'}
+                block.submit_problem(get_request_dict)
+
+            assert not block.student_answers_history, \
+                f"student_answers_history must stay empty when grading raises {exception_class.__name__}"
+            assert len(block.student_answers_history) == len(block.correct_map_history), (
+                "student_answers_history and correct_map_history must stay the same length "
+                f"when grading raises {exception_class.__name__}"
+            )
+
+    def test_answer_and_correct_map_histories_stay_aligned(self):
+        """
+        Verify that `student_answers_history` and `correct_map_history` hold one entry per graded attempt, so
+        an attempt that fails to grade does not misalign the two lists for the attempts that follow it.
+        """
+        block = CapaFactory.create(attempts=0, max_attempts=3, rerandomize=RANDOMIZATION.NEVER)
+
+        block.submit_problem({CapaFactory.input_key(): '3.14'})
+
+        with patch('xblocks_contrib.problem.capa.capa_problem.LoncapaProblem.grade_answers') as mock_grade:
+            mock_grade.side_effect = StudentInputError('test error')
+            block.submit_problem({CapaFactory.input_key(): 'not a number'})
+
+        block.submit_problem({CapaFactory.input_key(): '3.21'})
+
+        assert len(block.student_answers_history) == len(block.correct_map_history) == 2, \
+            "both histories must hold one entry per graded attempt, excluding the attempt that failed to grade"
+        assert block.student_answers_history[-1] == {CapaFactory.answer_key(): '3.21'}, \
+            "the last entry of student_answers_history must be the answers of the last graded attempt"
+
     def test_submit_problem_error_with_codejail_exception(self):
         """Verify codejail execution errors are sanitized and handled correctly."""
 

--- a/xmodule/tests/test_delay_between_attempts.py
+++ b/xmodule/tests/test_delay_between_attempts.py
@@ -198,6 +198,26 @@ class XModuleQuizAttemptsDelayTest(unittest.TestCase):
         # Also, the number of attempts should not be incremented
         self.assertRegex(result['success'], r"You must wait at least 3 minutes between submissions. 2 minutes remaining\..*")  # pylint: disable=line-too-long  # noqa: PT009
         assert block.attempts == num_attempts
+        assert not block.student_answers_history, \
+            "student_answers_history must stay empty when a submission arrives before the wait period elapsed"
+
+    def test_no_answer_history_when_submitted_too_soon(self):
+        """
+        Verify that a submission rejected for arriving before the wait period
+        elapsed is not recorded in `student_answers_history`.
+        """
+        num_attempts = 1
+        (block, result) = self.create_and_check(
+            num_attempts=num_attempts,
+            last_submission_time=datetime.datetime(2013, 12, 6, 0, 17, 36, tzinfo=UTC),
+            submission_wait_seconds=180,
+            considered_now=datetime.datetime(2013, 12, 6, 0, 18, 36, tzinfo=UTC)
+        )
+        self.assertRegex(result['success'], r"You must wait at least.*")
+        assert block.attempts == num_attempts, \
+            "attempts must not change when a submission arrives before the wait period elapsed"
+        assert block.student_answers_history == [], \
+            "student_answers_history must stay empty when a submission arrives before the wait period elapsed"
 
     def test_submit_quiz_1_second_too_soon(self):
         # Already attempted once (just now)


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->
# WIP: related work in xblocks-contrib is needed

## Description

`_BuiltInProblemBlock.submit_problem` (aka `ProblemBlock.submit_problem`) records the submitted answer into `student_answers_history` before the submission guards run, so rejected submissions are still recorded in history, while `attempts` correctly stays put. Each of those submissions also saves the block, writing a full `courseware_studentmodulehistory` row that carries the whole list, so the history table grows exponentially when too many rejected submissions are posted for the same problem.

Only the guards that `return` are affected: the xqueue waittime, `submission_wait_seconds`, and the `StudentInputError` / `ResponseError` / `LoncapaProblemError` branch. `closed()` and the unreset guard raise, so
nothing was ever persisted through them.

**Fix.** Move the append inside the `try`, immediately after `grade_answers()` returns. Only graded submissions
are recorded, the two lists stay in step, and the two `return` guards now leave the request with no dirty fields
at all, and no `StudentModule` write and no history row.

Operators benefit; learners see no change, since legitimate submissions are recorded exactly as before. No UI change, no configuration change, no migration.

## Supporting information

The defect was introduced in [this PR](https://github.com/openedx/openedx-platform/pull/33911) (see `xmodule/capa_block.py` line `1755`), and there is no explanation why the history append self.student_answers_history.append(answers_without_files)` was made way before the other update statements 

If there is a legit reason for the location of the append statement; then we must find another code fix for the bug. It is a bug to save history of rejected submissions especially when no `reject reason` is saved anywhere

## Real Example

This is an observation from a production instance. An exam that was configured to require two hours between attempts was targeted by bots re-submitting every five seconds. That produced 1400+ history rows for submissions that were never graded, inflating both `courseware_studentmodule` and `courseware_studentmodulehistory` for no reason. There is no reason to retain those submissions!

On the other hand, detecting the abuse is a separate concern and is unaffected by this change: the submissions still show up in the tracking logs whether or not they are kept as learner state.

## Testing instructions

**Automated**

- `pytest xmodule/tests/test_capa_block.py -k "answer_history or histories_stay_aligned"`
- `pytest xmodule/tests/test_delay_between_attempts.py`
- **Before the fix:** all three new tests fail. **After the fix:** all three pass.

**Manual: submissions rejected by the wait timer**

1. Create a Problem component, set **Timer Between Attempts** to 120 seconds, and allow multiple attempts.
2. As a learner, submit a correct answer.
3. Submit again immediately and confirm the "You must wait at least..." message appears.
4. Repeat step 3 several times.
5. Open **Staff Debug Info - Submission History** for that learner and problem.
   - **Before the fix:** each rejected submission added a history entry, every one carrying a longer
     `student_answers_history` than the last.
   - **After the fix:** the rejected submissions add no history entry at all, and `student_answers_history`
     holds one entry per graded attempt.

**Manual: submissions that fail to grade**

1. Open a `numericalresponse` problem.
2. Submit malformed input (e.g. `abc`) and confirm the error message is shown.
3. Submit a valid answer.
4. Inspect the stored state.
   - **Before the fix:** the malformed submission is in `student_answers_history`.
   - **After the fix:** the malformed submission is not in the list.

**Regression**: unchanged before and after

- Legitimate repeated submissions still work, including multi-tab and slow connections.
- `attempts` still increments exactly once per graded submission.
- Submitting to a closed or past-due problem still behaves as before.

## Deadline

None.

## Other information

Back-port for older version is possible, but with a minor change on a patched function name in tests
