### PR TITLE
feat: add competency-based education (CBE) API endpoint

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -361,6 +361,11 @@ urlpatterns += [
     path('api/content_tagging/', include(('openedx.core.djangoapps.content_tagging.urls', 'content_tagging'))),
 ]
 
+# openedx-core: competency-based education (CBE)
+urlpatterns += [
+    path('api/', include('openedx_learning.urls')),
+]
+
 # Authoring-api specific API docs (using drf-spectacular and openapi-v3).
 # This is separate from and in addition to the full studio swagger documentation already existing at /api-docs.
 # Custom settings are provided in SPECTACULAR_SETTINGS as environment variables


### PR DESCRIPTION
## Description

Mounts the competency-based education (CBE) REST API from `openedx-learning` (openedx-core) into Studio's URL configuration.

This is the platform-side half of the work: the endpoints, serializers, permissions and pagination all live in `openedx-core`, and this PR is the single `include()` that makes them reachable from a running Studio instance.

Combined with the routing added in the dependency PR, this exposes:

- `GET /api/cbe/v1/rule_profiles/` — paginated, read-only collection of non-archived competency rule profiles, restricted to taxonomy administrators.

It is wired into **CMS/Studio** (rather than LMS) because the consumer is the authoring-side Competency Management page. The `api/` prefix is deliberately generic so that `openedx_learning.urls` remains the single place where openedx-core owns its own URL namespacing — future CBE endpoints need no further change here.

**User roles impacted**

- **Course Author / Taxonomy Administrator** — gains access to the new read-only endpoint (permission checks are enforced in openedx-core, deferring to `openedx_tagging`'s admin checks).
- **Developer** — new routes available under Studio's `/api/`.
- **Learner** — no impact; nothing is exposed in the LMS.

No UI changes, so no screenshots. No settings or configuration changes.

## Supporting information

- Issue: https://github.com/openedx/openedx-core/issues/773 — *[BE] Read the rule profiles an instance defines*
- Dependency PR: https://github.com/jesperhodge/openedx-core/pull/9 — *feat: implement CBE REST API with competency rule profiles and permissions*

## Testing instructions

This PR cannot be tested on its own — the dependency PR must be installed first, otherwise Studio will fail to start with `ModuleNotFoundError: No module named 'openedx_learning.urls'`.

1. Install the `openedx-core` branch from the dependency PR into your Studio environment:
   ```
   pip install -e 'git+https://github.com/javoconsultant/openedx-core@773-read-rule-profiles#egg=openedx-learning'
   ```
2. Check out this branch and restart Studio.
3. Confirm the route is registered:
   ```
   ./manage.py cms show_urls | grep rule_profiles
   ```
4. As an **unauthenticated** user, `GET /api/cbe/v1/rule_profiles/` → `401`.
5. As an authenticated user **without** taxonomy admin rights → `403`.
6. As a **taxonomy administrator** → `200` with a paginated list of non-archived rule profiles, each carrying `id`, `scope_type`, `rule_type`, `rule_payload` and `archived`.
7. Confirm ordering is stable across repeated requests and that paging through the collection returns each profile exactly once.

Behavioural test coverage for the endpoint itself lives in the dependency PR.

## Deadline

None.

## Other information

- **Depends on** https://github.com/jesperhodge/openedx-core/pull/9. This PR should not merge until that one lands and the resulting `openedx-learning` version is pinned in `requirements/`.
- **Open question on the URL path:** the endpoint currently resolves to `/api/cbe/v1/rule_profiles/`, while the design docs describe `/api/cbe/rest_api/v1/rule_profiles/`. The prefix chosen here (`api/`) keeps that decision entirely inside openedx-core — if the path changes there, this file does not need to change.
- No database migrations.
- No new settings, feature flags or dependencies added by this PR itself.
- Access control and pagination limits are enforced in openedx-core, not here.
