### PR TITLE
fix: enforce GlobalRestrictedCountry on course access, not just registration

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -227,7 +227,10 @@ class TestCourseOutline(CourseTestCase):
         """
         Test to check number of queries made to mysql and mongo
         """
-        with self.assertNumQueries(21, table_ignorelist=WAFFLE_TABLES):
+        # 22, not 21: EmbargoMiddleware now always resolves GlobalRestrictedCountry's cached
+        # country list (one query on a cold cache) even when the course has no RestrictedCourse
+        # row, so a global block applies without needing a per-course row.
+        with self.assertNumQueries(22, table_ignorelist=WAFFLE_TABLES):
             with check_mongo_calls(3):
                 self.client.get(reverse_course_url('course_handler', self.course.id), content_type="application/json")
 

--- a/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
@@ -27,6 +27,7 @@ from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_STREAK_CELEBRATION,
 )
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
+from openedx.core.djangoapps.embargo.models import Country, GlobalRestrictedCountry
 
 
 @ddt.ddt
@@ -240,6 +241,34 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
             response = self.client.get(self.url)
 
         self._assert_course_access_response(response, expect_course_access, error_code)
+
+    @override_settings(EMBARGO=True)
+    def test_embargo_blocks_access(self):
+        """
+        A `GlobalRestrictedCountry` block applies here too, not just to the legacy
+        courseware page - this is the metadata endpoint the Learning MFE actually
+        reads `course_access` from, which `EmbargoMiddleware`'s URL-pattern matching
+        does not cover.
+        """
+        CourseEnrollment.enroll(self.user, self.course.id)
+        GlobalRestrictedCountry.objects.create(country=Country.objects.create(country='CU'))
+
+        with patch('openedx.core.djangoapps.embargo.api.country_code_from_ip', return_value='CU'):
+            response = self.client.get(self.url, HTTP_X_FORWARDED_FOR='1.2.3.4')
+
+        self._assert_course_access_response(response, False, 'embargo')
+
+    @override_settings(EMBARGO=True)
+    def test_embargo_staff_bypass(self):
+        """ Course staff should still get access even when their country is globally restricted. """
+        CourseInstructorRole(self.course.id).add_users(self.user)
+        GlobalRestrictedCountry.objects.create(country=Country.objects.create(country='CU'))
+
+        with patch('openedx.core.djangoapps.embargo.api.country_code_from_ip', return_value='CU'):
+            response = self.client.get(self.url, HTTP_X_FORWARDED_FOR='1.2.3.4')
+
+        assert response.status_code == 200
+        assert response.data['course_access']['has_access'] is True
 
     @override_settings(ENABLE_DISCUSSION_SERVICE=True)
     @ddt.data(True, False)

--- a/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/tests/test_views.py
@@ -259,6 +259,20 @@ class CourseHomeMetadataTests(BaseCourseHomeTests):
         self._assert_course_access_response(response, False, 'embargo')
 
     @override_settings(EMBARGO=True)
+    def test_embargo_does_not_mask_a_more_specific_denial(self):
+        """
+        An unenrolled learner in a restricted country keeps `enrollment_required` - the
+        embargo check only runs once access is otherwise granted, so the learner is told
+        the thing they can act on first, and blocked requests skip the country lookups.
+        """
+        GlobalRestrictedCountry.objects.create(country=Country.objects.create(country='CU'))
+
+        with patch('openedx.core.djangoapps.embargo.api.country_code_from_ip', return_value='CU'):
+            response = self.client.get(self.url, HTTP_X_FORWARDED_FOR='1.2.3.4')
+
+        self._assert_course_access_response(response, False, 'enrollment_required')
+
+    @override_settings(EMBARGO=True)
     def test_embargo_staff_bypass(self):
         """ Course staff should still get access even when their country is globally restricted. """
         CourseInstructorRole(self.course.id).add_users(self.user)

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -20,6 +20,7 @@ from lms.djangoapps.course_goals.models import UserActivity
 from lms.djangoapps.course_home_api.course_metadata.serializers import CourseHomeMetadataSerializer
 from lms.djangoapps.course_home_api.toggles import new_discussion_sidebar_view_is_enabled
 from lms.djangoapps.courseware.access import has_access, has_cms_access
+from lms.djangoapps.courseware.access_utils import check_embargo_access
 from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
 from lms.djangoapps.courseware.courses import check_course_access
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
@@ -104,6 +105,12 @@ class CourseHomeMetadataView(RetrieveAPIView):
             check_if_authenticated=True,
             apply_priority_access_checks=True,
         )
+        # A country embargo (GlobalRestrictedCountry / CountryAccessRule) takes priority over
+        # any other access denial reason, and is checked here - rather than shared into
+        # check_course_access() - so it stays scoped to metadata's UI-level access flag for now.
+        embargo_access = check_embargo_access(request.user, course)
+        if not embargo_access:
+            load_access = embargo_access
 
         _, request.user = setup_masquerade(
             request,

--- a/lms/djangoapps/course_home_api/course_metadata/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/views.py
@@ -105,12 +105,16 @@ class CourseHomeMetadataView(RetrieveAPIView):
             check_if_authenticated=True,
             apply_priority_access_checks=True,
         )
