### PR TITLE
feat: add taxonomy_type to TaxonomyOrgView

### DIFF
--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/tests/test_views.py
@@ -18,6 +18,7 @@ from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator, LibraryCollectionLocator, LibraryContainerLocator
 from openedx_authz.constants import permissions as authz_permissions
 from openedx_authz.constants.roles import COURSE_AUDITOR, COURSE_EDITOR, COURSE_STAFF
+from openedx_learning.models_api import CompetencyTaxonomy
 from openedx_tagging.models import Tag, Taxonomy
 from openedx_tagging.rest_api.v1.serializers import TaxonomySerializer
 from organizations.models import Organization
@@ -519,6 +520,68 @@ class TestTaxonomyListCreateViewSet(TestTaxonomyObjectsMixin, APITestCase):
             # Also checks if the taxonomy was associated with the org
             if user_attr == "staffA":
                 assert response.data["orgs"] == [self.orgA.short_name]
+
+    def test_create_competency_taxonomy(self) -> None:
+        """
+        Posting taxonomy_type="competency" creates a CompetencyTaxonomy linked to
+        the new Taxonomy.
+        """
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.post(
+            TAXONOMY_ORG_LIST_URL,
+            {"name": "Nursing Competencies", "export_id": "nursing-competencies", "taxonomy_type": "competency"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert CompetencyTaxonomy.objects.filter(pk=response.data["id"]).exists()
+
+    def test_create_competency_taxonomy_duplicate_export_id_returns_400(self) -> None:
+        """
+        A validation failure in the competency branch (duplicate export_id, via
+        full_clean()) returns a 400, like the "tags" branch, not an unhandled 500.
+        """
+        self.client.force_authenticate(user=self.staff)
+        self.client.post(
+            TAXONOMY_ORG_LIST_URL,
+            {"name": "Existing", "export_id": "duplicate-export-id"},
+            format="json",
+        )
+        response = self.client.post(
+            TAXONOMY_ORG_LIST_URL,
+            {"name": "Nursing Competencies", "export_id": "duplicate-export-id", "taxonomy_type": "competency"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @ddt.data("tags", None)
+    def test_create_taxonomy_tags_or_omitted_creates_no_competency_row(self, taxonomy_type: str | None) -> None:
+        """
+        Posting taxonomy_type="tags", or omitting it, creates a plain Taxonomy and
+        no CompetencyTaxonomy row.
+        """
+        create_data = {"name": "Plain Taxonomy", "export_id": "plain-taxonomy"}
+        if taxonomy_type is not None:
+            create_data["taxonomy_type"] = taxonomy_type
+
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.post(TAXONOMY_ORG_LIST_URL, create_data, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert not CompetencyTaxonomy.objects.filter(pk=response.data["id"]).exists()
+
+    def test_create_taxonomy_rejects_invalid_type(self) -> None:
+        """
+        An unsupported taxonomy_type (e.g. "system") 400s and names taxonomy_type
+        as the invalid field.
+        """
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.post(
+            TAXONOMY_ORG_LIST_URL,
+            {"name": "Rejected", "export_id": "rejected", "taxonomy_type": "system"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "taxonomy_type" in response.data
 
     @ddt.data(
         ('staff', 10),
@@ -2501,6 +2564,68 @@ class TestCreateImportView(ImportTaxonomyMixin, APITestCase):
 
         # Check if the taxonomy was not created
         assert not Taxonomy.objects.filter(name="Imported Taxonomy name").exists()
+
+    def test_import_competency_taxonomy(self) -> None:
+        """
+        Importing with taxonomy_type="competency" creates a CompetencyTaxonomy
+        linked to the new Taxonomy.
+        """
+        file = self._get_file([{"id": "tag_1", "value": "Tag 1"}], "json")
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.post(
+            TAXONOMY_CREATE_IMPORT_URL,
+            {
+                "taxonomy_name": "Imported Competency",
+                "taxonomy_description": "Imported Competency description",
+                "taxonomy_export_id": "imported-competency",
+                "taxonomy_type": "competency",
+                "file": file,
+            },
+            format="multipart",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert CompetencyTaxonomy.objects.filter(pk=response.data["id"]).exists()
+
+    def test_import_without_type_creates_no_competency_row(self) -> None:
+        """
+        Importing without taxonomy_type creates a plain Taxonomy and no
+        CompetencyTaxonomy row.
+        """
+        file = self._get_file([{"id": "tag_1", "value": "Tag 1"}], "json")
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.post(
+            TAXONOMY_CREATE_IMPORT_URL,
+            {
+                "taxonomy_name": "Imported Plain",
+                "taxonomy_description": "Imported Plain description",
+                "taxonomy_export_id": "imported-plain",
+                "file": file,
+            },
+            format="multipart",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert not CompetencyTaxonomy.objects.filter(pk=response.data["id"]).exists()
+
+    def test_import_rejects_invalid_type(self) -> None:
+        """
+        An unsupported taxonomy_type (e.g. "system") 400s on import and names
+        taxonomy_type as the invalid field.
+        """
+        file = self._get_file([{"id": "tag_1", "value": "Tag 1"}], "json")
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.post(
+            TAXONOMY_CREATE_IMPORT_URL,
+            {
+                "taxonomy_name": "Imported Rejected",
+                "taxonomy_description": "Imported Rejected description",
+                "taxonomy_export_id": "imported-rejected",
+                "taxonomy_type": "system",
+                "file": file,
+            },
+            format="multipart",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "taxonomy_type" in response.data
 
     @ddt.data(
         "csv",

--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/views.py
@@ -6,12 +6,15 @@ from __future__ import annotations
 import functools
 from typing import TYPE_CHECKING
 
+from django.core import exceptions
 from django.db.models import Count
 from django.http import StreamingHttpResponse
 from openedx_authz import api as authz_api
 from openedx_authz.constants.permissions import COURSES_MANAGE_TAGS, COURSES_VIEW_COURSE
+from openedx_learning.api import create_competency_taxonomy
 from openedx_tagging import rules as oel_tagging_rules
-from openedx_tagging.api import TagDoesNotExist
+from openedx_tagging.api import TagDoesNotExist, TaxonomyType
+from openedx_tagging.models import Taxonomy
 from openedx_tagging.rest_api.v1.views import ObjectTagView, TaxonomyView
 from rest_framework import status
 from rest_framework.decorators import action
@@ -24,7 +27,6 @@ from openedx.core.types.http import RestRequest
 
 from ...api import (
     InvalidOrgException,
-    create_taxonomy,
     generate_csv_rows,
     get_taxonomies,
     get_taxonomies_for_org,
@@ -100,12 +102,36 @@ class TaxonomyOrgView(TaxonomyView):
 
         return queryset
 
-    def perform_create(self, serializer):
+    def perform_create(self, serializer) -> None:
         """
-        Create a new taxonomy.
+        Create a new taxonomy (competency or tags).
         """
+        taxonomy_type = serializer.validated_data.pop("taxonomy_type", TaxonomyType.TAGS.value)
+        if taxonomy_type == TaxonomyType.COMPETENCY.value:
+            try:
+                serializer.instance = create_competency_taxonomy(**serializer.validated_data)
+            except exceptions.ValidationError as e:
+                raise ValidationError() from e
+        else:
+            super().perform_create(serializer)
         user_admin_orgs = get_admin_orgs(self.request.user)
-        serializer.instance = create_taxonomy(**serializer.validated_data, orgs=user_admin_orgs)
+        set_taxonomy_orgs(taxonomy=serializer.instance, all_orgs=False, orgs=user_admin_orgs)
+
+    def _create_taxonomy_for_import(self, validated_data: dict) -> Taxonomy:
+        """
+        Create a competency taxonomy if requested, otherwise defer to the base implementation.
+        """
+        taxonomy_type = validated_data.get("taxonomy_type", TaxonomyType.TAGS.value)
+        if taxonomy_type == TaxonomyType.COMPETENCY.value:
+            try:
+                return create_competency_taxonomy(
+                    name=validated_data["taxonomy_name"],
+                    description=validated_data["taxonomy_description"],
+                    export_id=validated_data.get("taxonomy_export_id"),
+                )
+            except exceptions.ValidationError as e:
+                raise ValidationError() from e
+        return super()._create_taxonomy_for_import(validated_data)
 
     @action(detail=False, url_path="import", methods=["post"])
     def create_import(self, request: RestRequest, **kwargs) -> Response:  # type: ignore

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -826,7 +826,7 @@ openedx-calc==5.0.0
     # via
     #   openedx-platform
     #   xblocks-contrib
-openedx-core==1.3.0
+openedx-core==1.4.0
     # via openedx-platform
 openedx-django-pyfs==4.0.0
     # via xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -928,7 +928,7 @@ openedx-calc==5.0.0
     # via
     #   openedx-platform
     #   xblocks-contrib
-openedx-core==1.3.0
+openedx-core==1.4.0
     # via openedx-platform
 openedx-django-pyfs==4.0.0
     # via xblock

--- a/uv.lock
+++ b/uv.lock
@@ -4288,7 +4288,7 @@ wheels = [
 
 [[package]]
 name = "openedx-core"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -4302,9 +4302,9 @@ dependencies = [
     { name = "rules" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/4b/677fc3dd1abffea9460e63c5d1e4c7a3f5c3b646de5b9d81cb1a2a9ee782/openedx_core-1.3.0.tar.gz", hash = "sha256:a68b2ee246bda682711c10bb19b4820037103058b3de7263b2ca92b410e1b376", size = 235342, upload-time = "2026-08-27T17:38:11.597Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/3e/ed8e012f309cea40ed2e95bf62e24437d61b78b985a653bad77eba28793e/openedx_core-1.4.0.tar.gz", hash = "sha256:b14a6dba9daf641d5b59cc6d96352c60f56960e620d57a48978762bfdb43db71", size = 235679, upload-time = "2026-09-11T18:52:40.51Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/b3/9f5e5b045fabbb131418afcc4944a245ce0bfb2b572a95990a808e3524c1/openedx_core-1.3.0-py2.py3-none-any.whl", hash = "sha256:d25b94f837bad1150e3776b0e7b8e65570c5ed189a479a18f0d2018a5b2c2871", size = 321356, upload-time = "2026-08-27T17:38:10.253Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/53/51c7f89d7ce719aacf4f75d8a4b2dbda4cb7502f243606e25ea8daf5597e/openedx_core-1.4.0-py2.py3-none-any.whl", hash = "sha256:972471eb6f80250ce25f049fa56d6629f5c2a22a9c9382863c9d876462561183", size = 321965, upload-time = "2026-09-11T18:52:38.934Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

`TaxonomyOrgView` now dispatches `taxonomy_type` itself, calling `create_taxonomy()` or
`create_competency_taxonomy()` directly depending on the value, instead of subclassing a
CBE-owned view. Implements the acceptance criteria from openedx/openedx-core#614.

## Changes

- `TaxonomyOrgView` subclasses `TaxonomyView` (from `openedx_tagging`) directly.
- `perform_create()`: branches on `taxonomy_type`. `"competency"` calls
  `create_competency_taxonomy()`, wrapped in the same try/except the base class uses
  around `create_taxonomy()`, so a validation failure (e.g. duplicate `export_id`) 400s
  on both paths instead of 500ing on only one. Anything else defers to
  `super().perform_create()`.
- `_create_taxonomy_for_import()`: same dispatch for the import path.
- `create_import()`: unchanged. It already calls `super().create_import()`, which
  now routes through this override via normal virtual dispatch.


## Tests

Seven test methods, one per #614 Given/When/Then scenario: creating and importing a
competency taxonomy (asserting the `CompetencyTaxonomy` row exists), creating and
importing with `"tags"` or no `taxonomy_type` (asserting it doesn't), and rejecting
an unsupported value on both endpoints. Plus a regression test for the duplicate
`export_id` case the try/except protects against.

## Manual testing instructions

To be able to test this PR locally you need to work with local version of openedx-core.
This PR depends on `openedx-core#803` (`taxonomy_type` support, `create_competency_taxonomy()`), mount a local `openedx-core` checkout with that work instead ( or pin 1.4.0 ver).

1. Mount `openedx-core`:
   ```
   tutor dev stop
   git clone https://github.com/openedx/openedx-core.git
   cd openedx-core && git checkout main
   cd ..
   tutor mounts add ./openedx-core
   tutor images build openedx-dev
   tutor dev launch
   ```

2. Check out this PR's branch and restart Studio:
   ```
   tutor dev restart lms cms
   ```

3. I asked claude to wrote a curl based script (with all cases) 
that captures coockies and CSRF tokens needed for the requests so I don't copy requests from developer tools every time (which should also work and for non default/tags requests testing can be done via ui):
   ```bash
   COOKIES=/tmp/lms_cookies.txt; rm -f "$COOKIES"
   curl -s -c "$COOKIES" "http://local.openedx.io:8000/login" -o /dev/null
   CSRFTOKEN=$(grep csrftoken "$COOKIES" | awk '{print $NF}')
   curl -s -b "$COOKIES" -c "$COOKIES" -H "X-CSRFToken: $CSRFTOKEN" -H "Referer: http://local.openedx.io:8000/login" --data-urlencode "email=test@test.com" --data-urlencode "password=test" "http://local.openedx.io:8000/api/user/v1/account/login_session/" -o /dev/null -w "login status: %{http_code}\n"
   AUTH_HEADER="Authorization: JWT $(grep "edx-jwt-cookie-header-payload" "$COOKIES" | awk '{print $NF}').$(grep "edx-jwt-cookie-signature" "$COOKIES" | awk '{print $NF}')"
   CMS_URL="http://studio.local.openedx.io:8001"
   ```

4. Then I use curl (Postman is fine too) to run all cases:

   Create, `taxonomy_type=competency` — expect `201`:
   ```bash
   curl -s -H "$AUTH_HEADER" -H "Content-Type: application/json" -X POST "$CMS_URL/api/content_tagging/v1/taxonomies/" -d '{"name": "Test Competency", "description": "test", "taxonomy_type": "competency"}'
   ```

5. Create, `taxonomy_type=tags` — expect `201`, no `CompetencyTaxonomy` row:
   ```bash
   curl -s -H "$AUTH_HEADER" -H "Content-Type: application/json" -X POST "$CMS_URL/api/content_tagging/v1/taxonomies/" -d '{"name": "Test Tags", "description": "test", "taxonomy_type": "tags"}'
   ```

6. Create, no `taxonomy_type` — expect `201`, no `CompetencyTaxonomy` row (same as `"tags"`):
   ```bash
   curl -s -H "$AUTH_HEADER" -H "Content-Type: application/json" -X POST "$CMS_URL/api/content_tagging/v1/taxonomies/" -d '{"name": "Test Default", "description": "test"}'
   ```

7. Create, `taxonomy_type=system` (unsupported) — expect `400`, `taxonomy_type` named in the response body:
   ```bash
   curl -s -H "$AUTH_HEADER" -H "Content-Type: application/json" -X POST "$CMS_URL/api/content_tagging/v1/taxonomies/" -d '{"name": "Test Test Rejected", "taxonomy_type": "system"}' -w "\nstatus: %{http_code}\n"
   ```

8. Import, `taxonomy_type=competency` — expect `201`:
   ```bash
   echo '{"tags": [{"id": "tag_1", "value": "Tag 1"}]}' > ./test_tags.json
   curl -s -H "$AUTH_HEADER" -X POST "$CMS_URL/api/content_tagging/v1/taxonomies/import/" -F "taxonomy_name=Test Import Competency" -F "taxonomy_description=test" -F "taxonomy_type=competency" -F "file=@./test_tags.json;type=application/json"
   ```

9. Import, no `taxonomy_type` — expect `201`:
   ```bash
   curl -s -H "$AUTH_HEADER" -X POST "$CMS_URL/api/content_tagging/v1/taxonomies/import/" -F "taxonomy_name=Test Import Default" -F "taxonomy_description=test" -F "file=@./test_tags.json;type=application/json"
   ```

10. Import, `taxonomy_type=system` — expect `400`:
    ```bash
    curl -s -H "$AUTH_HEADER" -X POST "$CMS_URL/api/content_tagging/v1/taxonomies/import/" -F "taxonomy_name=Test Import Rejected" -F "taxonomy_description=test" -F "taxonomy_type=system" -F "file=@./test_tags.json;type=application/json" -w "\nstatus: %{http_code}\n"
    ```
11. After each query confirm that `CompetencyTaxonomy` records appears or omitted in mysql tables.

Related to openedx/openedx-core#614
Dependent on https://github.com/openedx/openedx-core/pull/803

🤖 Generated with help of [Claude Code](https://claude.com/claude-code)
