### PR TITLE
fix: return 400 instead of 500 when Course Live provider is unresolved

### DIFF
--- a/openedx/core/djangoapps/course_live/tests/test_views.py
+++ b/openedx/core/djangoapps/course_live/tests/test_views.py
@@ -292,6 +292,38 @@ class TestCourseLiveConfigurationView(ModuleStoreTestCase, APITestCase):
         self.assertEqual(content, expected_data)  # noqa: PT009
         self.assertEqual(response.status_code, 400)  # noqa: PT009
 
+    def test_post_missing_provider_type_without_pii_flag(self):
+        """
+        Test a missing provider_type is reported as a 400, with no PII sharing flag set.
+
+        Distinct from `test_post_error_messages`, which enables `CourseAllowPIISharingInLTIFlag`.
+        That flag makes `pii_sharing_allowed` true, which short-circuits the `and` in the view's
+        PII check before the unresolved (None) provider is dereferenced. Without the flag the
+        provider *is* dereferenced, and the view used to raise an AttributeError -- a 500 on the
+        documented 400 path.
+        """
+        response = self._post({})
+
+        self.assertEqual(response.status_code, 400)  # noqa: PT009
+        content = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(content, {'provider_type': ['This field is required.']})  # noqa: PT009
+
+    def test_post_unknown_provider_type_without_pii_flag(self):
+        """
+        Test a provider_type that names no enabled provider is reported as a 400.
+
+        Same unresolved-provider path as above, reached with a provider_type that is present but
+        does not match an enabled provider.
+        """
+        response = self._post({
+            'enabled': True,
+            'provider_type': 'not_a_real_provider',
+        })
+
+        self.assertEqual(response.status_code, 400)  # noqa: PT009
+        content = json.loads(response.content.decode('utf-8'))
+        self.assertIn('does not exist', str(content))  # noqa: PT009
+
     def test_non_staff_user_access(self):
         """
         Test non staff user has no access to API

--- a/openedx/core/djangoapps/course_live/views.py
+++ b/openedx/core/djangoapps/course_live/views.py
@@ -116,7 +116,10 @@ class CourseLiveConfigurationView(APIView):
         """
         pii_sharing_allowed = get_lti_pii_sharing_state_for_course(course_id)
         provider = ProviderManager().get_enabled_providers().get(request.data.get('provider_type', ''), None)
-        if not pii_sharing_allowed and provider.requires_pii_sharing():
+        # `provider` is None when `provider_type` is missing or names a provider that is not
+        # enabled. Let the serializer report that as a 400 rather than raising an AttributeError
+        # here -- the check below already treats `provider` as optional.
+        if not pii_sharing_allowed and provider and provider.requires_pii_sharing():
             return Response({
                 "pii_sharing_allowed": pii_sharing_allowed,
                 "message": "PII sharing is not allowed on this course"


### PR DESCRIPTION
## Description

`CourseLiveConfigurationView.post` dereferences `provider` before checking it, while the very next line already treats it as optional:

```python
provider = ProviderManager().get_enabled_providers().get(request.data.get('provider_type', ''), None)
if not pii_sharing_allowed and provider.requires_pii_sharing():
    ...
if provider and not provider.additional_parameters and request.data.get('lti_configuration', False):
```

`provider` is `None` whenever `provider_type` is missing from the request or names a provider that is not enabled, so those requests raise an `AttributeError` and return **500** on a path the API documents as **400**.

The existing `test_post_error_messages` does cover a missing `provider_type`, but it does not catch this: it creates `CourseAllowPIISharingInLTIFlag` first, which makes `pii_sharing_allowed` true and short-circuits the `and` before `provider` is ever touched. Without that flag — the default for a course — the dereference happens.

With the guard added, both cases fall through to the serializer, which already reports them correctly: `"This field is required."` for a missing `provider_type`, and `"Provider type ... does not exist"` for an unknown one.

## Testing

Two regression tests, both exercising the no-PII-flag path the existing test does not reach:

- `test_post_missing_provider_type_without_pii_flag` — empty payload, no flag → 400 with `provider_type: ["This field is required."]`
- `test_post_unknown_provider_type_without_pii_flag` — an unrecognised `provider_type`, no flag → 400 with "does not exist"

I was not able to run the edx-platform suite locally (these tests need `ModuleStoreTestCase` and the full dev requirements), so I am relying on CI here — happy to adjust if the assertions need tightening.

## Relationship to #39021

I found this while investigating #39021 (Course Live LTI 1.1 save returning 500 in Studio). **It is not confirmed to be that issue's cause and I am not closing it.** Two things do not line up: the reporter's first failure was `PATCH /api/course_apps/v1/apps/{course_id}`, a different endpoint from the one changed here, and they had selected a provider, so `provider` should not have been `None` for them.

For what it is worth, I did rule out the LTI consumer side of #39021: the Course Live save path (`LtiConfiguration.objects.create(config_store=CONFIG_ON_DB)` followed by a save with the LTI 1.1 fields) runs clean against both current `xblock-lti-consumer` master and the 11.4.0 that was released at the time of the report. Diagnosing #39021 properly still needs the server traceback behind those 500s.

This change stands on its own regardless: a documented 400 should not be a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)