### PR TITLE
feat: [programs API] replace enterprise dependency with plugin hook

### DIFF
--- a/openedx/core/djangoapps/programs/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/programs/rest_api/v1/tests/test_views.py
@@ -6,9 +6,9 @@ from unittest import mock
 from uuid import uuid4
 
 from django.core.cache import cache
+from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse_lazy
-from enterprise.models import EnterpriseCourseEnrollment
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
@@ -22,16 +22,11 @@ from openedx.core.djangoapps.catalog.tests.factories import (
     PathwayFactory,
     ProgramFactory,
 )
+from openedx.core.djangoapps.programs.rest_api.v1.views import get_enterprise_course_ids
 from openedx.core.djangoapps.programs.tests.mixins import ProgramsApiConfigMixin
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from openedx.features.enterprise_support.api import enterprise_is_enabled
-from openedx.features.enterprise_support.tests.factories import (
-    EnterpriseCourseEnrollmentFactory,
-    EnterpriseCustomerFactory,
-    EnterpriseCustomerUserFactory,
-)
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory as ModuleStoreCourseFactory
 
@@ -135,6 +130,38 @@ class TestProgramProgressDetailView(ProgramsApiConfigMixin, SharedModuleStoreTes
         assert response.data["error_code"] == "No program data available."
 
 
+# Test target for OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS.
+_fake_get_enterprise_course_ids = mock.MagicMock(return_value=[])
+FAKE_OVERRIDE_PATH = f"{__name__}._fake_get_enterprise_course_ids"
+
+
+@skip_unless_lms
+class TestGetEnterpriseCourseIds(TestCase):
+    """Unit tests for the get_enterprise_course_ids pluggable override point."""
+
+    def test_get_enterprise_course_ids_default(self):
+        """With no plugin override configured, the base implementation returns an empty list"""
+        enterprise_uuid, user = str(uuid4()), mock.Mock()
+
+        result = get_enterprise_course_ids(enterprise_uuid=enterprise_uuid, user=user)
+
+        assert not result
+
+    @override_settings(OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS=FAKE_OVERRIDE_PATH)
+    def test_get_enterprise_course_ids_uses_plugin_override(self):
+        """When OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS is configured, it is used instead"""
+        enterprise_uuid, user = str(uuid4()), mock.Mock()
+        _fake_get_enterprise_course_ids.reset_mock()
+        _fake_get_enterprise_course_ids.return_value = ["course-v1:edX+DemoX+Demo_Course"]
+
+        result = get_enterprise_course_ids(enterprise_uuid=enterprise_uuid, user=user)
+
+        assert result == ["course-v1:edX+DemoX+Demo_Course"]
+        _fake_get_enterprise_course_ids.assert_called_once_with(
+            mock.ANY, enterprise_uuid=enterprise_uuid, user=user
+        )
+
+
 @skip_unless_lms
 class TestProgramsEnterpriseView(SharedModuleStoreTestCase, ProgramCacheMixin):
     """Unit tests for the program details page."""
@@ -149,17 +176,10 @@ class TestProgramsEnterpriseView(SharedModuleStoreTestCase, ProgramCacheMixin):
 
         cls.user = UserFactory()
         modulestore_course = ModuleStoreCourseFactory()
-        course_run = CourseRunFactory(key=str(modulestore_course.id))
+        cls.course_id = str(modulestore_course.id)
+        course_run = CourseRunFactory(key=cls.course_id)
         course = CourseFactory(course_runs=[course_run])
-        enterprise_customer = EnterpriseCustomerFactory(uuid=cls.enterprise_uuid)
-        enterprise_customer_user = EnterpriseCustomerUserFactory(
-            user_id=cls.user.id, enterprise_customer=enterprise_customer
-        )
         CourseEnrollmentFactory(is_active=True, course_id=modulestore_course.id, user=cls.user)
-        EnterpriseCourseEnrollmentFactory(
-            course_id=modulestore_course.id,
-            enterprise_customer_user=enterprise_customer_user,
-        )
 
         cls.program = ProgramFactory(
             uuid=cls.program_uuid,
@@ -184,20 +204,20 @@ class TestProgramsEnterpriseView(SharedModuleStoreTestCase, ProgramCacheMixin):
             program_uuid=self.program_uuid,
             external_user_key="0001",
         )
-
-    @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
-    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
-    @enterprise_is_enabled()
-    def test_program_list_enterprise(self):
-        """
-        Verify API returns proper response.
-        """
+        _fake_get_enterprise_course_ids.reset_mock()
+        _fake_get_enterprise_course_ids.return_value = [self.course_id]
         cache.set(
             SITE_PROGRAM_UUIDS_CACHE_KEY_TPL.format(domain=self.site.domain),
             [self.program_uuid],
             None,
         )
 
+    @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
+    @override_settings(OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS=FAKE_OVERRIDE_PATH)
+    def test_program_list_enterprise(self):
+        """
+        Verify API returns proper response.
+        """
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)  # noqa: PT009
         program = response.data[0]
