### PR TITLE
refactor: migrate MOCK_SETTINGS and mfe_config test overrides off FEATURES-as-dict

### DIFF
--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -193,9 +193,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
     ENABLED_SIGNALS = ['course_published']
     MOCK_SETTINGS = {
         'DISABLE_START_DATES': False,
-        'FEATURES': {
-            'DISABLE_SET_JWT_COOKIES_FOR_TESTS': True,
-        },
+        'DISABLE_SET_JWT_COOKIES_FOR_TESTS': True,
         'SOCIAL_SHARING_SETTINGS': {
             'CUSTOM_COURSE_URLS': True,
             'DASHBOARD_FACEBOOK': True,
@@ -203,9 +201,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         },
     }
     MOCK_SETTINGS_HIDE_COURSES = {
-        'FEATURES': {
-            'DISABLE_SET_JWT_COOKIES_FOR_TESTS': True,
-        }
+        'DISABLE_SET_JWT_COOKIES_FOR_TESTS': True,
     }
 
     def setUp(self):

--- a/lms/djangoapps/mfe_config_api/tests/test_views.py
+++ b/lms/djangoapps/mfe_config_api/tests/test_views.py
@@ -277,11 +277,10 @@ class MFEConfigTestCase(APITestCase):
         configuration_helpers_mock.get_value.side_effect = side_effect
 
         with override_settings(
-            HOMEPAGE_COURSE_MAX=3,  # Plain settings (lowest precedence)
-            FEATURES={              # Settings FEATURES
-                "ENABLE_COURSE_SORTING_BY_START_DATE": True,
-                "ENABLE_COURSE_DISCOVERY": True,
-            }
+            # Plain settings (lowest precedence)
+            HOMEPAGE_COURSE_MAX=3,
+            ENABLE_COURSE_SORTING_BY_START_DATE=True,
+            ENABLE_COURSE_DISCOVERY=True,
         ):
             response = self.client.get(f"{self.mfe_config_api_url}?mfe=catalog")
 


### PR DESCRIPTION
Two test-only spots that still set flags through the `FEATURES` dict.

- **`common/djangoapps/student/tests/test_views.py`** — `StudentDashboardTests` applied `MOCK_SETTINGS` / `MOCK_SETTINGS_HIDE_COURSES` via `@patch.multiple('django.conf.settings', ...)`, each nesting `DISABLE_SET_JWT_COOKIES_FOR_TESTS` inside a `'FEATURES'` sub-dict. The production reader (`user_authn/cookies.py`) reads the flat `settings.DISABLE_SET_JWT_COOKIES_FOR_TESTS`, so the key moves to the top level of both mock dicts (matching the `DISABLE_START_DATES` entry already there) and the now-empty `FEATURES` sub-dicts are dropped.
- **`lms/djangoapps/mfe_config_api/tests/test_views.py`** — `test_config_order_of_precedence` overrode `FEATURES={ENABLE_COURSE_SORTING_BY_START_DATE, ENABLE_COURSE_DISCOVERY}` as a "settings FEATURES" layer, but the view (`get_legacy_config`) reads those flags as **flat** settings, so the override never reached it. Set them as flat `override_settings` — the plain-settings layer the test intends. No assertion depends on `ENABLE_COURSE_DISCOVERY`, and the `ENABLE_COURSE_SORTING_BY_START_DATE` assertion still holds (MFE_CONFIG takes precedence).

Verified: `test_config_order_of_precedence` passes; the two `StudentDashboardTests` methods that use the mock dicts pass (5); `ruff` clean.