### PR TITLE
fix: move noqa:F811 to the line flake8 actually flags

### DIFF
--- a/openedx/core/djangoapps/user_api/management/tests/test_retire_user.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_retire_user.py
@@ -98,8 +98,8 @@ def test_successful_retire_with_userfile(setup_retirement_states):  # pylint: di
 @pytest.mark.parametrize('email_header', ['email', 'user_email'])
 @pytest.mark.parametrize('username_header', ['username', '\ufeffusername'])
 @skip_unless_lms
-def test_successful_retire_with_userfile_header(  # pylint: disable=redefined-outer-name, unused-argument  # noqa: F811
-    setup_retirement_states, email_header, username_header
+def test_successful_retire_with_userfile_header(  # pylint: disable=redefined-outer-name, unused-argument
+    setup_retirement_states, email_header, username_header  # noqa: F811
 ):
     user = UserFactory.create(username='header-user', email="header-user@example.com")
     username = user.username


### PR DESCRIPTION
## Description

Fixes a `flake8` F811 quality-check failure introduced in #38977, which merged with the check red on `master` (the `Quality checks` workflow only runs on `master`/`merge_group`, not on fork PRs, so this wasn't visible during review).

`test_successful_retire_with_userfile_header` splits its function signature across two lines. The `# noqa: F811` comment was placed on the `def` line, but pyflakes reports the "redefinition of unused name" violation on the line where the parameter (`setup_retirement_states`) actually appears, one line down. Since flake8 only suppresses a violation on the exact physical line the `noqa` comment sits on, the mismatch meant the warning wasn't suppressed. This PR moves the comment to the correct line. No behavior change; test logic is untouched.

Impacts: Developer/Operator only (CI quality gate). No learner- or author-facing change.

## Supporting information

- Jira: [LP-1180](https://2u-internal.atlassian.net/browse/LP-1180) (private)
- Introduced by: #38977
- Failing run: https://github.com/openedx/openedx-platform/actions/runs/34538160774 (job "Quality Others", step "Run Quality Tests")

## Testing instructions

1. Check out this branch.
2. Run `flake8 --select=F811 openedx/core/djangoapps/user_api/management/tests/test_retire_user.py`, should report 0 violations.
3. Run the existing test suite for the file to confirm no behavior change:
   `pytest openedx/core/djangoapps/user_api/management/tests/test_retire_user.py`

## Deadline

Could be good to merge asap as the master Quality check is failing in master.

## Other information

- Does not depend on other changes.
- No migrations, no deprecations, no security/accessibility concerns.
- Once this merges, #39095 (the revert) can be closed without merging.