@@ -216,25 +236,30 @@ class TestProgramsEnterpriseView(SharedModuleStoreTestCase, ProgramCacheMixin):
             "all_unenrolled": False,
         }
 
+        _fake_get_enterprise_course_ids.assert_called_once_with(
+            mock.ANY, enterprise_uuid=self.enterprise_uuid, user=self.user
+        )
+
     @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
-    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
-    @enterprise_is_enabled()
+    @override_settings(OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS=FAKE_OVERRIDE_PATH)
     def test_program_empty_list_if_no_enterprise_enrollments(self):
         """
         Verify API returns empty response if no enterprise enrollments exists for a learner.
         """
-        # delete all enterprise course enrollments for the user
-        EnterpriseCourseEnrollment.objects.filter(enterprise_customer_user__user_id=self.user.id).delete()
-
-        cache.set(
-            SITE_PROGRAM_UUIDS_CACHE_KEY_TPL.format(domain=self.site.domain),
-            [self.program_uuid],
-            None,
-        )
+        _fake_get_enterprise_course_ids.return_value = []
 
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)  # noqa: PT009
         self.assertEqual(response.data, [])  # noqa: PT009
+
+    @with_site_configuration(configuration={"COURSE_CATALOG_API_URL": "foo"})
+    def test_program_empty_list_without_override(self):
+        """
+        Verify API returns an empty response (not a 500) when no plugin override is installed.
+        """
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert not response.data
 
 
 @skip_unless_lms

--- a/openedx/core/djangoapps/programs/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/programs/rest_api/v1/views.py
@@ -3,7 +3,7 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
-from django.db.models.query import EmptyQuerySet
+from edx_django_utils.plugins import pluggable_override
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -16,17 +16,24 @@ from openedx.core.djangoapps.programs.utils import (
     get_program_and_course_data,
     get_program_urls,
 )
-from openedx.features.enterprise_support.api import enterprise_is_enabled, get_enterprise_course_enrollments
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import AnonymousUser, User  # pylint: disable=imported-auth-user
     from django.contrib.sites.models import Site
-    from django.db.models.query import QuerySet
     from django.http import HttpRequest, HttpResponse
 
-    from common.djangoapps.student.models import CourseEnrollment
-
 logger = logging.getLogger(__name__)
+
+
+@pluggable_override('OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS')
+def get_enterprise_course_ids(enterprise_uuid: str, user: "AnonymousUser | User") -> list[str]:
+    """
+    Return the course IDs the given user is enterprise-enrolled in for one enterprise customer.
+
+    This function can be overridden by an installed plugin via the
+    OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS setting.
+    """
+    return []
 
 
 class Programs(APIView):
@@ -92,9 +99,10 @@ class Programs(APIView):
         user: "AnonymousUser | User" = request.user  # noqa: UP037
 
         if enterprise_uuid:
-            enrollments = list(self._get_enterprise_course_enrollments(enterprise_uuid, user))
+            course_ids = get_enterprise_course_ids(enterprise_uuid=enterprise_uuid, user=user)
+            enrollments = list(get_course_enrollments(user=user, is_filtered=True, course_ids=course_ids))
         else:
-            enrollments = list(get_course_enrollments(user))
+            enrollments = list(get_course_enrollments(user=user))
 
         # return empty reponse if no enrollments exists for a user
         if not enrollments:
@@ -178,23 +186,6 @@ class Programs(APIView):
             programs.append(program)
 
         return programs