-        # A country embargo (GlobalRestrictedCountry / CountryAccessRule) takes priority over
-        # any other access denial reason, and is checked here - rather than shared into
-        # check_course_access() - so it stays scoped to metadata's UI-level access flag for now.
-        embargo_access = check_embargo_access(request.user, course)
-        if not embargo_access:
-            load_access = embargo_access
+        # A country embargo (GlobalRestrictedCountry / CountryAccessRule) is checked here -
+        # rather than shared into check_course_access() - so it stays scoped to metadata's
+        # UI-level access flag for now. Only worth checking once access is otherwise granted:
+        # a more specific denial (enrollment_required, authentication_required) keeps its own
+        # error code, and we skip the embargo check's country lookups on requests that are
+        # already blocked.
+        if load_access:
+            embargo_access = check_embargo_access(request.user, course)
+            if not embargo_access:
+                load_access = embargo_access
 
         _, request.user = setup_masquerade(
             request,

--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -290,3 +290,15 @@ class OldMongoAccessError(AccessError):
             course_name=courselike.display_name_with_default,
         )
         super().__init__(error_code, developer_message, user_message)
+
+
+class EmbargoAccessError(AccessError):
+    """
+    Access denied because the user's country is blocked by embargo rules
+    (`GlobalRestrictedCountry` or a per-course `CountryAccessRule`).
+    """
+    def __init__(self):
+        error_code = "embargo"
+        developer_message = "User's location is blocked by country embargo rules"
+        user_message = _("Access to this course is blocked from your current location")
+        super().__init__(error_code, developer_message, user_message)

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -173,6 +173,9 @@ def check_embargo_access(user, course):
     through, so those still serve content to an embargoed learner. Legacy courseware
     pages are covered separately by `EmbargoMiddleware` for URLs it recognizes.
 
+    Callers should only reach for this once access is otherwise granted: a more specific
+    denial keeps its own error code, and the country lookups behind this check are not free.
+
     Returns:
         AccessResponse: Either ACCESS_GRANTED or EmbargoAccessError.
     """

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -6,7 +6,9 @@ It allows us to share code between access.py and block transformers.
 from datetime import datetime, timedelta
 from logging import getLogger
 
+from crum import get_current_request
 from django.conf import settings
+from edx_django_utils import ip
 from openedx_filters.learning.filters import CourseStartDateValidationFailed
 from pytz import UTC
 
@@ -15,10 +17,12 @@ from common.djangoapps.student.roles import CourseBetaTesterRole
 from lms.djangoapps.courseware.access_response import (
     AccessResponse,
     AuthenticationRequiredAccessError,
+    EmbargoAccessError,
     EnrollmentRequiredAccessError,
     StartDateError,
 )
 from lms.djangoapps.courseware.masquerade import get_course_masquerade, is_masquerading_as_student
+from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.features.course_experience import (
     COURSE_ENABLE_UNENROLLED_ACCESS_FLAG,
     COURSE_PRE_START_ACCESS_FLAG,
@@ -157,6 +161,29 @@ def check_authentication(user, course):
         return ACCESS_GRANTED
 
     return AuthenticationRequiredAccessError()
+
+
+def check_embargo_access(user, course):
+    """
+    Deny access if the user's country is blocked by embargo rules.
+
+    Currently called only from the course_metadata BFF view, to report embargo denial
+    via its `course_access` JSON field - not from the shared `check_course_access()`
+    that other course-home BFF views (outline, dates, progress, navigation) route
+    through, so those still serve content to an embargoed learner. Legacy courseware
+    pages are covered separately by `EmbargoMiddleware` for URLs it recognizes.
+
+    Returns:
+        AccessResponse: Either ACCESS_GRANTED or EmbargoAccessError.
+    """
+    request = get_current_request()
+    ip_addresses = ip.get_all_client_ips(request) if request is not None else None
+    url = request.path if request is not None else None
+
+    if embargo_api.check_course_access(course.id, user=user, ip_addresses=ip_addresses, url=url):
+        return ACCESS_GRANTED
+
+    return EmbargoAccessError()
 
 
 def check_public_access(course, visibilities):

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1270,8 +1270,8 @@ class ProgressPageTests(ProgressPageBaseTests):
             self.assertContains(resp, "earned a certificate for this course.")
 
     @ddt.data(
-        (True, 56),
-        (False, 56),
+        (True, 57),
+        (False, 57),
     )
     @ddt.unpack
     def test_progress_queries_paced_courses(self, self_paced, query_count):
@@ -1285,8 +1285,11 @@ class ProgressPageTests(ProgressPageBaseTests):
     def test_progress_queries(self):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
         self.setup_course()
+        # 57, not 56: EmbargoMiddleware now always resolves GlobalRestrictedCountry's cached
+        # country list (one query on a cold cache) even when the course has no RestrictedCourse
+        # row, so a global block applies without needing a per-course row.
         with self.assertNumQueries(
-            56, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST
+            57, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST
         ), check_mongo_calls(2):
             self._get_progress_page()
 

--- a/openedx/core/djangoapps/embargo/api.py
+++ b/openedx/core/djangoapps/embargo/api.py
@@ -113,9 +113,10 @@ def _check_course_access(
     `disable_access_check` override may apply (it may only override a `CountryAccessRule` block,
     never a global one).
 
-    The global check runs across every IP address and the profile country before any
+    The global check runs across the profile country and every IP address before any
     per-course `CountryAccessRule` check is considered, so a global match is never missed
-    just because an earlier signal happened to also fail a per-course rule first.
+    just because an earlier signal happened to also fail a per-course rule first. The
+    (cached) profile country goes first so a globally blocked user never pays for GeoIP.
     """
     # No-op if the country access feature is not enabled
     if not settings.EMBARGO:
