### PR TITLE
fix: preserve configured production search engine

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -280,8 +280,8 @@ EVENT_TRACKING_BACKENDS['segmentio']['OPTIONS']['processors'][0]['OPTIONS']['whi
 )
 
 
-if ENABLE_COURSEWARE_INDEX or ENABLE_LIBRARY_INDEX:  # noqa: F405
-    # Use ElasticSearch for the search engine
+if (ENABLE_COURSEWARE_INDEX or ENABLE_LIBRARY_INDEX) and SEARCH_ENGINE is None:  # noqa: F405
+    # Use Elasticsearch as the default search engine when none was configured.
     SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
 
 # TODO: Once we have successfully upgraded to ES7, switch this back to ELASTIC_SEARCH_CONFIG.

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -321,12 +321,12 @@ OAUTH_EXPIRE_DELTA = datetime.timedelta(days=OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DA
 OAUTH_EXPIRE_DELTA_PUBLIC = datetime.timedelta(days=OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS)  # noqa: F405
 
 if (
-   ENABLE_COURSEWARE_SEARCH or  # noqa: F405
-   ENABLE_DASHBOARD_SEARCH or  # noqa: F405
-   ENABLE_COURSE_DISCOVERY or  # noqa: F405
-   ENABLE_TEAMS  # noqa: F405
-   ):
-    # Use ElasticSearch as the search engine herein
+    ENABLE_COURSEWARE_SEARCH  # noqa: F405
+    or ENABLE_DASHBOARD_SEARCH  # noqa: F405
+    or ENABLE_COURSE_DISCOVERY  # noqa: F405
+    or ENABLE_TEAMS  # noqa: F405
+) and SEARCH_ENGINE is None:  # noqa: F405
+    # Use Elasticsearch as the default search engine when none was configured.
     SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
 
 # TODO: Once we have successfully upgraded to ES7, switch this back to ELASTIC_SEARCH_CONFIG.


### PR DESCRIPTION
## Description

Preserve an explicitly configured `SEARCH_ENGINE` in the LMS and CMS production settings.

Previously, enabling courseware or library search unconditionally replaced the configured backend with Elasticsearch. This made documented alternative backends such as Typesense unreachable.

Elasticsearch remains the fallback when search is enabled and no engine was configured.

Closes #38991

## Testing

- Verified both production settings files compile.
- Verified configured backends remain unchanged.
- Verified Elasticsearch is selected when no backend is configured.
- Verified disabling search leaves the backend unset.