-
-    @enterprise_is_enabled(otherwise=EmptyQuerySet)
-    def _get_enterprise_course_enrollments(
-        self, enterprise_uuid: str, user: "AnonymousUser | User"
-    ) -> "QuerySet[CourseEnrollment]":
-        """
-        Return only enterprise enrollments for a user.
-        """
-        enterprise_enrollment_course_ids = (
-            get_enterprise_course_enrollments(user)
-            .filter(enterprise_customer_user__enterprise_customer__uuid=enterprise_uuid)
-            .values_list("course_id", flat=True)
-        )
-
-        course_enrollments = get_course_enrollments(user, True, list(enterprise_enrollment_course_ids))
-
-        return course_enrollments
 
 
 class ProgramProgressDetailView(APIView):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,7 +290,7 @@ constraint-dependencies = [
     "sphinx-autoapi<3.6.1",
     "setuptools<82",
     "astroid==4.0.4",
-    "edx-enterprise==8.9.2",
+    "edx-enterprise==8.9.3",
 ]
 [tool.edx_lint]
 uv_constraints = [
@@ -402,12 +402,11 @@ uv_constraints = [
     # version of astroid.
     # https://github.com/openedx/openedx-platform/issues/38066
     "astroid==4.0.4",
-    # Date: 2019-08-16 (bumped 2026-08-22 to match master's own already-reviewed
-    # bump in requirements/constraints.txt, PR #39012)
+    # Date: 2019-08-16
     # The team that owns this package will manually bump this package rather than
     # having it pulled in automatically. This is to allow them to better control its
     # deployment and to do it in a process that works better for them.
-    "edx-enterprise==8.9.2",
+    "edx-enterprise==8.9.3",
 ]
 
 [tool.setuptools]

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -482,7 +482,7 @@ edx-drf-extensions==10.6.0
     #   openedx-authz
     #   openedx-core
     #   openedx-platform
-edx-enterprise==8.9.2
+edx-enterprise==8.9.3
     # via openedx-platform
 edx-event-bus-kafka==6.1.0
     # via openedx-platform

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -534,7 +534,7 @@ edx-drf-extensions==10.6.0
     #   openedx-authz
     #   openedx-core
     #   openedx-platform
-edx-enterprise==8.9.2
+edx-enterprise==8.9.3
     # via openedx-platform
 edx-event-bus-kafka==6.1.0
     # via openedx-platform

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ constraints = [
     { name = "django-debug-toolbar", specifier = "<6.0.0" },
     { name = "django-oauth-toolkit", specifier = "==1.7.1" },
     { name = "django-stubs", specifier = "<6" },
-    { name = "edx-enterprise", specifier = "==8.9.2" },
+    { name = "edx-enterprise", specifier = "==8.9.3" },
     { name = "elasticsearch", specifier = "==7.9.1" },
     { name = "libsass", specifier = "==0.10.0" },
     { name = "lxml", specifier = "==5.3.2" },
@@ -1905,7 +1905,7 @@ wheels = [
 
 [[package]]
 name = "edx-enterprise"
-version = "8.9.2"
+version = "8.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleach" },
@@ -1958,9 +1958,9 @@ dependencies = [
     { name = "tincan" },
     { name = "unicodecsv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/bc/c5d43697f518e0f543781228d6e58892788c868cd218658aeaae371b0dfe/edx_enterprise-8.9.2.tar.gz", hash = "sha256:04c707debfb2970150c3611e8561198a32a3baba454b84ce0838f1662f5ce75d", size = 5164812, upload-time = "2026-08-21T14:41:26.226Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/8b/e82f92d8c861f1aee7571cf720ee8fae9d5e86572f235a0d27581d0e872b/edx_enterprise-8.9.3.tar.gz", hash = "sha256:684c0db1af35cf86fc5bbf98ffb1859ffde90b35a4f623b550a58b2e77ce2dc2", size = 5165693, upload-time = "2026-08-26T18:30:35.631Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/e0/93ba79e1976596dfa1bfe962a444d960fd1c35d84c6d55c8ee854df4de83/edx_enterprise-8.9.2-py3-none-any.whl", hash = "sha256:96dcacc4f454fd3109a8cd05e732aa5d3c140b2acb0236636a570448481f02ee", size = 5557964, upload-time = "2026-08-21T14:41:22.29Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c7/4df9e3316e4d44a23d749ba06fbe79fd60eb31181f584ec018cc3947bb63/edx_enterprise-8.9.3-py3-none-any.whl", hash = "sha256:ac13111029a9f957e55da2a248f62fb77bcb6d04f0349dc627cdb2950ea1d26c", size = 5558858, upload-time = "2026-08-26T18:30:31.676Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The programs API has two variants: B2C and B2B:

- B2C: `GET /api/dashboard/v1/programs/`
- B2B: `GET /api/dashboard/v1/programs/{enterprise_uuid}/`

The B2B variant uses enterprise internal functions to help filter the response to include only enterprise-subsidized enrollments. This can't go on any longer because we need to remove all enterprise imports from the platform.

This commit replaces those enterprise function calls with a plugin hook point. We introduce the `OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS` pluggable override which allows the enterprise plugin itself register an implementation, allowing all `enterprise` imports to be removed from the programs API views.py file.

ENT-11575

---

For comparison, here's the PR on thee 2U side: https://github.com/edx/edx-platform/pull/439