### PR TITLE
fix: lay out the fullscreen XBlock editor as a column [backport to verawood]

### DIFF
--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -439,7 +439,20 @@
 
             ul.settings-list {
               flex-grow: 1;
+              min-height: 0;
             }
+
+            > form {
+              display: flex;
+              flex-direction: column;
+              flex-grow: 1;
+              min-height: 0;
+            }
+          }
+
+          .xblock-actions {
+            position: static;
+            flex-shrink: 0;
           }
         }
       }


### PR DESCRIPTION
## Description

Backport of #39032 to `release/verawood`.

Expanding the Studio component editor to fullscreen left the settings of every advanced block either cut off or stranded. With a long settings list the Save and Cancel bar covered the last entries — the list scrolled under the bar but never past it. With a short one, the editor kept its natural height at the top of the page and the buttons sat alone at the very bottom, with a few hundred pixels of nothing between them.

Fullscreen now lays the editor out as a real column: the buttons sit directly under the settings, the settings take the height that is left and scroll inside it, and nothing hides behind anything. The normal, sized editor is untouched.

<details><summary>Implementation notes</summary>

- Three rules, all inside the existing `.modal-fullscreen` block of `cms/static/sass/elements/_modal-window.scss`.
- `.xblock-actions` is `position: absolute; bottom: 0` for the sized modal, where it lands just below the editor anyway. In a full-height column that becomes an overlay on the end of the scroll area, so fullscreen puts it back into the flow.
- `ul.settings-list` needed `min-height: 0` — as a flex item it would not shrink below its content, so it could not give the bar its 68px.
- `> form` covers the blocks whose studio view wraps the settings in a form (poll and survey do; scorm and feedback do not). The growing column stopped at that wrapper, which is why those two showed the empty-page symptom while the other two showed the cut-off one.
- No JS and no markup changes: the two shapes differ only in whether the wrapper is there.

</details>

## Screenshot/Video

| # | View | What to check | Before | After |
|:-:|:-----|:--------------|:-------|:------|
| 1 | **scorm, fullscreen**, settings scrolled to the end | The last setting is readable and clickable instead of sitting under the button bar | `01-legacy-scorm-before.png` | `01-legacy-scorm-after.png` |
| 2 | **poll, fullscreen** | The buttons sit under the form rather than at the foot of the page, and the form uses the height | `02-legacy-poll-before.png` | `02-legacy-poll-after.png` |

## Testing

Preconditions: a course with scorm, feedback, poll and survey components, a staff user.

1. Open a unit in Studio and click **Edit** on the scorm component, then the expand icon in the editor header.
2. Expected: the Save and Cancel bar sits below the settings, not over them. Scroll the settings to the end — the last setting is fully visible above the bar, not behind it.
3. Repeat for feedback.
4. Repeat for poll and survey.
5. Expected: the settings fill the height of the page and scroll, and the buttons sit right below them — not at the foot of the page with a gap above.
6. Leave fullscreen and check the same four in the normal editor.
7. Expected: unchanged from before this branch.

## Verified locally

| Check | Result |
|---|---|
| Fullscreen, all four blocks | settings list and button bar no longer overlap (was 68px on scorm and feedback); no empty space left below the bar (was 363px on poll and survey) |
| scorm, fullscreen | list 738px tall over 1142px of content, scrolls; scrolled to the end, the last setting sits fully inside the list |
| feedback, fullscreen | list 738px over 1984px, same behaviour |
| poll / survey, fullscreen | list grew from 375px to 738px — it was pinned to its natural height before |
| Normal editor, scorm | measurements identical to the branch point; the change is scoped to fullscreen |
| Sass build | `scripts/compile_sass.py --env=development` compiles; the rules land in the served `studio-main-v1.css` |
| **Not verified** | Only the four block types from the ticket were measured, in one browser at 1440×863. No automated test covers this — the file has no test coverage to extend. |
