### PR TITLE
docs: restore superseded code-owner monitoring ADR

### DIFF
--- a/lms/djangoapps/monitoring/docs/decisions/0001-monitoring-by-code-owner.rst
+++ b/lms/djangoapps/monitoring/docs/decisions/0001-monitoring-by-code-owner.rst
@@ -1,0 +1,50 @@
+Monitoring by Code Owner
+************************
+
+Status
+======
+
+Superseded (DEPR: https://github.com/openedx/edx-django-utils/issues/469)
+
+Context
+=======
+
+It is currently difficult for different teams to have team-based on-calls rotations, alerting and monitoring for various parts of the edx-platform (specifically LMS).
+
+Decision
+========
+
+We will implement a custom attribute "code_owner" that can be used in NewRelic (or other monitoring solutions that are made pluggable).
+
+The new custom attribute makes it simple to query NewRelic for all Transactions or TransactionErrors that are associated with requests with a specific owner.  This enables a team to quickly identify data that they own, for use in NewRelic alerts or NewRelic dashboards.
+
+To minimize maintenance, the value of the "code_owner" attribute will be populated using the source-of-truth of ownership of various parts of edx-platform.
+
+See `Rejected Alternatives`_ for details of the decision **not** to split the NewRelic application into multiple NewRelic applications.
+
+Note: "owner" is a MySql reserved word, which NewRelic cautions against using, so we are using "code_owner".
+
+Consequences
+============
+
+This attribute should be quickly available for use with custom alerts and custom dashboards.
+
+In the future, this attribute could potentially be added to logging as well.
+
+Rejected Alternatives
+=====================
+
+Splitting the NewRelic application
+----------------------------------
+
+The edx-platform (LMS) NewRelic application could have been split into multiple applications. This would have had the benefit of getting the out-of-the-box APM Dashboards for free.
+
+We decided against this alternative because:
+
+* To enable this solution, we would need to disable gunicorn instrumentation, and this instrumentation has proved to be valuable for understanding certain types of production issues.
+* Splitting the app may make it more difficult to pinpoint the source of any problem that affects multiple applications.
+* The application splitting depends on a slight "hack" from NewRelic, by resetting the application name for each path.
+
+  * This "hack" goes against the grain of NewRelic's typical recommendations, so there could be unknown pitfalls.
+  * The mapping of request path to owner would require additional maintenance.
+  * Processing time is **not** accounted for in the NewRelic transaction time, because any processing required takes place before the NewRelic transaction gets started.


### PR DESCRIPTION
## Description

Restores `lms/djangoapps/monitoring/docs/decisions/0001-monitoring-by-code-owner.rst`, which was mistakenly deleted (rather than marked superseded) by [#39047](https://github.com/openedx/openedx-platform/pull/39047) as part of the `set_code_owner_attribute` Celery-decorator cleanup.

Per [review feedback on #39047](https://github.com/openedx/openedx-platform/pull/39047#discussion_r3983601259), ADRs documenting a historical decision should be kept and marked `Superseded` rather than deleted outright, so the record of *why* the original decision was made isn't lost. This PR restores the file's original content unchanged and updates only its `Status` field to point at the DEPR issue that supersedes it.

This is a documentation-only change with no functional or runtime impact. It affects **Developers**/**Operators** reading architecture decision records, no impact on Learners or Course Authors.

## Supporting information

- DEPR tracking issue: [openedx/edx-django-utils#469](https://github.com/openedx/edx-django-utils/issues/469)
- Original cleanup PR: [openedx/openedx-platform#39047](https://github.com/openedx/openedx-platform/pull/39047)
- Review comment prompting this fix: [#39047 (review)](https://github.com/openedx/openedx-platform/pull/39047#discussion_r3983601259)

## Testing instructions

None required, this is a documentation-only change (one `.rst` file, no code).

## Deadline

None.

## Other information

- No functional or runtime code is touched, this only restores a deleted doc file with its `Status` field updated to `Superseded (DEPR: https://github.com/openedx/edx-django-utils/issues/469)`. All other content is byte-for-byte identical to the pre-deletion version.
- No database migration, no security or accessibility implications, no backport needed.
- Does not depend on any other open PR.