### PR TITLE
refactor: migrate ENABLE_EXAM_SETTINGS_HTML_VIEW and LICENSING off FEATURES-as-dict

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -287,7 +287,7 @@ if ENABLE_COURSEWARE_INDEX or ENABLE_LIBRARY_INDEX:  # noqa: F405
 # TODO: Once we have successfully upgraded to ES7, switch this back to ELASTIC_SEARCH_CONFIG.
 ELASTIC_SEARCH_CONFIG = _YAML_TOKENS.get('ELASTIC_SEARCH_CONFIG_ES7', [{}])
 
-XBLOCK_SETTINGS.setdefault("VideoBlock", {})["licensing_enabled"] = FEATURES["LICENSING"]  # noqa: F405
+XBLOCK_SETTINGS.setdefault("VideoBlock", {})["licensing_enabled"] = LICENSING  # noqa: F405
 XBLOCK_SETTINGS.setdefault("VideoBlock", {})['YOUTUBE_API_KEY'] = YOUTUBE_API_KEY  # noqa: F405
 
 ############################ OAUTH2 Provider ###################################

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -332,7 +332,7 @@ if (
 # TODO: Once we have successfully upgraded to ES7, switch this back to ELASTIC_SEARCH_CONFIG.
 ELASTIC_SEARCH_CONFIG = _YAML_TOKENS.get('ELASTIC_SEARCH_CONFIG_ES7', [{}])
 
-XBLOCK_SETTINGS.setdefault("VideoBlock", {})["licensing_enabled"] = FEATURES["LICENSING"]  # noqa: F405
+XBLOCK_SETTINGS.setdefault("VideoBlock", {})["licensing_enabled"] = LICENSING  # noqa: F405
 XBLOCK_SETTINGS.setdefault("VideoBlock", {})['YOUTUBE_API_KEY'] = YOUTUBE_API_KEY  # noqa: F405
 
 ##### Custom Courses for EdX #####

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -1213,6 +1213,17 @@ SHOW_BUMPER_PERIODICITY = 7 * 24 * 3600
 # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/9744
 ENABLE_SPECIAL_EXAMS = False
 
+# .. toggle_name: ENABLE_EXAM_SETTINGS_HTML_VIEW
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enable the "Exam Settings" view in Studio's course settings. When enabled,
+#   the corresponding legacy proctored/timed-exam fields on the course are marked deprecated in the
+#   advanced settings editor so they are edited via the dedicated view instead.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2020-07-09
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/24405
+ENABLE_EXAM_SETTINGS_HTML_VIEW = False
+
 # .. toggle_name: SHOW_HEADER_LANGUAGE_SELECTOR
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -53,7 +53,7 @@ DEFAULT_COURSE_VISIBILITY_IN_CATALOG = getattr(
 
 DEFAULT_MOBILE_AVAILABLE = getattr(settings, 'DEFAULT_MOBILE_AVAILABLE', False)
 # Note: updating assets does not have settings defined, so using `getattr`.
-EXAM_SETTINGS_HTML_VIEW_ENABLED = getattr(settings, 'FEATURES', {}).get('ENABLE_EXAM_SETTINGS_HTML_VIEW', False)
+EXAM_SETTINGS_HTML_VIEW_ENABLED = getattr(settings, 'ENABLE_EXAM_SETTINGS_HTML_VIEW', False)
 SPECIAL_EXAMS_ENABLED = getattr(settings, 'ENABLE_SPECIAL_EXAMS', False)
 
 COURSE_VISIBILITY_PRIVATE = 'private'

--- a/xmodule/course_block.py
+++ b/xmodule/course_block.py
@@ -45,16 +45,11 @@ CATALOG_VISIBILITY_CATALOG_AND_ABOUT = "both"
 CATALOG_VISIBILITY_ABOUT = "about"
 CATALOG_VISIBILITY_NONE = "none"
 
-DEFAULT_COURSE_VISIBILITY_IN_CATALOG = getattr(
-    settings,
-    'DEFAULT_COURSE_VISIBILITY_IN_CATALOG',
-    'both'
-)
+DEFAULT_COURSE_VISIBILITY_IN_CATALOG = settings.DEFAULT_COURSE_VISIBILITY_IN_CATALOG
 
-DEFAULT_MOBILE_AVAILABLE = getattr(settings, 'DEFAULT_MOBILE_AVAILABLE', False)
-# Note: updating assets does not have settings defined, so using `getattr`.
-EXAM_SETTINGS_HTML_VIEW_ENABLED = getattr(settings, 'ENABLE_EXAM_SETTINGS_HTML_VIEW', False)
-SPECIAL_EXAMS_ENABLED = getattr(settings, 'ENABLE_SPECIAL_EXAMS', False)
+DEFAULT_MOBILE_AVAILABLE = settings.DEFAULT_MOBILE_AVAILABLE
+EXAM_SETTINGS_HTML_VIEW_ENABLED = settings.ENABLE_EXAM_SETTINGS_HTML_VIEW
+SPECIAL_EXAMS_ENABLED = settings.ENABLE_SPECIAL_EXAMS
 
 COURSE_VISIBILITY_PRIVATE = 'private'
 COURSE_VISIBILITY_PUBLIC_OUTLINE = 'public_outline'
@@ -236,7 +231,7 @@ class ProctoringProvider(String):
         and include any inherited values from the platform default.
         """
         value = super().from_json(value)
-        if getattr(settings, 'ENABLE_PROCTORED_EXAMS', False):
+        if settings.ENABLE_PROCTORED_EXAMS:
             # Only validate the provider value if ProctoredExams are enabled on the environment
             # Otherwise, the passed in provider does not matter. We should always return default
             if validate_providers:
@@ -275,7 +270,7 @@ class ProctoringProvider(String):
         """
         default = super().default
 
-        proctoring_backend_settings = getattr(settings, 'PROCTORING_BACKENDS', None)
+        proctoring_backend_settings = settings.PROCTORING_BACKENDS
 
         if proctoring_backend_settings:
             return proctoring_backend_settings.get('DEFAULT', None)
@@ -287,11 +282,7 @@ def get_available_providers() -> list[str]:
     """
     Return list of available proctoring providers.
     """
-    proctoring_backend_settings = getattr(
-        settings,
-        'PROCTORING_BACKENDS',
-        {}
-    )
+    proctoring_backend_settings = settings.PROCTORING_BACKENDS
 
     available_providers = [provider for provider in proctoring_backend_settings if provider != 'DEFAULT']
     available_providers.append('lti_external')


### PR DESCRIPTION
Two production/settings readers that still went through the `FEATURES` dict.

- **`ENABLE_EXAM_SETTINGS_HTML_VIEW`** — `xmodule/course_block.py` read it via `getattr(settings, 'FEATURES', {}).get('ENABLE_EXAM_SETTINGS_HTML_VIEW', False)` to mark the legacy proctored/timed-exam `CourseBlock` fields as deprecated. It had no flat definition, so this adds an annotated `ENABLE_EXAM_SETTINGS_HTML_VIEW = False` to `openedx/envs/common.py` and reads it via `getattr(settings, 'ENABLE_EXAM_SETTINGS_HTML_VIEW', False)` — matching the adjacent `DEFAULT_MOBILE_AVAILABLE`/`ENABLE_SPECIAL_EXAMS` readers (getattr kept because the module is imported in contexts where settings may not be configured, e.g. asset compilation).
- **`LICENSING`** — `lms/envs/production.py` and `cms/envs/production.py` set `XBLOCK_SETTINGS["VideoBlock"]["licensing_enabled"]` from `FEATURES["LICENSING"]`. `LICENSING` is a flat setting (`openedx/envs/common.py`) available via the common star-import, so read it directly.

Verified: `xmodule/tests/test_course_block.py` passes (33); reloading `course_block` under `@override_settings(ENABLE_EXAM_SETTINGS_HTML_VIEW=True)` yields `EXAM_SETTINGS_HTML_VIEW_ENABLED == True`; `ruff` clean. Operator configs that set these via `FEATURES:` YAML continue to work through the production `FEATURES:`-to-settings loop.