### PR TITLE
docs: drop stale TODO in lti_provider render_courseware

### DIFF
--- a/lms/djangoapps/lti_provider/views.py
+++ b/lms/djangoapps/lti_provider/views.py
@@ -217,14 +217,10 @@ def get_custom_parameters(params: dict[str]) -> dict[str]:
 def render_courseware(request, usage_key):
     """
     Render the content requested for the LTI launch.
-    TODO: This method depends on the current refactoring work on the
-    courseware/courseware.html template. It's signature may change depending on
-    the requirements for that template once the refactoring is complete.
 
-    Return an HttpResponse object that contains the template and necessary
-    context to render the courseware.
+    Return an HttpResponse object that contains the chromeless rendering of the
+    requested XBlock (via ``render_xblock``) for embedding in the consuming LTI tool.
     """
-    # return an HttpResponse object that contains the template and necessary context to render the courseware.
     from lms.djangoapps.courseware.views.views import render_xblock
     return render_xblock(request, str(usage_key), check_if_enrolled=False, disable_staff_debug_info=True)
 


### PR DESCRIPTION
The `render_courseware` docstring in `lms/djangoapps/lti_provider/views.py` referenced ongoing refactoring of the `courseware/courseware.html` Mako template and warned that the method signature might change once that work landed.

That template was deleted when `CoursewareIndex` became a pure redirect to the learning MFE (562df7386c), and `render_courseware` already renders through `render_xblock`. This updates the docstring to describe the current behavior and drops the obsolete TODO.

Docs-only; no behavior change.