### PR TITLE
feat: add MEILISEARCH_COURSE_INDEXING to scope Studio course indexing

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1284,6 +1284,18 @@ MEILISEARCH_PUBLIC_URL = "http://meilisearch.example.com"
 MEILISEARCH_INDEX_PREFIX = ""
 MEILISEARCH_API_KEY = "devkey"
 
+# .. setting_name: MEILISEARCH_COURSE_INDEXING
+# .. setting_default: 'all'
+# .. setting_description: Controls how much course content is written to the Studio
+# ..   Meilisearch index. 'all' indexes every course XBlock, the historical behaviour.
+# ..   'library_downstream_only' indexes only course blocks linked to a library upstream,
+# ..   which is what the course-libraries Review tab needs; the Studio course content
+# ..   search modal and the course outline block-type facets go empty. 'none' writes no
+# ..   course content at all. Library content is indexed in every mode. Changing this
+# ..   setting takes full effect after a reindex (./manage.py cms reindex_studio
+# ..   --experimental), so it is reversible without a code change.
+MEILISEARCH_COURSE_INDEXING = "all"
+
 # .. setting_name: LIBRARY_ENABLED_BLOCKS
 # .. setting_default: ['problem', 'video', 'html', 'drag-and-drop-v2']
 # .. setting_description: List of block types that are ready/enabled to be created/used

--- a/openedx/core/djangoapps/content/search/api.py
+++ b/openedx/core/djangoapps/content/search/api.py
@@ -80,6 +80,15 @@ MAX_ORGS_IN_FILTER = 1_000
 
 EXCLUDED_XBLOCK_TYPES = ["course", "course_info"]
 
+# Values for the MEILISEARCH_COURSE_INDEXING setting, which controls how much course
+# content is written to the Studio index. Library content is always indexed.
+COURSE_INDEXING_ALL = "all"
+COURSE_INDEXING_LIBRARY_DOWNSTREAM_ONLY = "library_downstream_only"
+COURSE_INDEXING_NONE = "none"
+COURSE_INDEXING_MODES = frozenset(
+    {COURSE_INDEXING_ALL, COURSE_INDEXING_LIBRARY_DOWNSTREAM_ONLY, COURSE_INDEXING_NONE}
+)
+
 
 @contextmanager
 def _index_rebuild_lock() -> Generator[str, None, None]:
@@ -355,6 +364,48 @@ def is_meilisearch_enabled() -> bool:
     return False
 
 