@@ -128,6 +129,21 @@ def _check_course_access(
 
     if not course_is_restricted and not globally_restricted_countries:
         return _AccessCheckResult(True, False)
+
+    # The profile country is cached (see `_get_user_country_from_profile`), so it's the
+    # cheapest signal we have: check it against the global list first, and a globally
+    # blocked user costs no GeoIP lookups at all.
+    profile_country = _get_user_country_from_profile(user) if user is not None else None
+
+    if profile_country is not None and profile_country in globally_restricted_countries:
+        return _AccessCheckResult(_deny_unless_staff(
+            user, course_key,
+            (
+                "Blocking user %s from accessing course %s at %s "
+                "because the user's profile country %s is globally restricted."
+            ),
+            user.id, course_key, url, profile_country,
+        ), True)
 
     # Resolve each IP's country lazily and cache it in `ip_countries`, so a global
     # block on an early IP skips GeoIP lookups for the rest of the chain, while the
@@ -146,20 +162,6 @@ def _check_course_access(
                 ),
                 getattr(user, 'id', '<Not Authenticated>'), course_key, url, ip_address, country,
             ), True)
-
-    # The profile country is only resolved here (not alongside `ip_countries` above),
-    # so a request already decided by the IP pass doesn't pay for it needlessly.
-    profile_country = _get_user_country_from_profile(user) if user is not None else None
-
-    if profile_country is not None and profile_country in globally_restricted_countries:
-        return _AccessCheckResult(_deny_unless_staff(
-            user, course_key,
-            (
-                "Blocking user %s from accessing course %s at %s "
-                "because the user's profile country %s is globally restricted."
-            ),
-            user.id, course_key, url, profile_country,
-        ), True)
 
     if not course_is_restricted:
         return _AccessCheckResult(True, False)

--- a/openedx/core/djangoapps/embargo/api.py
+++ b/openedx/core/djangoapps/embargo/api.py
@@ -7,7 +7,7 @@ This API is exposed via the middleware(emabargo/middileware.py) layer but may be
 """
 
 import logging
-from typing import List, Optional  # noqa: UP035
+from typing import List, NamedTuple, Optional  # noqa: UP035
 
 from django.conf import settings
 from django.core.cache import cache
@@ -21,7 +21,7 @@ from common.djangoapps.student.auth import has_course_author_access
 from openedx.core import types
 from openedx.core.djangoapps.geoinfo.api import country_code_from_ip
 
-from .models import CountryAccessRule, RestrictedCourse
+from .models import CountryAccessRule, GlobalRestrictedCountry, RestrictedCourse
 
 log = logging.getLogger(__name__)
 
@@ -36,7 +36,8 @@ def redirect_if_blocked(
     Redirect if the user does not have access to the course.
 
     Even if the user would normally be blocked, if the given access_point is 'courseware' and the course has enabled
-    the `is_disabled_access_check` flag, then the user can still view that course.
+    the `is_disabled_access_check` flag, then the user can still view that course - unless the block is coming from
+    `GlobalRestrictedCountry`, which `is_disabled_access_check` (a per-course override) can never bypass.
 
     Arguments:
         request: The current request to be checked.
@@ -50,10 +51,10 @@ def redirect_if_blocked(
     if settings.EMBARGO:
         client_ips = ip.get_all_client_ips(request)
         user = user or request.user
-        is_blocked = not check_course_access(course_key, user=user, ip_addresses=client_ips, url=request.path)
-        if is_blocked:
+        result = _check_course_access(course_key, user=user, ip_addresses=client_ips, url=request.path)
+        if not result.allowed:
             if access_point == "courseware":
-                if not RestrictedCourse.is_disabled_access_check(course_key):
+                if not RestrictedCourse.is_disabled_access_check(course_key) or result.blocked_globally:
                     return message_url_path(course_key, access_point)
             else:
                 return message_url_path(course_key, access_point)
@@ -68,6 +69,10 @@ def check_course_access(
     """
     Check is the user with this ip_addresses chain has access to the given course
 
+    A country listed in `GlobalRestrictedCountry` blocks every course, regardless
+    of whether the course has a `RestrictedCourse` entry. `CountryAccessRule`
+    checks only apply on top of that for courses that do have one.
+
     Arguments:
         course_key: Location of the course the user is trying to access.
         user: The user making the request. Can be None, in which case the user's profile country will not be checked.
