### PR TITLE
fix: course editor gets 403 copying a unit to the clipboard 

### DIFF
--- a/openedx/core/djangoapps/content_staging/tests/test_clipboard.py
+++ b/openedx/core/djangoapps/content_staging/tests/test_clipboard.py
@@ -6,8 +6,12 @@ from textwrap import dedent
 from typing import cast
 from xml.etree import ElementTree
 
+import ddt
+from openedx_authz.constants.roles import COURSE_ADMIN, COURSE_AUDITOR, COURSE_EDITOR, COURSE_STAFF
 from rest_framework.test import APIClient
 
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.authz.tests.mixins import CourseAuthoringAuthzTestMixin
 from openedx.core.djangoapps.content_staging import api as python_api
 from xmodule.contentstore.django import contentstore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, upload_file_to_course
@@ -378,3 +382,40 @@ class ClipboardTestCase(ModuleStoreTestCase):
         a = ElementTree.canonicalize(xml_str_a, strip_text=True)
         b = ElementTree.canonicalize(xml_str_b, strip_text=True)
         assert a == b
+
+
+@ddt.ddt
+class ClipboardAuthzTest(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase):
+    """
+    Regression test for openedx-authz#403: ClipboardEndpoint.post() required legacy read
+    access via has_studio_read_access(), so AuthZ-native roles with no legacy equivalent
+    (course_auditor, course_editor) got a 403 when copying a unit to the clipboard despite
+    holding COURSES_VIEW_COURSE.
+    """
+
+    @ddt.data(
+        COURSE_STAFF.external_key,
+        COURSE_ADMIN.external_key,
+        COURSE_AUDITOR.external_key,
+        COURSE_EDITOR.external_key,
+    )
+    def test_course_roles_can_copy_unit_to_clipboard(self, role_key):
+        course_key = ToyCourseFactory.create().id
+        html_key = course_key.make_usage_key("html", "toyhtml")
+
+        role_user = UserFactory(password=self.password)
+        self.add_user_to_role_in_course(role_user, role_key, course_key)
+
+        client = APIClient()
+        client.force_authenticate(user=role_user)
+        response = client.post(CLIPBOARD_ENDPOINT, {"usage_key": str(html_key)}, format="json")
+
+        assert response.status_code == 200
+
+    def test_unauthorized_user_gets_permission_denied(self):
+        course_key = ToyCourseFactory.create().id
+        html_key = course_key.make_usage_key("html", "toyhtml")
+
+        response = self.unauthorized_client.post(CLIPBOARD_ENDPOINT, {"usage_key": str(html_key)}, format="json")
+
+        assert response.status_code == 403

--- a/openedx/core/djangoapps/content_staging/tests/test_clipboard.py
+++ b/openedx/core/djangoapps/content_staging/tests/test_clipboard.py
@@ -416,6 +416,6 @@ class ClipboardAuthzTest(CourseAuthoringAuthzTestMixin, ModuleStoreTestCase):
         course_key = ToyCourseFactory.create().id
         html_key = course_key.make_usage_key("html", "toyhtml")
 
-        response = self.unauthorized_client.post(CLIPBOARD_ENDPOINT, {"usage_key": str(html_key)}, format="json")
-
-        assert response.status_code == 403
+        with self.allow_transaction_exception():
+            response = self.unauthorized_client.post(CLIPBOARD_ENDPOINT, {"usage_key": str(html_key)}, format="json")
+            assert response.status_code == 403

--- a/openedx/core/djangoapps/content_staging/views.py
+++ b/openedx/core/djangoapps/content_staging/views.py
@@ -12,11 +12,13 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.locator import CourseLocator, LibraryLocatorV2
 from openedx_authz.constants import permissions as authz_permissions
+from openedx_authz.constants.permissions import COURSES_VIEW_COURSE
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from common.djangoapps.student.auth import has_studio_read_access
+from openedx.core.djangoapps.authz.constants import LegacyAuthoringPermission
+from openedx.core.djangoapps.authz.decorators import user_has_course_permission
 from openedx.core.djangoapps.xblock import api as xblock_api
 from openedx.core.lib.api.view_utils import view_auth_classes
 from xmodule.modulestore.django import modulestore
@@ -102,7 +104,12 @@ class ClipboardEndpoint(APIView):
         try:
             if isinstance(course_key, CourseLocator):
                 # Make sure the user has permission on that course
-                if not has_studio_read_access(request.user, course_key):
+                if not user_has_course_permission(
+                    request.user,
+                    COURSES_VIEW_COURSE.identifier,
+                    course_key,
+                    LegacyAuthoringPermission.READ,
+                ):
                     raise PermissionDenied(
                         "You must be a member of the course team in Studio to export OLX using this API."
                     )


### PR DESCRIPTION
## Description

Closes [openedx-authz#403.](https://github.com/openedx/openedx-authz/issues/403)

A user with the **Course Editor** role gets a `403 Forbidden` when trying to copy a unit to the clipboard in Studio, even though they can view and edit the course content normally elsewhere in Studio.

The issue is in `ClipboardEndpoint.post()` (`openedx/core/djangoapps/content_staging/views.py`), which uses `has_studio_read_access()` to check whether the user can read the course. That check only knows about the legacy `CourseAccessRole` roles (staff, instructor, limited staff, etc.) and doesn't account for AuthZ-native roles such as `course_editor` or `course_auditor`, which don't have a legacy equivalent.

As a result, users whose course access comes only from one of these AuthZ roles are denied by the clipboard endpoint, even though they have the appropriate permissions to work with the course in Studio.

This is the same type of issue fixed in openedx-authz#384, where `_get_item_in_course` was relying on a legacy write check for callers that only needed read access.

The fix follows the same approach: use `user_has_course_permission()` with the AuthZ `COURSES_VIEW_COURSE` permission, and fall back to the existing `has_studio_read_access` check through `LegacyAuthoringPermission.READ` when AuthZ course authoring is not enabled for the course.

This keeps the existing behavior unchanged for courses that have not been migrated to AuthZ.