+def get_course_indexing_mode() -> str:
+    """
+    Returns the configured MEILISEARCH_COURSE_INDEXING mode.
+
+    Falls back to indexing everything, which is the historical behaviour, when the
+    setting is absent or holds an unrecognised value.
+    """
+    mode = getattr(settings, "MEILISEARCH_COURSE_INDEXING", COURSE_INDEXING_ALL)
+    if mode not in COURSE_INDEXING_MODES:
+        log.warning(
+            "Unrecognised MEILISEARCH_COURSE_INDEXING value %r; falling back to %r.",
+            mode,
+            COURSE_INDEXING_ALL,
+        )
+        return COURSE_INDEXING_ALL
+    return mode
+
+
+def is_course_indexing_enabled() -> bool:
+    """
+    Returns whether any course content is written to the Studio index.
+    """
+    return get_course_indexing_mode() != COURSE_INDEXING_NONE
+
+
+def should_index_course_block(block) -> bool:
+    """
+    Returns whether the given course XBlock should get a document in the Studio index.
+
+    Under ``library_downstream_only`` only blocks linked to a library upstream are
+    indexed. That is the set the course-libraries Review tab hydrates its out-of-sync
+    list from, so gating here keeps Libraries V2 workflows intact while dropping the
+    course-content bulk that dominates the index.
+    """
+    mode = get_course_indexing_mode()
+    if mode == COURSE_INDEXING_ALL:
+        return True
+    if mode == COURSE_INDEXING_NONE:
+        return False
+    return bool(getattr(block, "upstream", None))
+
+
 def reset_index(status_cb: Callable[[str], None] | None = None) -> None:
     """
     Reset the Meilisearch index, deleting all documents and reconfiguring it
@@ -564,9 +615,11 @@ def index_course(
 
     def add_with_children(block):
         """Recursively index the given XBlock/component"""
-        doc = searchable_doc_for_course_block(block)
-        doc.update(searchable_doc_tags(block.usage_key))
-        docs.append(doc)  # pylint: disable=cell-var-from-loop
+        # Recurse regardless: a skipped section can still contain indexable children.
+        if should_index_course_block(block):
+            doc = searchable_doc_for_course_block(block)
+            doc.update(searchable_doc_tags(block.usage_key))
+            docs.append(doc)  # pylint: disable=cell-var-from-loop
         _recurse_children(block, add_with_children)  # pylint: disable=cell-var-from-loop
 
     # Index course children
@@ -604,8 +657,12 @@ def rebuild_index(  # pylint: disable=too-many-statements
     num_libraries = len(lib_keys)
 
     # Get the list of courses
-    status_cb("Counting courses...")
-    num_courses = CourseOverview.objects.count()
+    index_courses = is_course_indexing_enabled()
+    if index_courses:
+        status_cb("Counting courses...")
+        num_courses = CourseOverview.objects.count()
+    else:
+        num_courses = 0
 
     # Some counters so we can track our progress as indexing progresses:
     num_libs_skipped = len(keys_indexed)
@@ -742,23 +799,27 @@ def rebuild_index(  # pylint: disable=too-many-statements
             num_contexts_done += 1
 
         ############## Courses ##############
-        status_cb("Indexing courses...")
-        # To reduce memory usage on large instances, split up the CourseOverviews into pages of 1,000 courses:
+        if index_courses:
+            status_cb("Indexing courses...")
+            # To reduce memory usage on large instances, split up the CourseOverviews into pages of 1,000 courses:
 
-        paginator = Paginator(CourseOverview.objects.only("id", "display_name").order_by("-created", "id"), 1000)
-        for p in paginator.page_range:
-            for course in paginator.page(p).object_list:
-                status_cb(
-                    f"{num_contexts_done + 1}/{num_contexts}. Now indexing course {course.display_name} ({course.id})"
-                )
-                if course.id in keys_indexed:
+            paginator = Paginator(CourseOverview.objects.only("id", "display_name").order_by("-created", "id"), 1000)
+            for p in paginator.page_range:
+                for course in paginator.page(p).object_list:
+                    status_cb(
+                        f"{num_contexts_done + 1}/{num_contexts}. "
+                        f"Now indexing course {course.display_name} ({course.id})"
+                    )
+                    if course.id in keys_indexed:
+                        num_contexts_done += 1
+                        continue
+                    course_docs = index_course(course.id, index_name, status_cb)
+                    if incremental:
+                        IncrementalIndexCompleted.objects.get_or_create(context_key=course.id)
                     num_contexts_done += 1
-                    continue
-                course_docs = index_course(course.id, index_name, status_cb)
-                if incremental:
-                    IncrementalIndexCompleted.objects.get_or_create(context_key=course.id)
-                num_contexts_done += 1
-                num_blocks_done += len(course_docs)
+                    num_blocks_done += len(course_docs)
+        else:
+            status_cb("Skipping courses: MEILISEARCH_COURSE_INDEXING is 'none'.")
 
     IncrementalIndexCompleted.objects.all().delete()
     status_cb(f"Done! {num_blocks_done} blocks indexed across {num_contexts_done} courses, collections and libraries.")
@@ -773,6 +834,9 @@ def upsert_xblock_index_doc(usage_key: UsageKey, recursive: bool = True) -> None
         usage_key (UsageKey): The usage key of the XBlock to index
         recursive (bool): If True, also index all children of the XBlock
     """
+    if not is_course_indexing_enabled():
+        return
+
     xblock = modulestore().get_item(usage_key)
     xblock_type = xblock.scope_ids.block_type
 
@@ -783,12 +847,16 @@ def upsert_xblock_index_doc(usage_key: UsageKey, recursive: bool = True) -> None
 
     def add_with_children(block):
         """Recursively index the given XBlock/component"""
-        doc = searchable_doc_for_course_block(block)
-        docs.append(doc)
+        # Recurse regardless: a skipped section can still contain indexable children.
+        if should_index_course_block(block):
+            docs.append(searchable_doc_for_course_block(block))
         if recursive:
             _recurse_children(block, add_with_children)
 
     add_with_children(xblock)