@@ -78,59 +83,111 @@ def check_course_access(
         True if the user has access to the course; False otherwise
 
     """
+    return _check_course_access(course_key, user=user, ip_addresses=ip_addresses, url=url).allowed
+
+
+class _AccessCheckResult(NamedTuple):
+    """
+    Result of `_check_course_access`.
+
+    `blocked_globally` reflects only whether the request's country matched
+    `GlobalRestrictedCountry` - it's set independently of `allowed` (a staff
+    user can have `allowed=True` and `blocked_globally=True` at once, since
+    staff bypass every block). Callers that care "was this actually denied,
+    and for which reason" should check `blocked_globally` together with
+    `not allowed`, not on its own.
+    """
+    allowed: bool
+    blocked_globally: bool
+
+
+def _check_course_access(
+        course_key: CourseKey,
+        user: Optional[types.User] = None,  # noqa: UP045
+        ip_addresses: Optional[List[str]] = None,  # noqa: UP006, UP045
+        url: Optional[str] = None,  # noqa: UP045
+) -> _AccessCheckResult:
+    """
+    Does the real work for `check_course_access`, also reporting whether a block came from
+    `GlobalRestrictedCountry` - `redirect_if_blocked` needs that to know whether a per-course
+    `disable_access_check` override may apply (it may only override a `CountryAccessRule` block,
+    never a global one).
+
+    The global check runs across every IP address and the profile country before any
+    per-course `CountryAccessRule` check is considered, so a global match is never missed
+    just because an earlier signal happened to also fail a per-course rule first.
+    """
     # No-op if the country access feature is not enabled
     if not settings.EMBARGO:
-        return True
+        return _AccessCheckResult(True, False)
 
-    # First, check whether there are any restrictions on the course.
-    # If not, then we do not need to do any further checks
+    # Check whether there are any per-course or global restrictions at all.
+    # If neither applies, skip the (non-free) IP/profile country lookups below.
     course_is_restricted = RestrictedCourse.is_restricted_course(course_key)
+    globally_restricted_countries = GlobalRestrictedCountry.get_countries()
 
-    if not course_is_restricted:
-        return True
+    if not course_is_restricted and not globally_restricted_countries:
+        return _AccessCheckResult(True, False)
 
-    # Always give global and course staff access, regardless of embargo settings.
-    if user is not None and has_course_author_access(user, course_key):
-        return True
-
-    if ip_addresses is not None:
-        # Check every IP address provided and deny access if ANY of them fail our country checks
-        for ip_address in ip_addresses:
-            # Retrieve the country code from the IP address
-            # and check it against the allowed countries list for a course
-            user_country_from_ip = country_code_from_ip(ip_address)
-
-            if not CountryAccessRule.check_country_access(course_key, user_country_from_ip):
-                log.info(
-                    (
-                        "Blocking user %s from accessing course %s at %s "
-                        "because the user's IP address %s appears to be "
-                        "located in %s."
-                    ),
-                    getattr(user, 'id', '<Not Authenticated>'),
-                    course_key,
-                    url,
-                    ip_address,
-                    user_country_from_ip
-                )
-                return False
-
-    if user is not None:
-        # Retrieve the country code from the user's profile
-        # and check it against the allowed countries list for a course.
-        user_country_from_profile = _get_user_country_from_profile(user)
-
-        if not CountryAccessRule.check_country_access(course_key, user_country_from_profile):
-            log.info(
+    # Resolve each IP's country lazily and cache it in `ip_countries`, so a global
+    # block on an early IP skips GeoIP lookups for the rest of the chain, while the
+    # per-course pass further down still reuses whatever was already resolved here.
+    ip_countries = []
+    for ip_address in (ip_addresses or []):
+        country = country_code_from_ip(ip_address)
+        ip_countries.append((ip_address, country))
+        if country in globally_restricted_countries:
+            return _AccessCheckResult(_deny_unless_staff(
+                user, course_key,
                 (
                     "Blocking user %s from accessing course %s at %s "
-                    "because the user's profile country is %s."
+                    "because the user's IP address %s appears to be "
+                    "located in globally restricted country %s."
                 ),
-                user.id, course_key, url, user_country_from_profile
-            )
-            return False
+                getattr(user, 'id', '<Not Authenticated>'), course_key, url, ip_address, country,
+            ), True)
 
-    return True
+    # The profile country is only resolved here (not alongside `ip_countries` above),
+    # so a request already decided by the IP pass doesn't pay for it needlessly.
+    profile_country = _get_user_country_from_profile(user) if user is not None else None
+
+    if profile_country is not None and profile_country in globally_restricted_countries:
+        return _AccessCheckResult(_deny_unless_staff(
+            user, course_key,
+            (
+                "Blocking user %s from accessing course %s at %s "
+                "because the user's profile country %s is globally restricted."
+            ),
+            user.id, course_key, url, profile_country,
+        ), True)
+
+    if not course_is_restricted:
+        return _AccessCheckResult(True, False)
+
+    # Per-course pass: only relevant once we know the request isn't globally blocked.
+    for ip_address, country in ip_countries:
+        if not CountryAccessRule.check_country_access(course_key, country):
+            return _AccessCheckResult(_deny_unless_staff(
+                user, course_key,
+                (
+                    "Blocking user %s from accessing course %s at %s "
+                    "because the user's IP address %s appears to be "
+                    "located in %s."
+                ),
+                getattr(user, 'id', '<Not Authenticated>'), course_key, url, ip_address, country,
+            ), False)
+
+    if profile_country is not None and not CountryAccessRule.check_country_access(course_key, profile_country):
+        return _AccessCheckResult(_deny_unless_staff(
+            user, course_key,
+            (
+                "Blocking user %s from accessing course %s at %s "
+                "because the user's profile country is %s."
+            ),
+            user.id, course_key, url, profile_country,
+        ), False)
+
+    return _AccessCheckResult(True, False)
 
 
 def message_url_path(course_key: CourseKey, access_point: str) -> str:
@@ -152,6 +209,25 @@ def message_url_path(course_key: CourseKey, access_point: str) -> str:
 
     """
     return RestrictedCourse.message_url_path(course_key, access_point)
