### PR TITLE
feat: register openedx_learning app for CBE competency models

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -933,6 +933,9 @@ INSTALLED_APPS = [
     # Core models to represent courses
     "openedx_catalog",
 
+    # Competency criteria and student progress models
+    "openedx_learning",
+
     # Core apps that power libraries
     "openedx_content",
     *openedx_content_backcompat_apps_to_install(),

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2122,6 +2122,9 @@ INSTALLED_APPS = [
     # Core models to represent courses
     "openedx_catalog",
 
+    # Competency criteria and student progress models
+    "openedx_learning",
+
     # Core apps that power libraries
     "openedx_content",
     *openedx_content_backcompat_apps_to_install(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -689,7 +689,7 @@ ignore = [
 ]
 
 [tool.importlinter]
-root_packages = ["lms", "cms", "openedx", "openedx_content", "openedx_catalog"]
+root_packages = ["lms", "cms", "openedx", "openedx_content", "openedx_catalog", "openedx_learning"]
 include_external_packages = true
 # Our custom contract which checks that we're only importing from 'api.py'
 # for participating packages.
@@ -810,6 +810,7 @@ isolated_apps = [
     "openedx.core.djangoapps.xblock",
     "openedx.core.lib.xblock_serializer",
     "openedx_catalog",
+    "openedx_learning",
 ]
 allowed_modules = [
     # Only imports from api.py and data.py are allowed elsewhere in the code


### PR DESCRIPTION
## Description

Registers the `openedx_learning` Django app from `openedx-core` so its
`CompetencyTaxonomy` model and migrations become active in both LMS and
CMS.

## Changes

- `lms/envs/common.py`, `cms/envs/common.py`: add `openedx_learning` to
  `INSTALLED_APPS`.
- `pyproject.toml`: add `openedx_learning` to the `isolated_apps`
  import-linter contract (restricts future imports to its
  `api`/`models_api`/`data` modules) and to `root_packages` (required
  for import-linter to recognize the app at all).
- `.annotation_safe_list.yml`: add the PII safe-list entry for
  `CompetencyTaxonomy`.


See openedx/openedx-platform#38958