+
+    if not docs:
+        return
 
     _update_index_docs(docs)
 

--- a/openedx/core/djangoapps/content/search/handlers.py
+++ b/openedx/core/djangoapps/content/search/handlers.py
@@ -47,6 +47,7 @@ from openedx.core.djangoapps.content_libraries import api as lib_api
 from xmodule.modulestore.django import SignalHandler
 
 from .api import (
+    is_course_indexing_enabled,
     is_meilisearch_enabled,
     only_if_meilisearch_enabled,
     reconcile_index,
@@ -125,6 +126,9 @@ def xblock_created_handler(**kwargs) -> None:
         log.error("Received null or incorrect data for event")
         return
 
+    if not is_course_indexing_enabled():
+        return
+
     upsert_xblock_index_doc.delay(
         str(xblock_info.usage_key),
         recursive=False,
@@ -140,6 +144,9 @@ def xblock_updated_handler(**kwargs) -> None:
     xblock_info = kwargs.get("xblock_info", None)
     if not xblock_info or not isinstance(xblock_info, XBlockData):  # pragma: no cover
         log.error("Received null or incorrect data for event")
+        return
+
+    if not is_course_indexing_enabled():
         return
 
     upsert_xblock_index_doc.delay(
@@ -396,6 +403,9 @@ def handle_reindex_on_signal(**kwargs):
     course_data = kwargs.get("course", None)
     if not course_data or not isinstance(course_data, CourseData):
         log.error("Received null or incorrect data for event")
+        return
+
+    if not is_course_indexing_enabled():
         return
 
     upsert_course_blocks_docs.delay(str(course_data.course_key))

--- a/openedx/core/djangoapps/content/search/tests/test_api.py
+++ b/openedx/core/djangoapps/content/search/tests/test_api.py
@@ -386,6 +386,23 @@ class TestSearchApi(ModuleStoreTestCase):
             any_order=True,
         )
 
+    @override_settings(MEILISEARCH_ENABLED=True, MEILISEARCH_COURSE_INDEXING="none")
+    def test_reindex_meilisearch_skips_courses(self, mock_meilisearch) -> None:
+        """
+        A rebuild with course indexing off still populates every library document and
+        writes no course documents, which is what makes the gate reversible: flip the
+        setting back to "all" and re-run reindex_studio to restore course content.
+        """
+        api.rebuild_index()
+
+        indexed_types = {
+            doc["type"]
+            for call_args in mock_meilisearch.return_value.index.return_value.add_documents.call_args_list
+            for doc in call_args[0][0]
+        }
+        assert "course_block" not in indexed_types
+        assert "library_block" in indexed_types
+
     @override_settings(MEILISEARCH_ENABLED=True)
     def test_reindex_meilisearch_incremental(self, mock_meilisearch) -> None:
 
@@ -603,6 +620,54 @@ class TestSearchApi(ModuleStoreTestCase):
         api.upsert_xblock_index_doc(UsageKey.from_string(self.course_block_key))
 
         mock_meilisearch.return_value.index.return_value.update_document.assert_not_called()
+
+    @override_settings(MEILISEARCH_ENABLED=True, MEILISEARCH_COURSE_INDEXING="none")
+    def test_index_xblock_course_indexing_none(self, mock_meilisearch) -> None:
+        """
+        With course indexing off entirely, no course block reaches the index.
+        """
+        api.upsert_xblock_index_doc(self.sequential.usage_key, recursive=True)
+
+        mock_meilisearch.return_value.index.return_value.update_documents.assert_not_called()
+
+    @override_settings(MEILISEARCH_ENABLED=True, MEILISEARCH_COURSE_INDEXING="library_downstream_only")
+    def test_index_xblock_downstream_only_skips_unlinked(self, mock_meilisearch) -> None:
+        """
+        Course blocks with no library upstream are skipped in library_downstream_only mode.
+        """
+        api.upsert_xblock_index_doc(self.sequential.usage_key, recursive=True)
+
+        mock_meilisearch.return_value.index.return_value.update_documents.assert_not_called()
+
+    @override_settings(MEILISEARCH_ENABLED=True, MEILISEARCH_COURSE_INDEXING="library_downstream_only")
+    def test_index_xblock_downstream_only_indexes_linked(self, mock_meilisearch) -> None:
+        """
+        A course block linked to a library upstream is still indexed, and the walk
+        reaches it through an ancestor that is itself skipped.
+
+        This is what the course-libraries Review tab hydrates its out-of-sync list from.
+        """
+        vertical = self.store.get_item(
+            UsageKey.from_string("block-v1:org1+test_course+test_run+type@vertical+block@test_vertical")
+        )
+        vertical.upstream = str(self.problem1.usage_key)
+        self.store.update_item(vertical, self.user_id)
+
+        api.upsert_xblock_index_doc(self.sequential.usage_key, recursive=True)
+
+        indexed = mock_meilisearch.return_value.index.return_value.update_documents.call_args[0][0]
+        assert [doc["usage_key"] for doc in indexed] == [str(vertical.usage_key)]
+
+    @override_settings(MEILISEARCH_ENABLED=True)
+    @ddt.data("all", "library_downstream_only", "none")
+    def test_get_course_indexing_mode(self, mode, mock_meilisearch) -> None:  # pylint: disable=unused-argument
+        with override_settings(MEILISEARCH_COURSE_INDEXING=mode):
+            assert api.get_course_indexing_mode() == mode
+
+    @override_settings(MEILISEARCH_ENABLED=True, MEILISEARCH_COURSE_INDEXING="nonsense")
+    def test_get_course_indexing_mode_invalid(self, mock_meilisearch) -> None:  # pylint: disable=unused-argument
+        assert api.get_course_indexing_mode() == api.COURSE_INDEXING_ALL
+        assert api.is_course_indexing_enabled()
 
     @override_settings(MEILISEARCH_ENABLED=True)
     def test_index_xblock_tags(self, mock_meilisearch) -> None:

--- a/openedx/core/djangoapps/content/search/tests/test_handlers.py
+++ b/openedx/core/djangoapps/content/search/tests/test_handlers.py
@@ -139,6 +139,39 @@ class TestUpdateIndexHandlers(ModuleStoreTestCase, LiveServerTestCase):
             "block-v1orgatest_coursetest_runtypeverticalblocktest_vertical-011f143b"
         )
 
+    @override_settings(MEILISEARCH_COURSE_INDEXING="none")
+    def test_course_indexing_none_skips_xblock_events(self, meilisearch_client):
+        """
+        With MEILISEARCH_COURSE_INDEXING='none', XBlock create/update events never
+        reach the index. Deletes stay ungated so a later re-enable does not inherit
+        stale documents.
+        """
+        course = self.store.create_course(
+            self.orgA.short_name,
+            "no_index_course",
+            "test_run",
+            self.user_id,
+            fields={"display_name": "Test Course"},
+        )
+        SearchAccess.objects.get_or_create(context_key=course.id)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            sequential = self.store.create_child(self.user_id, course.location, "sequential", "test_sequential")
+
+        meilisearch_client.return_value.index.return_value.update_documents.assert_not_called()
+
+        sequential = self.store.get_item(sequential.location, self.user_id)
+        sequential.display_name = "Updated Sequential"
+        with self.captureOnCommitCallbacks(execute=True):
+            self.store.update_item(sequential, self.user_id)
+
+        meilisearch_client.return_value.index.return_value.update_documents.assert_not_called()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.store.delete_item(sequential.location, self.user_id)
+
+        meilisearch_client.return_value.index.return_value.delete_document.assert_called()
+
     def test_library_creation_creates_search_access(self, meilisearch_client):
         """
         Test that creating a library automatically creates a SearchAccess record.


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

`openedx/core/djangoapps/content/search` is gated only on `MEILISEARCH_ENABLED`, so an operator running Meilisearch for Libraries V2 necessarily also indexes every course XBlock into `studio_content`. There is currently no way to have one without the other.

This adds `MEILISEARCH_COURSE_INDEXING`, which takes three values:

- `all` — every course XBlock. The default, so behaviour is unchanged for everyone who does not set it.
- `library_downstream_only` — only course blocks carrying an `upstream` link.
- `none` — no course content, and no indexing task is even enqueued.

Library content (Libraries V2 blocks, collections, containers) is indexed in every mode.

`library_downstream_only` is the interesting one, and it lines up with an existing invariant rather than inventing a new rule.

`frontend-app-authoring`'s course-libraries Review tab lists library components in a course that have upstream updates ready to sync. It gets the authoritative list from the entity-links REST API, then queries this index purely to hydrate those blocks for display:

```jsx
// src/course-libraries/ReviewTabContent.tsx
extraFilter={[`context_key = "${courseId}"`, `usage_key IN ["${downstreamKeys?.join('","')}"]`]}
```

where `downstreamKeys` is `outOfSyncItems.map(link => link.downstreamUsageKey)`. Every one of those keys belongs to a `PublishableEntityLink` row, and `create_or_update_xblock_upstream_link` (`cms/djangoapps/contentstore/utils.py`) opens with `if not xblock.upstream: return None`. So a link exists only where `xblock.upstream` is set — which is exactly what the gate keeps. That holds for the `use_top_level_parents=True` case the Review tab passes too, since the substituted parents are themselves `ContainerLink` rows.

What it gives up is the Studio course content search modal and the block-type breakdown in the course outline info sidebar. LMS-side courseware search and discovery are untouched: `openedx.core.djangoapps.content.search` is in `cms/envs/common.py`'s `INSTALLED_APPS` only, not the LMS's.

Details worth noting in review:

- The gate is `should_index_course_block(block)` in `api.py`, testing `getattr(block, "upstream", None)`. `upstream` is a `String` field on `UpstreamSyncMixin` (`cms/lib/xblock/upstream_sync.py`), which is in the CMS `XBLOCK_MIXINS`, so the test needs no extra DB round trip.
- `index_course` and `upsert_xblock_index_doc` filter each block but **recurse regardless**, since an unlinked section can contain linked children.
- `rebuild_index` skips the Courses section entirely (including the `CourseOverview` count) only when the mode is `none`.
- Deletes are deliberately left ungated — `xblock_deleted_handler` and `listen_for_course_delete` — so that widening the setting later does not inherit index documents for content that was removed while the scope was narrow.
- Switching modes takes full effect after `./manage.py cms reindex_studio`, so the scope is reversible by configuration rather than by reverting a commit.
- Not gated: the tag/collection stub-doc path (`upsert_content_object_tags_index_doc` and friends). It is driven by manual tagging at human scale, and gating it would require a modulestore load inside a signal handler for negligible benefit.

What motivated it, from one production instance on 2026-08-28: `studio_content` held 1,319,937 documents at 11.91 GiB against a 4 GiB pod memory limit. 966 of those documents were library content. The rest were course XBlocks, written by ordinary publishes plus a batch of course reruns and imports. That instance runs Meilisearch solely for Libraries V2; Studio course search is not a feature it uses. The index size was in turn making library component creation slow enough to hit a gateway timeout.

### How can this be tested?

**Automated.** New tests in `openedx/core/djangoapps/content/search/tests/test_api.py` and `tests/test_handlers.py` cover: `none` writing nothing; `library_downstream_only` skipping an unlinked block while still indexing one whose `upstream` is set, reached through a skipped ancestor; a rebuild under `none` emitting `library_block` docs and no `course_block` docs; and an unrecognised setting value falling back to `all`. **These have not been executed** — I have no local edx-platform environment, so they have had a compile and line-length check only. CI needs to run them.

**Manual**, against a Studio with Meilisearch enabled and at least one V2 library:

1. Leave the setting unset. Publish a course block and confirm it still reaches the index — this is the no-op path that protects existing operators.
2. Set `MEILISEARCH_COURSE_INDEXING = "library_downstream_only"`, restart, and run `./manage.py cms reindex_studio --experimental`. Confirm the index drops to library content plus downstream course blocks.
3. Publish, import and rerun a course. Confirm no document writes for blocks with no `upstream`.
4. Create, edit, publish and delete a V2 library component. Each should still reach the index.
5. On a course with a library component that has a pending upstream update, confirm the course-libraries **Review** tab still lists it and renders its display data. This is the criterion the design exists to satisfy.
6. Confirm the Studio course content search modal and the outline block-type facets are empty, which is the accepted cost.
7. Set the value back to `all`, restart, re-run `reindex_studio`, and confirm course documents fully repopulate.

Note for step 7: use the non-incremental form. Meilisearch's LMDB store never returns freed pages to the filesystem, so narrowing the scope only reclaims disk through the temp-index-and-swap path.