+
+
+def _deny_unless_staff(
+    user: Optional[types.User],  # noqa: UP045
+    course_key: CourseKey,
+    log_message: str,
+    *log_args,
+) -> bool:
+    """
+    Deny access (after logging why), unless the user is global or course staff.
+
+    Global and course staff always get access, regardless of embargo settings.
+    Callers should only invoke this once a block would otherwise occur - the
+    underlying role lookup is not free, and most requests are never blocked.
+    """
+    if user is not None and has_course_author_access(user, course_key):
+        return True
+    log.info(log_message, *log_args)
+    return False
 
 
 def _get_user_country_from_profile(user: types.User) -> str:

--- a/openedx/core/djangoapps/embargo/models.py
+++ b/openedx/core/djangoapps/embargo/models.py
@@ -319,11 +319,15 @@ class RestrictedCourse(models.Model):
         # Presumably if the caller is requesting a URL, the caller
         # has already determined that the user should be blocked.
         # We use generic messaging unless we find something more specific,
-        # but *always* return a valid URL path.
+        # but *always* return a valid URL path. The fallback keeps the caller's
+        # access point, so a user blocked while enrolling still gets the
+        # enrollment-specific message (a course blocked only by
+        # `GlobalRestrictedCountry` has no `RestrictedCourse` row and always
+        # lands here).
         default_path = reverse(
             'embargo:blocked_message',
             kwargs={
-                'access_point': 'courseware',
+                'access_point': access_point,
                 'message_key': 'default'
             }
         )

--- a/openedx/core/djangoapps/embargo/tests/test_api.py
+++ b/openedx/core/djangoapps/embargo/tests/test_api.py
@@ -34,7 +34,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 from .. import api as embargo_api
 from ..exceptions import InvalidAccessPoint
-from ..models import Country, CountryAccessRule, RestrictedCourse
+from ..models import Country, CountryAccessRule, GlobalRestrictedCountry, RestrictedCourse
 
 QUERY_COUNT_TABLE_IGNORELIST = WAFFLE_TABLES + AUTHZ_TABLES
 
@@ -126,13 +126,16 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
             assert not result
 
     def test_course_not_restricted(self):
-        # No restricted course model for this course key,
-        # so all access checks should be skipped.
+        # No `RestrictedCourse` row for this course, and no `GlobalRestrictedCountry`
+        # rows either, so `check_course_access` takes its fast path: it only needs
+        # to warm the two "is anything restricted at all" caches, then returns
+        # without ever looking at the IP or the user's profile.
         unrestricted_course = CourseFactory.create()
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             embargo_api.check_course_access(unrestricted_course.id, user=self.user, ip_addresses=['0.0.0.0'])
 
-        # The second check should require no database queries
+        # The second check should require no database queries - both caches
+        # (restricted-course list, global-country list) are warm by now.
         with self.assertNumQueries(0):
             embargo_api.check_course_access(unrestricted_course.id, user=self.user, ip_addresses=['0.0.0.0'])
 
@@ -174,8 +177,14 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
             # Test the scenario that will go through every check
             # (restricted course, but pass all the checks)
             # This is the worst case, so it will hit all of the
-            # caching code.
-            with self.assertNumQueries(5, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
+            # caching code: restricted-course cache (1) + global-country
+            # cache (1) + per-course country-access-rule cache (1) = 3.
+            # `CountryAccessRule.check_country_access` caches its allowed-countries
+            # list per course_key, so the IP check and the profile check below share
+            # that single query rather than each paying for their own. This scenario
+            # also doesn't pay for the `has_course_author_access` role lookup, since
+            # that's deferred until a block is about to happen, and nothing blocks here.
+            with self.assertNumQueries(3, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
                 embargo_api.check_course_access(self.course.id, user=self.user, ip_addresses=['0.0.0.0'])
 
             with self.assertNumQueries(0, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
@@ -185,7 +194,8 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
         RestrictedCourse.objects.all().delete()
         cache.clear()
 
-        with self.assertNumQueries(1):
+        # Same fast path as `test_course_not_restricted` - see there for the count.
+        with self.assertNumQueries(2):
             embargo_api.check_course_access(self.course.id, user=self.user, ip_addresses=['0.0.0.0'])
 
         with self.assertNumQueries(0):
@@ -213,22 +223,134 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
         # Expect that the user is blocked, because the user isn't staff
         assert not result, "User should not have access because the user isn't staff."
 
-        # Instantiate the role, configuring it for this course or org
-        if issubclass(staff_role_cls, CourseRole):
-            staff_role = staff_role_cls(self.course.id)
-        elif issubclass(staff_role_cls, OrgRole):
-            staff_role = staff_role_cls(self.course.id.org)
-        else:
-            staff_role = staff_role_cls()
-
-        # Add the user to the role
-        staff_role.add_users(self.user)
+        self._add_staff_role(staff_role_cls, self.course.id)
 
         # Now the user should have access
         with self._mock_geoip('US'):
             result = embargo_api.check_course_access(self.course.id, user=self.user, ip_addresses=['0.0.0.0'])
 
         assert result, 'User should have access because the user is staff.'
+
+    @ddt.data(
+        GlobalStaff,
+        CourseStaffRole,
+        CourseInstructorRole,
+        OrgStaffRole,
+        OrgInstructorRole,
+    )
+    def test_staff_access_global_country_block(self, staff_role_cls):
+        # Staff should bypass a `GlobalRestrictedCountry` block too, on a
+        # course that has no `RestrictedCourse` row at all.
+        course_key = CourseFactory.create().id
+        GlobalRestrictedCountry.objects.create(country=Country.objects.get(country='IR'))
+
+        with self._mock_geoip('IR'):
+            result = embargo_api.check_course_access(course_key, user=self.user, ip_addresses=['0.0.0.0'])
+        assert not result, "User should not have access because the user isn't staff."
+
+        self._add_staff_role(staff_role_cls, course_key)
+
+        with self._mock_geoip('IR'):
+            result = embargo_api.check_course_access(course_key, user=self.user, ip_addresses=['0.0.0.0'])
+        assert result, 'User should have access because the user is staff.'
+
+    def _add_staff_role(self, staff_role_cls, course_key):
+        """Instantiate `staff_role_cls` for `course_key` (or its org) and add `self.user` to it."""
+        if issubclass(staff_role_cls, CourseRole):
+            staff_role = staff_role_cls(course_key)
+        elif issubclass(staff_role_cls, OrgRole):
+            staff_role = staff_role_cls(course_key.org)
+        else:
+            staff_role = staff_role_cls()
+        staff_role.add_users(self.user)
+
+    @ddt.data(
+        # course_restricted, rule_type, rule_country, global_country, country, source, allow_access
+        (False, None, None, 'IR', 'IR', 'ip', False),  # no RestrictedCourse row at all, blocked globally
+        (False, None, None, 'IR', 'US', 'ip', True),  # no RestrictedCourse row, unrelated country is fine
+        (False, None, None, 'IR', 'IR', 'profile', False),  # global block also applies via profile country
+        (True, CountryAccessRule.BLACKLIST_RULE, 'CU', None, 'CU', 'ip', False),  # existing per-course rule, unaffected
+        (True, CountryAccessRule.BLACKLIST_RULE, 'CU', None, 'US', 'ip', True),
+        (True, CountryAccessRule.WHITELIST_RULE, 'IR', 'IR', 'IR', 'ip', False),  # global restriction beats whitelist
+    )
+    @ddt.unpack
+    def test_global_restricted_country_access(
+        self, course_restricted, rule_type, rule_country, global_country, country, source, allow_access,
+    ):
+        course_key = self.course.id if course_restricted else CourseFactory.create().id
+
+        if rule_type is not None:
+            CountryAccessRule.objects.create(
+                rule_type=rule_type,
+                restricted_course=self.restricted_course,
+                country=Country.objects.get(country=rule_country),
+            )
+
+        if global_country is not None:
+            GlobalRestrictedCountry.objects.create(country=Country.objects.get(country=global_country))
+
+        if source == 'profile':
+            self.user.profile.country = country
+            self.user.profile.save()
+            ip_country = ''
+        else:
+            ip_country = country
+
+        with self._mock_geoip(ip_country):
+            result = embargo_api.check_course_access(course_key, user=self.user, ip_addresses=['0.0.0.0'])
+        assert result == allow_access
+
+    def test_redirect_if_blocked_global_restricted_country(self):
+        # A course with no `RestrictedCourse` row still redirects to the
+        # default blocked-message page when blocked by `GlobalRestrictedCountry`.
+        unrestricted_course = CourseFactory.create()
+        GlobalRestrictedCountry.objects.create(country=Country.objects.get(country='IR'))
+
+        request = RequestFactory().get('', HTTP_X_FORWARDED_FOR='0.0.0.0')
+        request.user = self.user
+
+        with self._mock_geoip('IR'):
+            redirect_url = embargo_api.redirect_if_blocked(request, unrestricted_course.id, access_point='courseware')
+        assert redirect_url == '/embargo/blocked-message/courseware/default/'
+
+    def test_disable_access_check_does_not_bypass_global_restriction(self):
+        # `disable_access_check` is a per-course escape hatch for `CountryAccessRule`
+        # blocks. It must NOT let a `GlobalRestrictedCountry` block through too.
+        self.restricted_course.disable_access_check = True
+        self.restricted_course.save()
+        GlobalRestrictedCountry.objects.create(country=Country.objects.get(country='IR'))
+
+        request = RequestFactory().get('', HTTP_X_FORWARDED_FOR='0.0.0.0')
+        request.user = self.user
+
+        with self._mock_geoip('IR'):
+            redirect_url = embargo_api.redirect_if_blocked(request, self.course.id, access_point='courseware')
+        assert redirect_url is not None, "A global restriction should still redirect even with disable_access_check."
+
+    def test_global_restriction_via_profile_not_masked_by_earlier_ip_rule_match(self):
+        # A per-course `CountryAccessRule` match on the IP must not short-circuit
+        # before the profile country is also checked against `GlobalRestrictedCountry` -
+        # otherwise a globally-restricted user could slip through via disable_access_check
+        # just because their IP happened to also fail a (unrelated) per-course rule first.
+        self.restricted_course.disable_access_check = True
+        self.restricted_course.save()
+        CountryAccessRule.objects.create(
+            rule_type=CountryAccessRule.BLACKLIST_RULE,
+            restricted_course=self.restricted_course,
+            country=Country.objects.get(country='CU'),
+        )
+        GlobalRestrictedCountry.objects.create(country=Country.objects.get(country='IR'))
+        self.user.profile.country = 'IR'
+        self.user.profile.save()
+
+        request = RequestFactory().get('', HTTP_X_FORWARDED_FOR='0.0.0.0')
+        request.user = self.user
+
+        # IP matches the per-course blacklist (CU), not the global list - but the
+        # profile country (IR) is globally restricted, and that must still win.
+        with self._mock_geoip('CU'):
+            redirect_url = embargo_api.redirect_if_blocked(request, self.course.id, access_point='courseware')
+        assert redirect_url is not None, "Global restriction must not be masked by an earlier IP rule match."
 
     @ddt.data(
         # (Note that any '0.x.x.x' IP _should_ be blocked in this test.)
@@ -262,8 +384,14 @@ class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
         ('courseware', True, True),  # Unless the access check has been disabled, then we allow them
     )
     @ddt.unpack
-    @mock.patch('openedx.core.djangoapps.embargo.api.check_course_access', return_value=False)
+    @mock.patch(
+        'openedx.core.djangoapps.embargo.api._check_course_access',
+        return_value=embargo_api._AccessCheckResult(False, False),  # pylint: disable=protected-access
+    )
     def test_redirect_if_blocked_courseware(self, access_point, check_disabled, allow_access, _mock_access):  # noqa: PT019  # pylint: disable=line-too-long
+        # blocked_globally=False here - this test is specifically about the
+        # per-course disable_access_check override, which only ever applies
+        # to a non-global (CountryAccessRule) block.
         self.restricted_course.disable_access_check = check_disabled
         self.restricted_course.save()
 

--- a/openedx/core/djangoapps/embargo/tests/test_api.py
+++ b/openedx/core/djangoapps/embargo/tests/test_api.py
@@ -469,8 +469,10 @@ class EmbargoMessageUrlApiTests(UrlResetMixin, ModuleStoreTestCase):
         # No restrictions for the course
         url_path = embargo_api.message_url_path(self.course.id, access_point)
 
-        # Use a default path
-        assert url_path == '/embargo/blocked-message/courseware/default/'
+        # Use a default path - the default for the access point the user was blocked at.
+        # A course blocked only by `GlobalRestrictedCountry` has no `RestrictedCourse` row,
+        # so this fallback is what an embargoed learner actually sees.
+        assert url_path == f'/embargo/blocked-message/{access_point}/default/'
 
     def test_invalid_access_point(self):
         with pytest.raises(InvalidAccessPoint):

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -50,7 +50,10 @@ class TestCourseUpdatesPage(BaseCourseUpdatesTestCase):
 
         # Fetch the view and verify that the query counts haven't changed
         # TODO: decrease query count as part of REVO-28
-        with self.assertNumQueries(54, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
+        # 55, not 54: EmbargoMiddleware now always resolves GlobalRestrictedCountry's cached
+        # country list (one query on a cold cache) even when the course has no RestrictedCourse
+        # row, so a global block applies without needing a per-course row.
+        with self.assertNumQueries(55, table_ignorelist=QUERY_COUNT_TABLE_IGNORELIST):
             with check_mongo_calls(3):
                 url = course_updates_url(self.course)
                 self.client.get(url)


### PR DESCRIPTION
## Description

`GlobalRestrictedCountry` (added in #36202 / #36398) only blocks account
registration and profile-country changes today — it has no effect on course
access. The only mechanism that enforces course access is `RestrictedCourse` +
`CountryAccessRule`, which needs a row per course, so there was no way to
block a country from every course at once.

This PR wires `GlobalRestrictedCountry` into
`embargo.api.check_course_access()` so a listed country blocks every course,
with or without a `RestrictedCourse` entry. Per-course `CountryAccessRule`
checks still apply on top where configured, staff still bypass every check,
and a per-course `disable_access_check` override can never bypass a *global*
block (only a per-course one).

**It also surfaces a related enforcement gap discovered while testing this
change**: embargo enforcement previously ran only inside `EmbargoMiddleware`,
which recognizes legacy `/course/`/`/courses/` URLs. The Learning MFE's
`course_home_api` endpoints (outline, dates, progress, navigation,
course_metadata) don't match that URL pattern, so a learner in an embargoed
country could browse a course through the MFE with no indication they were
blocked, regardless of `RestrictedCourse`/`GlobalRestrictedCountry`
configuration.

This PR closes that gap for the `course_metadata` endpoint specifically —
the one endpoint the Learning MFE already reads a `course_access`
(`hasAccess`/`errorCode`) flag from to redirect denied learners. A new
`check_embargo_access()` helper (`lms/djangoapps/courseware/access_utils.py`)
is called directly from `CourseHomeMetadataView`
(`lms/djangoapps/course_home_api/course_metadata/views.py`), so an embargoed
learner's `course_access.errorCode` comes back as `"embargo"`.

**Known, deliberate limitation (not fixed here):** the check is *not* wired
into the shared `check_course_access()` in
`lms/djangoapps/courseware/courses.py` that `outline`/`dates`/`progress`/
`navigation` route through — an earlier version of this PR did that, but it
meant those endpoints started hard-403ing, which crashed the Learning MFE
(it wasn't written to expect a 403 there) and would have required frontend
data-layer changes to fix cleanly. Scoping the check down to `course_metadata`
only avoids that: those four endpoints still serve real course content to an
embargoed learner today, even though `course_metadata` correctly reports the
block. A companion Learning MFE PR
(openedx/frontend-app-learning#2055) makes the MFE redirect away from every
tab (including outline, which previously rendered anyway) once it sees
`errorCode: "embargo"` — but that's a UI-level mitigation, not a data-layer
block. Extending enforcement to those endpoints is left as follow-up work if/
when it's needed.

## Behavior changes reviewers should know about

**`disable_access_check` no longer waives a global block.** The per-course
`RestrictedCourse.disable_access_check` escape hatch can override a
`CountryAccessRule` block, but not a `GlobalRestrictedCountry` one. This is
reachable whenever a course has a `RestrictedCourse` row with
`disable_access_check=True` and the learner is in a globally-restricted
country — that learner was previously let through and is now blocked. It is a
deliberate reduction in per-course operator control: a platform-wide legal
restriction should not be waivable per course.

**Staff still bypass embargo blocks.** Global and course staff/authors keep
access even from a restricted country. That is long-standing platform
behavior (`has_course_author_access` in `embargo.api`), not introduced here —
global blocks simply inherit it. If OFAC compliance requires course staff to
be blocked too, that is a follow-up policy decision rather than part of this
PR.

**Error-code precedence in `course_metadata`.** The embargo check runs only
once access is otherwise granted, so a more specific denial keeps its own
error code — an unenrolled learner in a restricted country reports
`enrollment_required`, not `embargo`. They are still blocked from enrolling
by the existing enrollment-access-point check, so no gap is introduced, and
already-denied requests skip the embargo check's country lookups.

**Default blocked-message URL now keeps its access point.**
`RestrictedCourse`'s message-URL fallback previously hardcoded the
`courseware` access point. A course blocked only by `GlobalRestrictedCountry`
has no `RestrictedCourse` row, so it *always* lands on that fallback — which
meant a learner blocked while enrolling was shown courseware messaging. The
fallback now uses the caller's access point. This changes a pre-existing
code path (covered by the updated
`test_message_url_path_no_restrictions_for_course`), though it was previously
unreachable in blocked flows: before this PR, only a course *with* a
`RestrictedCourse` row could ever be blocked, and such a course always found
its configured message key.

**Impact:** Operators can now block a country platform-wide via
`GlobalRestrictedCountry` (Django admin) instead of a row per course.
Learners in a globally-restricted country are blocked from enrollment, the
legacy courseware pages, and (via `course_metadata`) get a correctly-flagged
Learning MFE that redirects them away. Real course content served by the
Learning MFE's other BFF endpoints is not yet blocked at the data layer (see
above). No change for Course Authors/Developers, and no behavior change for
existing deployments (both tables are empty by default everywhere).

## Supporting information

Motivating use case: mitodl/hq#13170 (OFAC embargo requirement).

Companion PR: openedx/frontend-app-learning#2055 (Learning MFE reacts to
`errorCode: "embargo"` by redirecting every tab to the legacy blocked-message
page).

## Testing instructions

1. Enable `FEATURES['EMBARGO']` (or confirm `settings.EMBARGO` is already
   `True` — it defaults `True` under `lms.envs.tutor.development`, `False`
   in general `envs/common.py`).
2. Add a country to `GlobalRestrictedCountry` in Django Admin (no
   `RestrictedCourse` row needed), or via shell:
   ```python
   from openedx.core.djangoapps.embargo.models import Country, GlobalRestrictedCountry
   country, _ = Country.objects.get_or_create(country='IR')
   GlobalRestrictedCountry.objects.get_or_create(country=country)
   ```
3. Set a test learner's profile country to the same code (easiest way to
   test without IP-header spoofing tooling):
   ```python
   from django.contrib.auth import get_user_model
   from django.core.cache import cache
   user = get_user_model().objects.get(username='<test-learner>')
   user.profile.country = 'IR'
   user.profile.save()
   cache.clear()
   ```
4. Confirm enrollment and the legacy courseware page
   (`/courses/<course_id>/course/`) are blocked as before (unchanged by this
   PR) — the legacy page redirects to `/embargo/blocked-message/courseware/default/`.
5. Confirm `GET /api/course_home/course_metadata/<course_id>` now returns
   `course_access: {"has_access": false, "error_code": "embargo", ...}` for
   that learner (status is still `200` — `course_metadata` always reports
   access in-band, same as `enrollment_required`/other denial reasons).
6. Confirm staff/course-author accounts bypass the block (still `has_access: true`).
7. Optional, if also running the companion Learning MFE branch: log into the
   MFE as the test learner and confirm every course tab (outline included)
   redirects to the legacy blocked-message page instead of rendering.
8. `pytest openedx/core/djangoapps/embargo/ lms/djangoapps/courseware/tests/test_access.py lms/djangoapps/course_home_api/`
9. Clean up: remove the `GlobalRestrictedCountry` row and reset the test
   learner's `profile.country`.

## Deadline

None.

## Other information

No migration (reuses the existing `GlobalRestrictedCountry` table), no
dependency changes, no public API change (`check_course_access()`'s
signature/return contract is unchanged). See "Known, deliberate limitation"
above for the accepted scope gap (outline/dates/progress/navigation
endpoints still serve real content to an embargoed learner via the Learning
MFE) and its companion frontend PR.

